### PR TITLE
fix(schema): add missing af-south-1 availability zone pattern

### DIFF
--- a/schema/pkl/aws.pkl
+++ b/schema/pkl/aws.pkl
@@ -48,6 +48,7 @@ typealias Region = "af-south-1" |
   "us-west-2"
 
 typealias AvailabilityZone = String((str) -> (
+  str.matches(Regex(#"af\-south\-1[a-c]"#)) ||
   str.matches(Regex(#"ap\-east\-1[a-c]"#)) ||
   str.matches(Regex(#"ap\-east\-2[a-c]"#)) ||
   str.matches(Regex(#"ap\-northeast\-1[a|c|d]"#)) ||


### PR DESCRIPTION
## Summary

- Add missing `af-south-1[a-c]` regex pattern to the `AvailabilityZone` typealias in `schema/pkl/aws.pkl`
- The `Region` typealias already includes `af-south-1`, but the `AvailabilityZone` constraint was missing it, causing Pkl evaluation failures when using AZs in that region

Closes #22

## Test plan

- [x] `make lint` passes
- [x] `make test-unit` passes
- [ ] Pkl evaluation accepts `af-south-1a`, `af-south-1b`, `af-south-1c` as valid availability zones