### PR TITLE
chore(examples): implement aurora example suitable for testing http access

### DIFF
--- a/examples/PklProject
+++ b/examples/PklProject
@@ -4,7 +4,5 @@ dependencies {
   ["formae"] {
     uri = "package://hub.platform.engineering/plugins/pkl/schema/pkl/formae/formae@0.80.0"
   }
-  ["aws"] {
-    uri = "package://hub.platform.engineering/plugins/aws/schema/pkl/aws/aws@0.1.0"
-  }
+  ["aws"] = import("../schema/pkl/PklProject")
 }

--- a/examples/aurora-dataapi/README.md
+++ b/examples/aurora-dataapi/README.md
@@ -1,0 +1,89 @@
+# Aurora Data API Infrastructure
+
+This example creates an Aurora PostgreSQL Serverless v2 cluster with the **Data API enabled** for testing the `DatastoreAuroraDataAPI` implementation.
+
+## Deploy Infrastructure
+
+```bash
+# Apply the Aurora Data API infrastructure
+./formae apply --mode reconcile --watch ../formae-plugin-aws/examples/aurora-dataapi/main.pkl
+```
+
+## What Gets Created
+
+| Resource | Purpose |
+|----------|---------|
+| VPC + Subnets | Network for Aurora (required by AWS) |
+| Security Group | Allow PostgreSQL within VPC |
+| DB Subnet Group | Required for Aurora cluster |
+| Aurora PostgreSQL Cluster | Serverless v2 with `enableHttpEndpoint = true` |
+| Aurora DB Instance | Serverless instance in the cluster |
+
+## Get ARNs for Testing
+
+After deployment:
+
+```bash
+# Cluster ARN
+aws rds describe-db-clusters --db-cluster-identifier aurora-dataapi-cluster \
+    --query 'DBClusters[0].DBClusterArn' --output text
+
+# Secret ARN (RDS-managed master password)
+aws rds describe-db-clusters --db-cluster-identifier aurora-dataapi-cluster \
+    --query 'DBClusters[0].MasterUserSecret.SecretArn' --output text
+```
+
+Or via formae:
+
+```bash
+  ./formae inventory resources --query 'type:AWS::RDS::DBCluster'                                                                                    
+  ./formae inventory resources --query 'stack:aurora-dataapi' 
+```
+
+## Run Datastore Tests
+
+Once deployed, run the datastore tests against Aurora Data API:
+
+```bash
+cd ../formae
+
+go test -v ./internal/metastructure/datastore/... \
+    -dbType=auroradataapi \
+    -clusterArn="arn:aws:rds:us-east-1:ACCOUNT:cluster:aurora-dataapi-cluster" \
+    -secretArn="arn:aws:secretsmanager:us-east-1:ACCOUNT:secret:rds!cluster-..." \
+    -database="formae"
+```
+
+## IAM Permissions Required
+
+Your AWS credentials need these permissions to call Data API:
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "rds-data:ExecuteStatement",
+                "rds-data:BatchExecuteStatement",
+                "rds-data:BeginTransaction",
+                "rds-data:CommitTransaction",
+                "rds-data:RollbackTransaction"
+            ],
+            "Resource": "arn:aws:rds:*:*:cluster:aurora-dataapi-cluster"
+        },
+        {
+            "Effect": "Allow",
+            "Action": "secretsmanager:GetSecretValue",
+            "Resource": "arn:aws:secretsmanager:*:*:secret:rds!cluster-*"
+        }
+    ]
+}
+```
+
+## Cleanup
+
+```bash
+./formae destroy --watch ../formae-plugin-aws/examples/aurora-dataapi/main.pkl
+```

--- a/examples/aurora-dataapi/infrastructure/rds_resources.pkl
+++ b/examples/aurora-dataapi/infrastructure/rds_resources.pkl
@@ -1,0 +1,96 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+import "@formae/formae.pkl"
+import "@aws/ec2/vpc.pkl"
+import "@aws/ec2/subnet.pkl"
+import "@aws/ec2/securitygroup.pkl"
+import "@aws/ec2/securitygroupingress.pkl"
+import "@aws/rds/dbcluster.pkl"
+import "@aws/rds/dbinstance.pkl"
+import "@aws/rds/dbsubnetgroup.pkl"
+
+class RdsResources {
+    name: String
+    vpcCidr: String
+    dbName: String
+    vpc: vpc.VPC
+    subnet1: subnet.Subnet
+    subnet2: subnet.Subnet
+
+    hidden auroraSg: securitygroup.SecurityGroup = new {
+        label = "\(name)-aurora-sg"
+        groupDescription = "Security group for Aurora Data API cluster"
+        vpcId = vpc.res.id
+        tags { new { key = "Name"; value = "\(name)-aurora-sg" } }
+    }
+
+    hidden auroraSgIngress: securitygroupingress.SecurityGroupIngress = new {
+        label = "\(name)-aurora-sg-ingress"
+        ipProtocol = "tcp"
+        fromPort = 5432
+        toPort = 5432
+        cidrIp = vpcCidr
+        groupId = auroraSg.res.groupId
+    }
+
+    hidden dbSubnetGroup: dbsubnetgroup.DBSubnetGroup = new {
+        label = "\(name)-db-subnet-group"
+        dbSubnetGroupDescription = "Subnet group for Aurora Data API cluster"
+        subnetIds { subnet1.res.subnetId; subnet2.res.subnetId }
+        tags { new { key = "Name"; value = "\(name)-db-subnet-group" } }
+    }
+
+    hidden auroraCluster: dbcluster.DBCluster = new {
+        label = "\(name)-cluster"
+        dbClusterIdentifier = "\(name)-cluster"
+        engine = "aurora-postgresql"
+        engineVersion = "16.4"
+
+        // Enable Data API to allow HTTP access
+        enableHttpEndpoint = true
+
+        serverlessV2ScalingConfiguration {
+            minCapacity = 0.5
+            maxCapacity = 2.0
+        }
+
+        // Credentials managed by RDS
+        masterUsername = "postgres"
+        manageMasterUserPassword = true
+        masterUserSecret {
+            kmsKeyId = null  // Use default KMS key
+        }
+
+        databaseName = dbName
+        dbSubnetGroupName = dbSubnetGroup.res.dbSubnetGroupName
+        vpcSecurityGroupIds { auroraSg.res.groupId }
+        storageEncrypted = true
+        backupRetentionPeriod = 1
+
+        tags {
+            new { key = "Name"; value = "\(name)-cluster" }
+            new { key = "Purpose"; value = "DatastoreAuroraDataAPI testing" }
+        }
+    }
+
+    hidden auroraInstance: dbinstance.DBInstance = new {
+        label = "\(name)-instance"
+        dbInstanceIdentifier = "\(name)-instance"
+        dbClusterIdentifier = auroraCluster.res.dbClusterIdentifier
+        dbInstanceClass = "db.serverless"
+        engine = "aurora-postgresql"
+        tags { new { key = "Name"; value = "\(name)-instance" } }
+    }
+
+    hidden resources: Listing<formae.Resource> = new {
+        auroraSg
+        auroraSgIngress
+        dbSubnetGroup
+        auroraCluster
+        auroraInstance
+    }
+}

--- a/examples/aurora-dataapi/infrastructure/vpc_resources.pkl
+++ b/examples/aurora-dataapi/infrastructure/vpc_resources.pkl
@@ -1,0 +1,63 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+import "@formae/formae.pkl"
+import "@aws/ec2/vpc.pkl" as awsvpc
+import "@aws/ec2/subnet.pkl"
+import "@aws/ec2/internetgateway.pkl"
+import "@aws/ec2/vpcgatewayattachment.pkl"
+
+class VpcResources {
+    name: String
+    vpcCidr: String
+    subnetCidr1: String
+    subnetCidr2: String
+    availabilityZone1: String
+    availabilityZone2: String
+
+    hidden vpc: awsvpc.VPC = new {
+        label = "\(name)-vpc"
+        cidrBlock = vpcCidr
+        enableDnsHostnames = true
+        enableDnsSupport = true
+        tags { new { key = "Name"; value = "\(name)-vpc" } }
+    }
+
+    hidden igw: internetgateway.InternetGateway = new {
+        label = "\(name)-igw"
+        tags { new { key = "Name"; value = "\(name)-igw" } }
+    }
+
+    hidden attachIgw: vpcgatewayattachment.VPCGatewayAttachment = new {
+        label = "\(name)-igw-attachment"
+        vpcId = vpc.res.id
+        internetGatewayId = igw.res.id
+    }
+
+    hidden subnet1: subnet.Subnet = new {
+        label = "\(name)-subnet-1"
+        vpcId = vpc.res.id
+        cidrBlock = subnetCidr1
+        availabilityZone = availabilityZone1
+        tags { new { key = "Name"; value = "\(name)-subnet-1" } }
+    }
+
+    hidden subnet2: subnet.Subnet = new {
+        label = "\(name)-subnet-2"
+        vpcId = vpc.res.id
+        cidrBlock = subnetCidr2
+        availabilityZone = availabilityZone2
+        tags { new { key = "Name"; value = "\(name)-subnet-2" } }
+    }
+
+    hidden resources: Listing<formae.Resource> = new {
+        vpc
+        igw
+        attachIgw
+        subnet1
+        subnet2
+    }
+}

--- a/examples/aurora-dataapi/main.pkl
+++ b/examples/aurora-dataapi/main.pkl
@@ -1,0 +1,90 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ *
+ * Aurora PostgreSQL cluster with Data API enabled.
+ * Used to test the DatastoreAuroraDataAPI implementation.
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "./infrastructure/vpc_resources.pkl"
+import "./infrastructure/rds_resources.pkl"
+
+import "./vars.pkl"
+
+description {
+    text = """
+    Aurora PostgreSQL Serverless v2 cluster with Data API enabled.
+
+    This forma provisions:
+    - VPC with two subnets across availability zones
+    - Internet gateway for external connectivity
+    - Security group allowing PostgreSQL traffic within the VPC
+    - DB subnet group for Aurora placement
+    - Aurora PostgreSQL Serverless v2 cluster with Data API enabled
+    - Aurora instance for the cluster
+
+    The resulting infrastructure is ready for testing the DatastoreAuroraDataAPI implementation.
+    """
+    confirm = true
+}
+
+properties {
+    name = new formae.Prop {
+        flag = "name"
+        default = vars.projectName
+    }
+    region = new formae.Prop {
+        flag = "region"
+        default = vars.region
+    }
+    vpcCidr = new formae.Prop {
+        flag = "vpcCidr"
+        default = vars.vpcCidr
+    }
+    subnetCidr1 = new formae.Prop {
+        flag = "subnetCidr1"
+        default = vars.subnetCidr1
+    }
+    subnetCidr2 = new formae.Prop {
+        flag = "subnetCidr2"
+        default = vars.subnetCidr2
+    }
+    availabilityZone1 = new formae.Prop {
+        flag = "az1"
+        default = vars.availabilityZone1
+    }
+    availabilityZone2 = new formae.Prop {
+        flag = "az2"
+        default = vars.availabilityZone2
+    }
+}
+
+local _vpc = new vpc_resources.VpcResources {
+    name = properties.name.value
+    vpcCidr = properties.vpcCidr.value
+    subnetCidr1 = properties.subnetCidr1.value
+    subnetCidr2 = properties.subnetCidr2.value
+    availabilityZone1 = properties.availabilityZone1.value
+    availabilityZone2 = properties.availabilityZone2.value
+}
+
+local _rds = new rds_resources.RdsResources {
+    name = properties.name.value
+    vpcCidr = properties.vpcCidr.value
+    dbName = vars.dbName
+    vpc = _vpc.vpc
+    subnet1 = _vpc.subnet1
+    subnet2 = _vpc.subnet2
+}
+
+forma {
+    vars.stack
+    vars.target
+
+    ..._vpc.resources
+    ..._rds.resources
+}

--- a/examples/aurora-dataapi/vars.pkl
+++ b/examples/aurora-dataapi/vars.pkl
@@ -1,0 +1,29 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+import "@formae/formae.pkl"
+import "@aws/aws.pkl"
+
+projectName = "aurora-dataapi"
+region = "us-east-1"
+availabilityZone1 = "us-east-1a"
+availabilityZone2 = "us-east-1b"
+vpcCidr = "10.100.0.0/16"
+subnetCidr1 = "10.100.1.0/24"
+subnetCidr2 = "10.100.2.0/24"
+dbName = "formae"
+
+stack: formae.Stack = new {
+    label = "aurora-dataapi"
+    description = "Test infrastructure for Aurora Data API datastore"
+}
+
+target: formae.Target = new formae.Target {
+    label = "aurora-dataapi-target"
+    config = new aws.Config {
+        region = module.region
+    }
+}

--- a/schema/pkl/rds/dbcluster.pkl
+++ b/schema/pkl/rds/dbcluster.pkl
@@ -48,6 +48,9 @@ open class ServerlessV2ScalingConfiguration extends formae.SubResource {
 open class DBClusterResolvable extends formae.Resolvable {
     hidden type = module.type
 
+    hidden dbClusterIdentifier: DBClusterResolvable = (this) {
+        property = "DBClusterIdentifier"
+    }
     hidden dbClusterArn: DBClusterResolvable = (this) {
         property = "DBClusterArn"
     }
@@ -287,7 +290,7 @@ open class DBCluster extends formae.Resource {
     useLatestRestorableTime: Boolean?
 
     @aws.FieldHint
-    vpcSecurityGroupIds: Listing<String>?
+    vpcSecurityGroupIds: Listing<String|formae.Resolvable>?
 
     hidden parent = this
 

--- a/schema/pkl/rds/dbinstance.pkl
+++ b/schema/pkl/rds/dbinstance.pkl
@@ -139,7 +139,7 @@ open class DBInstance extends formae.Resource {
         createOnly = true
         outputField = "DBClusterIdentifier"
         }
-    dbClusterIdentifier: String?
+    dbClusterIdentifier: (String|formae.Resolvable)?
 
     @aws.FieldHint{
         outputField = "DBClusterSnapshotIdentifier"

--- a/schema/pkl/rds/dbsubnetgroup.pkl
+++ b/schema/pkl/rds/dbsubnetgroup.pkl
@@ -34,10 +34,13 @@ open class DBSubnetGroupResolvable extends formae.Resolvable {
 }
 open class DBSubnetGroup extends formae.Resource {
 
-    @aws.FieldHint
-    dbSubnetGroupDescription: String?
+    @aws.FieldHint{outputField = "DBSubnetGroupDescription"}
+    dbSubnetGroupDescription: String
 
-    @aws.FieldHint{createOnly = true}
+    @aws.FieldHint{
+        createOnly = true
+        outputField = "DBSubnetGroupName"
+    }
     dbSubnetGroupName: String?
 
     @aws.FieldHint


### PR DESCRIPTION
Add class-based Aurora Data API example demonstrating Aurora with HTTP endpoint enabled for testing the `DatastoreAuroraDataAPI` implementation.         