### PR TITLE
refactor(schema): remove unused writeOnly, persist, nonprovisionable annotations

### DIFF
--- a/schema/pkl/apigateway/apikey.pkl
+++ b/schema/pkl/apigateway/apikey.pkl
@@ -46,7 +46,6 @@ open class ApiKey extends formae.Resource {
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     generateDistinctId: Boolean?
 

--- a/schema/pkl/apigateway/deployment.pkl
+++ b/schema/pkl/apigateway/deployment.pkl
@@ -83,7 +83,6 @@ open class Deployment extends formae.Resource {
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     deploymentCanarySettings: CanarySetting?
 
@@ -95,13 +94,11 @@ open class Deployment extends formae.Resource {
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     stageDescription: StageDescription?
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     stageName: String?
 

--- a/schema/pkl/apigateway/restapi.pkl
+++ b/schema/pkl/apigateway/restapi.pkl
@@ -57,19 +57,16 @@ open class RestApi extends formae.Resource {
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     body: Dynamic?
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     bodyS3Location: BodyS3Location?
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     cloneFrom: String?
 
@@ -83,7 +80,6 @@ open class RestApi extends formae.Resource {
     endpointConfiguration: EndpointConfiguration?
 
     @aws.FieldHint{
-        writeOnly = true
     }
     failOnWarnings: Boolean?
 
@@ -91,7 +87,6 @@ open class RestApi extends formae.Resource {
     minimumCompressionSize: Int?
 
     @aws.FieldHint{
-        writeOnly = true
     }
     mode: String?
 
@@ -99,7 +94,6 @@ open class RestApi extends formae.Resource {
     name: String?
 
     @aws.FieldHint{
-        writeOnly = true
     }
     parameters: Mapping<String, Any>?
 

--- a/schema/pkl/dynamodb/globaltable.pkl
+++ b/schema/pkl/dynamodb/globaltable.pkl
@@ -21,7 +21,7 @@ open class AttributeDefinition extends formae.SubResource {
 open class CapacityAutoScalingSettings extends formae.SubResource {
     maxCapacity: Int
     minCapacity: Int
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     seedCapacity: Int?
     targetTrackingScalingPolicyConfiguration: TargetTrackingScalingPolicyConfiguration
 }

--- a/schema/pkl/dynamodb/table.pkl
+++ b/schema/pkl/dynamodb/table.pkl
@@ -160,7 +160,6 @@ open class Table extends formae.Resource {
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     importSourceSpecification: ImportSourceSpecification?
 

--- a/schema/pkl/ec2/capacityreservation.pkl
+++ b/schema/pkl/ec2/capacityreservation.pkl
@@ -67,6 +67,6 @@ open class CapacityReservation extends formae.Resource {
     @aws.FieldHint
     tenancy: String?
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     unusedReservationBillingOwnerId: String?
 }

--- a/schema/pkl/ec2/eip.pkl
+++ b/schema/pkl/ec2/eip.pkl
@@ -31,7 +31,6 @@ open class EIP extends formae.Resource {
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     address: String?
 
@@ -43,7 +42,6 @@ open class EIP extends formae.Resource {
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     ipamPoolId: String?
 
@@ -61,7 +59,6 @@ open class EIP extends formae.Resource {
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     transferAddress: String?
 

--- a/schema/pkl/ec2/instance.pkl
+++ b/schema/pkl/ec2/instance.pkl
@@ -24,10 +24,10 @@ open class BlockDeviceMapping extends formae.SubResource {
     deviceName: String
     ebs: EBS?
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     noDevice: Dynamic?
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     virtualName: String?
 }
 
@@ -157,7 +157,7 @@ open class InstanceResolvable extends formae.Resolvable {
 }
 open class Instance extends formae.Resource {
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     additionalInfo: String?
 
     @aws.FieldHint
@@ -213,13 +213,11 @@ open class Instance extends formae.Resource {
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     ipv6AddressCount: Int?
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     ipv6Addresses: Listing<Ipv6Address>?
 
@@ -231,7 +229,6 @@ open class Instance extends formae.Resource {
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     launchTemplate: Dynamic?
 
@@ -253,7 +250,7 @@ open class Instance extends formae.Resource {
     @aws.FieldHint{createOnly = true}
     privateIpAddress: String?
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     propagateTagsToVolumeOnCreation: Boolean?
 
     @aws.FieldHint

--- a/schema/pkl/ec2/instanceconnectendpoint.pkl
+++ b/schema/pkl/ec2/instanceconnectendpoint.pkl
@@ -19,7 +19,6 @@ open class InstanceConnectEndpoint extends formae.Resource {
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     clientToken: String?
 

--- a/schema/pkl/ec2/ipamallocation.pkl
+++ b/schema/pkl/ec2/ipamallocation.pkl
@@ -30,7 +30,6 @@ open class IPAMAllocation extends formae.Resource {
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     netmaskLength: Int?
 }

--- a/schema/pkl/ec2/keypair.pkl
+++ b/schema/pkl/ec2/keypair.pkl
@@ -40,7 +40,6 @@ open class KeyPair extends formae.Resource {
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     keyFormat: KeyFormat?
 

--- a/schema/pkl/ec2/launchtemplate.pkl
+++ b/schema/pkl/ec2/launchtemplate.pkl
@@ -368,7 +368,6 @@ open class VCpuCount extends formae.SubResource {
 open class LaunchTemplate extends formae.Resource {
 
     @aws.FieldHint{
-        writeOnly = true
         requiredOnCreate = true
     }
     launchTemplateData: LaunchTemplateData?
@@ -376,9 +375,9 @@ open class LaunchTemplate extends formae.Resource {
     @aws.FieldHint{createOnly = true}
     launchTemplateName: String?
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     tagSpecifications: Listing<TagSpecification>?
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     versionDescription: String?
 }

--- a/schema/pkl/ec2/natgateway.pkl
+++ b/schema/pkl/ec2/natgateway.pkl
@@ -34,7 +34,7 @@ open class NatGateway extends formae.Resource {
     @aws.FieldHint{createOnly = true}
     connectivityType: String?
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     maxDrainDurationSeconds: Int?
 
     @aws.FieldHint{createOnly = true}

--- a/schema/pkl/ec2/networkinsightsaccessscope.pkl
+++ b/schema/pkl/ec2/networkinsightsaccessscope.pkl
@@ -54,13 +54,11 @@ open class NetworkInsightsAccessScope extends formae.Resource {
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     excludePaths: Listing<ScopeAccessScopePathRequest>?
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     matchPaths: Listing<ScopeAccessScopePathRequest>?
 

--- a/schema/pkl/ec2/route.pkl
+++ b/schema/pkl/ec2/route.pkl
@@ -26,53 +26,49 @@ open class Route extends formae.Resource {
 
     @aws.FieldHint{
         createOnly = true
-        persist = true
     }
     destinationCidrBlock: String?
 
     @aws.FieldHint{
         createOnly = true
-        persist = true
     }
     destinationIpv6CidrBlock: String?
 
     @aws.FieldHint{
         createOnly = true
-        persist = true
     }
     destinationPrefixListId: String?
 
-    @aws.FieldHint{persist = true}
+    @aws.FieldHint{}
     egressOnlyInternetGatewayId: String?
 
-    @aws.FieldHint{persist = true}
+    @aws.FieldHint{}
     gatewayId: (String|formae.Resolvable)?
 
-    @aws.FieldHint{persist = true}
+    @aws.FieldHint{}
     instanceId: (String|formae.Resolvable)?
 
-    @aws.FieldHint{persist = true}
+    @aws.FieldHint{}
     localGatewayId: (String|formae.Resolvable)?
 
-    @aws.FieldHint{persist = true}
+    @aws.FieldHint{}
     natGatewayId: (String|formae.Resolvable)?
 
-    @aws.FieldHint{persist = true}
+    @aws.FieldHint{}
     networkInterfaceId: (String|formae.Resolvable)?
 
     @aws.FieldHint{
         createOnly = true
-        persist = true
     }
     routeTableId: (String|formae.Resolvable)
 
-    @aws.FieldHint{persist = true}
+    @aws.FieldHint{}
     transitGatewayId: String?
 
-    @aws.FieldHint{persist = true}
+    @aws.FieldHint{}
     vpcEndpointId: String?
 
-    @aws.FieldHint{persist = true}
+    @aws.FieldHint{}
     vpcPeeringConnectionId: String?
 
 }

--- a/schema/pkl/ec2/spotfleet.pkl
+++ b/schema/pkl/ec2/spotfleet.pkl
@@ -97,7 +97,7 @@ open class NetworkInterface extends formae.SubResource {
     deleteOnTermination: Boolean?
     description: String?
     deviceIndex: Int?
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     groups: Listing<String>?
     ipv6AddressCount: Int?
     ipv6Addresses: Listing<Ipv6Address>?
@@ -238,7 +238,7 @@ open class LaunchSpecification extends formae.SubResource {
     spotPrice: String?
     subnetId: String?
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     tagSpecifications: Listing<TagSpecification>?
 
     userData: String?

--- a/schema/pkl/ec2/subnet.pkl
+++ b/schema/pkl/ec2/subnet.pkl
@@ -65,18 +65,16 @@ open class Subnet extends formae.Resource {
     @aws.FieldHint
     enableDns64: Boolean? = false
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     enableLniAtDeviceIndex: Int?
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     ipv4IpamPoolId: String?
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     ipv4NetmaskLength: Int?
 
@@ -85,7 +83,6 @@ open class Subnet extends formae.Resource {
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     ipv6IpamPoolId: String?
 
@@ -94,7 +91,6 @@ open class Subnet extends formae.Resource {
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     ipv6NetmaskLength: Int?
 

--- a/schema/pkl/ec2/subnetcidrblock.pkl
+++ b/schema/pkl/ec2/subnetcidrblock.pkl
@@ -22,13 +22,11 @@ open class SubnetCidrBlock extends formae.Resource {
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     ipv6IpamPoolId: String?
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     ipv6NetmaskLength: Int?
 

--- a/schema/pkl/ec2/transitgatewayvpcattachment.pkl
+++ b/schema/pkl/ec2/transitgatewayvpcattachment.pkl
@@ -17,13 +17,13 @@ const type = "AWS::EC2::TransitGatewayVpcAttachment"
 }
 open class TransitGatewayVpcAttachment extends formae.Resource {
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     addSubnetIds: Listing<String|formae.Resolvable>?
 
     @aws.FieldHint
     options: Dynamic?
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     removeSubnetIds: Listing<String|formae.Resolvable>?
 
     @aws.FieldHint{createOnly = true}

--- a/schema/pkl/ec2/verifiedaccesstrustprovider.pkl
+++ b/schema/pkl/ec2/verifiedaccesstrustprovider.pkl
@@ -23,7 +23,7 @@ open class OidcOptions extends formae.SubResource {
     authorizationEndpoint: String?
     clientId: String?
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     clientSecret: String?
 
     issuer: String?

--- a/schema/pkl/ec2/vpc.pkl
+++ b/schema/pkl/ec2/vpc.pkl
@@ -55,11 +55,10 @@ open class VPC extends formae.Resource {
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     ipv4IpamPoolId: String?
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     ipv4NetmaskLength: String?
 
     @aws.FieldHint {

--- a/schema/pkl/ec2/vpccidrblock.pkl
+++ b/schema/pkl/ec2/vpccidrblock.pkl
@@ -28,13 +28,11 @@ open class VPCCidrBlock extends formae.Resource {
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     ipv4IpamPoolId: (String|formae.Resolvable)?
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     ipv4NetmaskLength: Int?
 
@@ -46,13 +44,11 @@ open class VPCCidrBlock extends formae.Resource {
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     ipv6IpamPoolId: (String|formae.Resolvable)?
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     ipv6NetmaskLength: Int?
 

--- a/schema/pkl/ec2/vpcendpointservice.pkl
+++ b/schema/pkl/ec2/vpcendpointservice.pkl
@@ -20,7 +20,7 @@ open class VPCEndpointService extends formae.Resource {
     @aws.FieldHint
     acceptanceRequired: Boolean?
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     contributorInsightsEnabled: Boolean?
 
     @aws.FieldHint

--- a/schema/pkl/ec2/vpcpeeringconnection.pkl
+++ b/schema/pkl/ec2/vpcpeeringconnection.pkl
@@ -25,7 +25,6 @@ open class VPCPeeringConnection extends formae.Resource {
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     peerRoleArn: String?
 

--- a/schema/pkl/ec2/vpnconnection.pkl
+++ b/schema/pkl/ec2/vpnconnection.pkl
@@ -92,7 +92,7 @@ open class VpnTunnelOptionsSpecification extends formae.SubResource {
     phase2IntegrityAlgorithms: Listing<VPNConnectionPhase2IntegrityAlgorithmsRequestListValue>?
     phase2LifetimeSeconds: Int?
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     preSharedKey: String?
 
     rekeyFuzzPercentage: Int?

--- a/schema/pkl/ecr/pullthroughcacherule.pkl
+++ b/schema/pkl/ecr/pullthroughcacherule.pkl
@@ -19,7 +19,6 @@ open class PullThroughCacheRule extends formae.Resource {
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     credentialArn: (String(matches(Regex(#"^arn:aws:secretsmanager:[a-zA-Z0-9-:]+:secret:ecr\-pullthroughcache\/[a-zA-Z0-9\/_+=.@-]+$"#)))|formae.Value)?
 
@@ -28,7 +27,6 @@ open class PullThroughCacheRule extends formae.Resource {
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     upstreamRegistry: String?
 

--- a/schema/pkl/ecr/repository.pkl
+++ b/schema/pkl/ecr/repository.pkl
@@ -36,7 +36,7 @@ typealias ImageTagMutability = "MUTABLE"|"IMMUTABLE"
 }
 open class Repository extends formae.Resource {
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     emptyOnDelete: Boolean?
 
     @aws.FieldHint{createOnly = true}

--- a/schema/pkl/ecs/ecscluster.pkl
+++ b/schema/pkl/ecs/ecscluster.pkl
@@ -86,7 +86,7 @@ open class Cluster extends formae.Resource {
     @aws.FieldHint
     defaultCapacityProviderStrategy: Listing<CapacityProviderStrategy>?
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     serviceConnectDefaults: ServiceConnectDefaults?
 
     @aws.FieldHint {

--- a/schema/pkl/ecs/service.pkl
+++ b/schema/pkl/ecs/service.pkl
@@ -250,7 +250,7 @@ open class Service extends formae.Resource {
     @aws.FieldHint{createOnly = true}
     schedulingStrategy: SchedulingStrategy?
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     serviceConnectConfiguration: ServiceConnectConfiguration?
 
     @aws.FieldHint{createOnly = true}
@@ -268,7 +268,7 @@ open class Service extends formae.Resource {
     @aws.FieldHint
     taskDefinition: (String|formae.Resolvable)?
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     volumeConfigurations: Listing<VolumeConfiguration>?
 
     @aws.FieldHint

--- a/schema/pkl/efs/accesspoint.pkl
+++ b/schema/pkl/efs/accesspoint.pkl
@@ -58,7 +58,6 @@ open class AccessPoint extends formae.Resource {
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     clientToken: (String)?
 

--- a/schema/pkl/eks/ekscluster.pkl
+++ b/schema/pkl/eks/ekscluster.pkl
@@ -17,7 +17,7 @@ typealias AccessConfigAuthenticationMode = "CONFIG_MAP"|"API_AND_CONFIG_MAP"|"AP
 open class AccessConfig extends formae.SubResource {
     authenticationMode: AccessConfigAuthenticationMode?
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     bootstrapClusterCreatorAdminPermissions: Boolean?
 }
 
@@ -150,7 +150,6 @@ open class Cluster extends formae.Resource {
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     accessConfig: AccessConfig?
 
@@ -163,7 +162,7 @@ open class Cluster extends formae.Resource {
     @aws.FieldHint
     encryptionConfig: Listing<EncryptionConfig>?
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     force: Boolean?
 
     @aws.FieldHint

--- a/schema/pkl/eks/nodegroup.pkl
+++ b/schema/pkl/eks/nodegroup.pkl
@@ -85,7 +85,7 @@ open class Nodegroup extends formae.Resource {
     @aws.FieldHint
     diskSize: Int?
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     forceUpdateEnabled: Boolean?
 
     @aws.FieldHint

--- a/schema/pkl/elasticbeanstalk/configurationtemplate.pkl
+++ b/schema/pkl/elasticbeanstalk/configurationtemplate.pkl
@@ -39,7 +39,6 @@ open class ConfigurationTemplate extends formae.Resource {
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     environmentId: (String|formae.Resolvable)?
 
@@ -54,7 +53,6 @@ open class ConfigurationTemplate extends formae.Resource {
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     sourceConfiguration: SourceConfiguration?
 }

--- a/schema/pkl/elasticbeanstalk/environment.pkl
+++ b/schema/pkl/elasticbeanstalk/environment.pkl
@@ -50,7 +50,7 @@ open class Environment extends formae.Resource {
     @aws.FieldHint
     operationsRole: String?
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     optionSettings: Listing<OptionSetting>?
 
     @aws.FieldHint
@@ -65,7 +65,7 @@ open class Environment extends formae.Resource {
     }
     tags: Listing<aws.Tag>?
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     templateName: String?
 
     @aws.FieldHint

--- a/schema/pkl/elasticloadbalancingv2/listener.pkl
+++ b/schema/pkl/elasticloadbalancingv2/listener.pkl
@@ -40,7 +40,7 @@ open class AuthenticateOidcConfig extends formae.SubResource {
     authenticationRequestExtraParams: Mapping<String, Any>?
     authorizationEndpoint: String
     clientId: String
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     clientSecret: String?
     issuer: String
     onUnauthenticatedRequest: String?

--- a/schema/pkl/elasticloadbalancingv2/listenerrule.pkl
+++ b/schema/pkl/elasticloadbalancingv2/listenerrule.pkl
@@ -40,7 +40,7 @@ open class AuthenticateOidcConfig extends formae.SubResource {
     authenticationRequestExtraParams: Mapping<String, Any>?
     authorizationEndpoint: String
     clientId: String
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     clientSecret: String?
     issuer: String
     onUnauthenticatedRequest: String?
@@ -154,7 +154,6 @@ open class ListenerRule extends formae.Resource {
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     listenerArn: (String|formae.Resolvable)?
 

--- a/schema/pkl/elasticloadbalancingv2/truststore.pkl
+++ b/schema/pkl/elasticloadbalancingv2/truststore.pkl
@@ -17,13 +17,13 @@ const type = "AWS::ElasticLoadBalancingV2::TrustStore"
 }
 open class TrustStore extends formae.Resource {
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     caCertificatesBundleS3Bucket: String?
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     caCertificatesBundleS3Key: String?
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     caCertificatesBundleS3ObjectVersion: String?
 
     @aws.FieldHint{createOnly = true}

--- a/schema/pkl/elasticloadbalancingv2/truststorerevocation.pkl
+++ b/schema/pkl/elasticloadbalancingv2/truststorerevocation.pkl
@@ -29,7 +29,6 @@ open class TrustStoreRevocation extends formae.Resource {
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     revocationContents: Listing<RevocationContent>?
 

--- a/schema/pkl/iam/servercertificate.pkl
+++ b/schema/pkl/iam/servercertificate.pkl
@@ -19,13 +19,11 @@ open class ServerCertificate extends formae.Resource {
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     certificateBody: String(matches(Regex(#"[\u0009\u000A\u000D\u0020-\u00FF]+"#)))?
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     certificateChain: String(matches(Regex(#"[\u0009\u000A\u000D\u0020-\u00FF]+"#)))?
 
@@ -34,7 +32,6 @@ open class ServerCertificate extends formae.Resource {
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     privateKey: String(matches(Regex(#"[\u0009\u000A\u000D\u0020-\u00FF]+"#)))?
 

--- a/schema/pkl/iam/servicelinkedrole.pkl
+++ b/schema/pkl/iam/servicelinkedrole.pkl
@@ -20,14 +20,12 @@ open class ServiceLinkedRole extends formae.Resource {
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
         outputField = "AWSServiceName"
     }
     awsServiceName: String?
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     customSuffix: String?
 

--- a/schema/pkl/iam/user.pkl
+++ b/schema/pkl/iam/user.pkl
@@ -13,7 +13,7 @@ const type = "AWS::IAM::User"
 
 @aws.SubResourceHint
 open class UserLoginProfile extends formae.SubResource {
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     password: (String|formae.Value)?
     passwordResetRequired: Boolean?
 }

--- a/schema/pkl/kms/key.pkl
+++ b/schema/pkl/kms/key.pkl
@@ -33,7 +33,7 @@ open class KeyResolvable extends formae.Resolvable {
 }
 open class Key extends formae.Resource {
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     bypassPolicyLockoutSafetyCheck: Boolean?
 
     @aws.FieldHint
@@ -60,10 +60,10 @@ open class Key extends formae.Resource {
     @aws.FieldHint{createOnly = true}
     origin: Origin?
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     pendingWindowInDays: Int?
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     rotationPeriodInDays: Int?
 
     @aws.FieldHint {

--- a/schema/pkl/lambda/func.pkl
+++ b/schema/pkl/lambda/func.pkl
@@ -13,21 +13,21 @@ const type = "AWS::Lambda::Function"
 
 @aws.SubResourceHint
 open class Code extends formae.SubResource {
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     imageUri: String?
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     s3Bucket: (String(matches(Regex(#"^[0-9A-Za-z\.\-_]*(?<!\.)$"#))))?
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     s3Key: String?
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     s3ObjectVersion: String?
 
     sourceKMSKeyArn: (String(matches(Regex(#"^(arn:(aws[a-zA-Z-]*)?:[a-z0-9-.]+:.*)|()$"#))))?
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     zipFile: String?
 }
 
@@ -185,7 +185,6 @@ open class Function extends formae.Resource {
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     snapStart: SnapStart?
 

--- a/schema/pkl/lambda/layerversion.pkl
+++ b/schema/pkl/lambda/layerversion.pkl
@@ -33,7 +33,6 @@ open class LayerVersion extends formae.Resource {
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
         requiredOnCreate = true
     }
     content: Content?

--- a/schema/pkl/rds/customdbengineversion.pkl
+++ b/schema/pkl/rds/customdbengineversion.pkl
@@ -53,13 +53,11 @@ open class CustomDBEngineVersion extends formae.Resource {
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     manifest: String?
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     sourceCustomDbEngineVersionIdentifier: String?
 
@@ -74,7 +72,6 @@ open class CustomDBEngineVersion extends formae.Resource {
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     useAwsProvidedLatestImage: Boolean?
 

--- a/schema/pkl/rds/dbcluster.pkl
+++ b/schema/pkl/rds/dbcluster.pkl
@@ -97,7 +97,6 @@ open class DBCluster extends formae.Resource {
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     clusterScalabilityType: String?
 
@@ -118,7 +117,6 @@ open class DBCluster extends formae.Resource {
     dbClusterParameterGroupName: String?
 
     @aws.FieldHint{
-        writeOnly = true
         outputField = "DBInstanceParameterGroupName"
     }
     dbInstanceParameterGroupName: String?
@@ -240,7 +238,6 @@ open class DBCluster extends formae.Resource {
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     restoreType: String?
 
@@ -252,19 +249,16 @@ open class DBCluster extends formae.Resource {
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     snapshotIdentifier: String?
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     sourceDBClusterIdentifier: String?
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     sourceRegion: aws.Region?
 
@@ -282,7 +276,6 @@ open class DBCluster extends formae.Resource {
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     useLatestRestorableTime: Boolean?
 

--- a/schema/pkl/rds/dbinstance.pkl
+++ b/schema/pkl/rds/dbinstance.pkl
@@ -94,7 +94,7 @@ open class DBInstance extends formae.Resource {
     @aws.FieldHint
     allocatedStorage: Int?
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     allowMajorVersionUpgrade: Boolean?
 
     @aws.FieldHint
@@ -103,7 +103,7 @@ open class DBInstance extends formae.Resource {
     @aws.FieldHint
     autoMinorVersionUpgrade: Boolean?
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     automaticBackupReplicationKmsKeyId: String?
 
     @aws.FieldHint
@@ -123,7 +123,7 @@ open class DBInstance extends formae.Resource {
     @aws.FieldHint
     certificateDetails: CertificateDetails?
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     certificateRotationRestart: Boolean?
 
     @aws.FieldHint{createOnly = true}
@@ -152,7 +152,6 @@ open class DBInstance extends formae.Resource {
     dbInstanceClass: String?
 
     @aws.FieldHint{
-        writeOnly = true
         outputField = "DBInstanceIdentifier"
     }
     dbInstanceIdentifier: (String(matches(Regex(#"^$|^[a-zA-Z]{1}(?:-?[a-zA-Z0-9]){0,62}$"#))))?
@@ -193,7 +192,7 @@ open class DBInstance extends formae.Resource {
     @aws.FieldHint
     dedicatedLogVolume: Boolean?
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     deleteAutomatedBackups: Boolean?
 
     @aws.FieldHint
@@ -250,7 +249,7 @@ open class DBInstance extends formae.Resource {
     @aws.FieldHint
     manageMasterUserPassword: Boolean?
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     masterUserPassword: (String|formae.Resolvable|formae.Value)?
 
     @aws.FieldHint
@@ -307,24 +306,23 @@ open class DBInstance extends formae.Resource {
     @aws.FieldHint
     replicaMode: String?
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     restoreTime: String?
 
     @aws.FieldHint
     sourceDBClusterIdentifier: String?
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     sourceDBInstanceAutomatedBackupsArn: String?
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     sourceDBInstanceIdentifier: (String|formae.Resolvable)?
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     sourceDbiResourceId: (String|formae.Resolvable)?
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     sourceRegion: aws.Region?
 
@@ -346,16 +344,16 @@ open class DBInstance extends formae.Resource {
     @aws.FieldHint
     tdeCredentialArn: String?
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     tdeCredentialPassword: String?
 
     @aws.FieldHint{createOnly = true}
     timezone: String?
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     useDefaultProcessorFeatures: Boolean?
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     useLatestRestorableTime: Boolean?
 
     @aws.FieldHint{outputField = "VPCSecurityGroups"}

--- a/schema/pkl/rds/dbshardgroup.pkl
+++ b/schema/pkl/rds/dbshardgroup.pkl
@@ -45,7 +45,7 @@ open class DBShardGroup extends formae.Resource {
     @aws.FieldHint
     maxACU: Number
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     minACU: Number?
 
     @aws.FieldHint{createOnly = true}

--- a/schema/pkl/route53/healthcheck.pkl
+++ b/schema/pkl/route53/healthcheck.pkl
@@ -13,7 +13,6 @@ const type = "AWS::Route53::HealthCheck"
 
 @aws.ResourceHint {
     type = module.type
-    nonprovisionable = true
     identifier = "Id"
 }
 open class HealthCheck extends formae.Resource {

--- a/schema/pkl/route53/recordset.pkl
+++ b/schema/pkl/route53/recordset.pkl
@@ -56,14 +56,12 @@ open class GeoProximityLocation extends formae.SubResource {
 @aws.ResourceHint {
     type = module.type
     identifier = "Id"
-    nonprovisionable = true
     parent = "AWS::Route53::HostedZone"
     listParam = new formae.ListProperty { parentProperty = "Id" listParameter = "HostedZoneId" }
     discoverable = true
 }
 open class RecordSet extends formae.Resource {
     @aws.FieldHint{
-        persist = true
     }
     aliasTarget: (AliasTarget)?
 
@@ -87,7 +85,6 @@ open class RecordSet extends formae.Resource {
 
     @aws.FieldHint {
         createOnly = true
-        persist = true
     }
     hostedZoneId: (String|formae.Resolvable)?
 
@@ -101,14 +98,12 @@ open class RecordSet extends formae.Resource {
 
     @aws.FieldHint{
         createOnly = true
-        persist = true
     }
     name: String
 
     region: aws.Region?
 
     @aws.FieldHint {
-        persist = true
     }
     resourceRecords: (Listing<String>)?
 
@@ -116,13 +111,11 @@ open class RecordSet extends formae.Resource {
     setIdentifier: String?
 
     @aws.FieldHint{
-        persist = true
         outputField = "TTL"
     }
     ttl: Number?
 
     @aws.FieldHint{
-        persist = true
     }
     type: String
 

--- a/schema/pkl/route53/recordsetgroup.pkl
+++ b/schema/pkl/route53/recordsetgroup.pkl
@@ -74,7 +74,6 @@ open class RecordSet extends formae.SubResource {
 
 @aws.ResourceHint {
     type = module.type
-    nonprovisionable = true
     identifier = "Id"
     discoverable = false
 }

--- a/schema/pkl/s3/accessgrant.pkl
+++ b/schema/pkl/s3/accessgrant.pkl
@@ -50,7 +50,6 @@ open class AccessGrant extends formae.Resource {
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     s3PrefixType: AccessGrantS3PrefixType?
 

--- a/schema/pkl/s3/bucket.pkl
+++ b/schema/pkl/s3/bucket.pkl
@@ -431,7 +431,6 @@ open class Rule extends formae.SubResource {
     noncurrentVersionExpirationInDays: Int?
 
     @aws.FieldHint {
-        writeOnly = true
     }
     noncurrentVersionTransition: NoncurrentVersionTransition?
 
@@ -442,7 +441,6 @@ open class Rule extends formae.SubResource {
     objectSizeLessThan: String(matches(Regex(#"[0-9]+"#)))?
 
     @aws.FieldHint {
-        writeOnly = true
     }
     prefix: String?
 
@@ -600,7 +598,6 @@ open class Bucket extends formae.Resource {
     accelerateConfiguration: AccelerateConfiguration?
 
     @aws.FieldHint {
-        writeOnly = true
     }
     accessControl: AccessControl?
 

--- a/schema/pkl/sagemaker/domain.pkl
+++ b/schema/pkl/sagemaker/domain.pkl
@@ -276,7 +276,6 @@ open class Domain extends formae.Resource {
 
     @aws.FieldHint{
         createOnly = true
-        writeOnly = true
     }
     tags: Listing<aws.Tag>?
 

--- a/schema/pkl/sagemaker/endpoint.pkl
+++ b/schema/pkl/sagemaker/endpoint.pkl
@@ -92,13 +92,13 @@ open class Endpoint extends formae.Resource {
     @aws.FieldHint{createOnly = true}
     endpointName: String?
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     excludeRetainedVariantProperties: Listing<VariantProperty>?
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     retainAllVariantProperties: Boolean?
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     retainDeploymentConfig: Boolean?
 
     @aws.FieldHint {

--- a/schema/pkl/sagemaker/userprofile.pkl
+++ b/schema/pkl/sagemaker/userprofile.pkl
@@ -183,7 +183,6 @@ open class UserProfile extends formae.Resource {
     singleSignOnUserValue: String?
 
     @aws.FieldHint {
-        writeOnly = true
         updateMethod = "EntitySet"
         indexField = "Key"
     }

--- a/schema/pkl/secretsmanager/resourcepolicy.pkl
+++ b/schema/pkl/secretsmanager/resourcepolicy.pkl
@@ -17,7 +17,7 @@ const type = "AWS::SecretsManager::ResourcePolicy"
 }
 open class ResourcePolicy extends formae.Resource {
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     blockPublicPolicy: Boolean?
 
     @aws.FieldHint

--- a/schema/pkl/secretsmanager/rotationschedule.pkl
+++ b/schema/pkl/secretsmanager/rotationschedule.pkl
@@ -39,10 +39,10 @@ open class RotationRules extends formae.SubResource {
 }
 open class RotationSchedule extends formae.Resource {
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     hostedRotationLambda: HostedRotationLambda?
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{}
     rotateImmediatelyOnUpdate: Boolean?
 
     @aws.FieldHint

--- a/schema/pkl/secretsmanager/secret.pkl
+++ b/schema/pkl/secretsmanager/secret.pkl
@@ -67,7 +67,6 @@ open class Secret extends formae.Resource {
     description: String?
 
     @aws.FieldHint {
-        writeOnly = true
     }
     generateSecretString: GenerateSecretString?
 
@@ -86,7 +85,6 @@ open class Secret extends formae.Resource {
 
 
     @aws.FieldHint {
-        writeOnly = true
     }
     hidden secretString: (formae.Value|String)?
 


### PR DESCRIPTION
Remove annotations that are declared in the formae schema but never used:

- writeOnly: Extensively set but never checked in formae agent
- persist: Set in PKL but never checked in Go code
- nonprovisionable: Only printed in dev CLI, no logic depends on it

This cleanup prepares for the corresponding formae schema change that removes these fields entirely.