### PR TITLE
fix(telemetry): use k.platform.engineering endpoint

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -141,7 +141,7 @@ jobs:
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
         run: |
           REPO=$(basename "$(git remote get-url origin)" .git 2>/dev/null || echo "unknown")
-          curl -sf -o /dev/null https://us.i.posthog.com/capture/ \
+          curl -sf -o /dev/null https://k.platform.engineering/capture/ \
             -H "Content-Type: application/json" \
             -d "$(jq -n \
               --arg api_key "$POSTHOG_API_KEY" \

--- a/scripts/run-conformance-tests.sh
+++ b/scripts/run-conformance-tests.sh
@@ -62,7 +62,7 @@ formae_track_event() {
     payload=$(echo "$payload" | jq --arg k "$key" --arg v "$val" '.properties[$k] = $v')
   done
 
-  curl -sf -o /dev/null https://us.i.posthog.com/capture/ \
+  curl -sf -o /dev/null https://k.platform.engineering/capture/ \
     -H "Content-Type: application/json" \
     -d "$payload" || echo "[telemetry] event send failed (non-critical)" >&2 &
 }


### PR DESCRIPTION
Replace `us.i.posthog.com` with `k.platform.engineering` in nightly workflow and conformance test script.