### PR TITLE
feat: add TIMEOUT parameter for conformance tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ clean-environment:
 	@./scripts/ci/clean-environment.sh
 
 ## conformance-test: Run all conformance tests (CRUD + discovery)
-## Usage: make conformance-test [VERSION=0.80.0] [TEST=s3-bucket] [PARALLEL=10]
+## Usage: make conformance-test [VERSION=0.80.0] [TEST=s3-bucket] [PARALLEL=10] [TIMEOUT=15]
 ## Downloads the specified formae version (or latest) and runs conformance tests.
 ## Calls setup-credentials and clean-environment automatically.
 ##
@@ -96,16 +96,17 @@ clean-environment:
 ##   VERSION  - Formae version to test against (default: latest)
 ##   TEST     - Filter tests by name pattern (e.g., TEST=s3-bucket)
 ##   PARALLEL - Max parallel tests (default: 1 = sequential)
+##   TIMEOUT  - Timeout in minutes for long-running operations (default: 5)
 conformance-test: conformance-test-crud conformance-test-discovery
 
 ## conformance-test-crud: Run only CRUD lifecycle tests
-## Usage: make conformance-test-crud [VERSION=0.80.0] [TEST=s3-bucket] [PARALLEL=10]
+## Usage: make conformance-test-crud [VERSION=0.80.0] [TEST=s3-bucket] [PARALLEL=10] [TIMEOUT=15]
 conformance-test-crud: install setup-credentials
 	@echo "Pre-test cleanup..."
 	@./scripts/ci/clean-environment.sh || true
 	@echo ""
 	@echo "Running CRUD conformance tests..."
-	@FORMAE_TEST_FILTER="$(TEST)" FORMAE_TEST_TYPE=crud FORMAE_TEST_PARALLEL="$(PARALLEL)" ./scripts/run-conformance-tests.sh $(VERSION); \
+	@FORMAE_TEST_FILTER="$(TEST)" FORMAE_TEST_TYPE=crud FORMAE_TEST_PARALLEL="$(PARALLEL)" FORMAE_TEST_TIMEOUT="$(TIMEOUT)" ./scripts/run-conformance-tests.sh $(VERSION); \
 	TEST_EXIT=$$?; \
 	echo ""; \
 	echo "Post-test cleanup..."; \
@@ -113,13 +114,13 @@ conformance-test-crud: install setup-credentials
 	exit $$TEST_EXIT
 
 ## conformance-test-discovery: Run only discovery tests
-## Usage: make conformance-test-discovery [VERSION=0.80.0] [TEST=s3-bucket] [PARALLEL=10]
+## Usage: make conformance-test-discovery [VERSION=0.80.0] [TEST=s3-bucket] [PARALLEL=10] [TIMEOUT=15]
 conformance-test-discovery: install setup-credentials
 	@echo "Pre-test cleanup..."
 	@./scripts/ci/clean-environment.sh || true
 	@echo ""
 	@echo "Running discovery conformance tests..."
-	@FORMAE_TEST_FILTER="$(TEST)" FORMAE_TEST_TYPE=discovery FORMAE_TEST_PARALLEL="$(PARALLEL)" ./scripts/run-conformance-tests.sh $(VERSION); \
+	@FORMAE_TEST_FILTER="$(TEST)" FORMAE_TEST_TYPE=discovery FORMAE_TEST_PARALLEL="$(PARALLEL)" FORMAE_TEST_TIMEOUT="$(TIMEOUT)" ./scripts/run-conformance-tests.sh $(VERSION); \
 	TEST_EXIT=$$?; \
 	echo ""; \
 	echo "Post-test cleanup..."; \

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/platform-engineering-labs/formae/pkg/model v0.1.2
 	github.com/platform-engineering-labs/formae/pkg/plugin v0.1.8
-	github.com/platform-engineering-labs/formae/pkg/plugin-conformance-tests v0.1.12
+	github.com/platform-engineering-labs/formae/pkg/plugin-conformance-tests v0.1.14
 	github.com/stretchr/testify v1.11.1
 )
 


### PR DESCRIPTION
## Summary

- Bump `plugin-conformance-tests` to v0.1.13
- Add `TIMEOUT` parameter to Makefile conformance test targets
- Passes `FORMAE_TEST_TIMEOUT` environment variable for slow resources

## Usage

```bash
# Default 5-minute timeout
make conformance-test

# 15-minute timeout for slow resources
make conformance-test TIMEOUT=15
```

## Related

- platform-engineering-labs/formae#213