### PR TITLE
fix(schema): accept formae.Resolvable on ID/Arn/Name reference properties

### DIFF
--- a/schema/pkl/apigateway/apikey.pkl
+++ b/schema/pkl/apigateway/apikey.pkl
@@ -14,7 +14,7 @@ const type = "AWS::ApiGateway::ApiKey"
 @aws.SubResourceHint
 open class StageKey extends formae.SubResource {
     restApiId: (String|formae.Resolvable)?
-    stageName: (String|formae.Resolvable)?
+    stageName: String?
 }
 
 open class ApiKeyResolvable extends formae.Resolvable {

--- a/schema/pkl/apigateway/apikey.pkl
+++ b/schema/pkl/apigateway/apikey.pkl
@@ -13,8 +13,8 @@ const type = "AWS::ApiGateway::ApiKey"
 
 @aws.SubResourceHint
 open class StageKey extends formae.SubResource {
-    restApiId: String?
-    stageName: String?
+    restApiId: (String|formae.Resolvable)?
+    stageName: (String|formae.Resolvable)?
 }
 
 open class ApiKeyResolvable extends formae.Resolvable {
@@ -36,7 +36,7 @@ open class ApiKeyResolvable extends formae.Resolvable {
 open class ApiKey extends formae.Resource {
 
     @aws.FieldHint
-    customerId: String?
+    customerId: (String|formae.Resolvable)?
 
     @aws.FieldHint
     description: String?

--- a/schema/pkl/apigateway/deployment.pkl
+++ b/schema/pkl/apigateway/deployment.pkl
@@ -103,7 +103,7 @@ open class Deployment extends formae.Resource {
         createOnly = true
         writeOnly = true
     }
-    stageName: (String|formae.Resolvable)?
+    stageName: String?
 
     local parent = this
 

--- a/schema/pkl/apigateway/deployment.pkl
+++ b/schema/pkl/apigateway/deployment.pkl
@@ -13,7 +13,7 @@ const type = "AWS::ApiGateway::Deployment"
 
 @aws.SubResourceHint
 open class AccessLogSetting extends formae.SubResource {
-    destinationArn: String?
+    destinationArn: (String|formae.Resolvable)?
     format: String?
 }
 
@@ -47,7 +47,7 @@ open class StageDescription extends formae.SubResource {
     cacheTtlInSeconds: Int?
     cachingEnabled: Boolean?
     canarySetting: CanarySetting?
-    clientCertificateId: String?
+    clientCertificateId: (String|formae.Resolvable)?
     dataTraceEnabled: Boolean?
     description: String?
     documentationVersion: String?
@@ -103,7 +103,7 @@ open class Deployment extends formae.Resource {
         createOnly = true
         writeOnly = true
     }
-    stageName: String?
+    stageName: (String|formae.Resolvable)?
 
     local parent = this
 

--- a/schema/pkl/apigateway/method.pkl
+++ b/schema/pkl/apigateway/method.pkl
@@ -26,7 +26,7 @@ open class Integration extends formae.SubResource {
     cacheKeyParameters: Listing<String>?
     @aws.FieldHint { hasProviderDefault = true }
     cacheNamespace: String?
-    connectionId: String?
+    connectionId: (String|formae.Resolvable)?
     connectionType: IntegrationConnectionType?
     contentHandling: IntegrationContentHandling?
     credentials: String?

--- a/schema/pkl/apigateway/restapi.pkl
+++ b/schema/pkl/apigateway/restapi.pkl
@@ -17,7 +17,7 @@ open class EndpointConfiguration extends formae.SubResource {
     @aws.FieldHint { hasProviderDefault = true }
     ipAddressType: String?
     types: Listing<String>?
-    vpcEndpointIds: Listing<String>?
+    vpcEndpointIds: Listing<String|formae.Resolvable>?
 }
 
 @aws.SubResourceHint

--- a/schema/pkl/apigateway/stage.pkl
+++ b/schema/pkl/apigateway/stage.pkl
@@ -13,13 +13,13 @@ const type = "AWS::ApiGateway::Stage"
 
 @aws.SubResourceHint
 open class AccessLogSetting extends formae.SubResource {
-    destinationArn: String?
+    destinationArn: (String|formae.Resolvable)?
     format: String?
 }
 
 @aws.SubResourceHint
 open class CanarySetting extends formae.SubResource {
-    deploymentId: String?
+    deploymentId: (String|formae.Resolvable)?
     percentTraffic: Number?
     stageVariableOverrides: Mapping<String, Any>?
     useStageCache: Boolean?

--- a/schema/pkl/apigateway/usageplan.pkl
+++ b/schema/pkl/apigateway/usageplan.pkl
@@ -14,7 +14,7 @@ const type = "AWS::ApiGateway::UsagePlan"
 
 @aws.SubResourceHint
 open class ApiStage extends formae.SubResource {
-    apiId: String?
+    apiId: (String|formae.Resolvable)?
     stage: String?
     throttle: Mapping<String, Any>?
 }

--- a/schema/pkl/apprunner/apprunnerservice.pkl
+++ b/schema/pkl/apprunner/apprunnerservice.pkl
@@ -37,7 +37,7 @@ typealias SourceCodeVersionType = "BRANCH"
 @aws.SubResourceHint
 open class AuthenticationConfiguration extends formae.SubResource {
     accessRoleArn: (String|formae.Resolvable)?
-    connectionArn: String?
+    connectionArn: (String|formae.Resolvable)?
 }
 
 @aws.SubResourceHint
@@ -102,7 +102,7 @@ open class ImageConfiguration extends formae.SubResource {
 @aws.SubResourceHint
 open class ImageRepository extends formae.SubResource {
     imageConfiguration: ImageConfiguration?
-    imageIdentifier: String
+    imageIdentifier: String|formae.Resolvable
     imageRepositoryType: ImageRepositoryType
 }
 

--- a/schema/pkl/cloudfront/distribution.pkl
+++ b/schema/pkl/cloudfront/distribution.pkl
@@ -31,12 +31,12 @@ typealias EventType = "viewer-request"|"viewer-response"|"origin-request"|"origi
 @aws.SubResourceHint
 open class DistributionConfig extends formae.SubResource {
     aliases: Listing<String>?
-    anycastIpListId: String?
+    anycastIpListId: (String|formae.Resolvable)?
     @aws.FieldHint{outputField = "CNAMEs"}
     cnames: Listing<String>?
     cacheBehaviors: Listing<CacheBehavior>?
     comment: String?
-    continuousDeploymentPolicyId: String?
+    continuousDeploymentPolicyId: (String|formae.Resolvable)?
     customErrorResponses: Listing<CustomErrorResponse>?
     customOrigin: CustomOrigin?
     defaultCacheBehavior: DefaultCacheBehavior
@@ -53,27 +53,27 @@ open class DistributionConfig extends formae.SubResource {
     s3Origin: S3Origin?
     staging: Boolean?
     viewerCertificate: ViewerCertificate?
-    webACLId: String?
+    webACLId: (String|formae.Resolvable)?
 }
 
 @aws.SubResourceHint
 open class CacheBehavior extends formae.SubResource {
     allowedMethods: Listing<String>?
-    cachePolicyId: String?
+    cachePolicyId: (String|formae.Resolvable)?
     cachedMethods: Listing<String>?
     compress: Boolean?
     defaultTTL: Number?
-    fieldLevelEncryptionId: String?
+    fieldLevelEncryptionId: (String|formae.Resolvable)?
     forwardedValues: ForwardedValues?
     functionAssociations: Listing<FunctionAssociation>?
     grpcConfig: GrpcConfig?
     lambdaFunctionAssociations: Listing<LambdaFunctionAssociation>?
     maxTTL: Number?
     minTTL: Number?
-    originRequestPolicyId: String?
+    originRequestPolicyId: (String|formae.Resolvable)?
     pathPattern: String
-    realtimeLogConfigArn: String?
-    responseHeadersPolicyId: String?
+    realtimeLogConfigArn: (String|formae.Resolvable)?
+    responseHeadersPolicyId: (String|formae.Resolvable)?
     smoothStreaming: Boolean?
     targetOriginId: String
     trustedKeyGroups: Listing<String>?
@@ -110,20 +110,20 @@ open class CustomOriginConfig extends formae.SubResource {
 @aws.SubResourceHint
 open class DefaultCacheBehavior extends formae.SubResource {
     allowedMethods: Listing<String>?
-    cachePolicyId: String?
+    cachePolicyId: (String|formae.Resolvable)?
     cachedMethods: Listing<String>?
     compress: Boolean?
     defaultTTL: Number?
-    fieldLevelEncryptionId: String?
+    fieldLevelEncryptionId: (String|formae.Resolvable)?
     forwardedValues: ForwardedValues?
     functionAssociations: Listing<FunctionAssociation>?
     grpcConfig: GrpcConfig?
     lambdaFunctionAssociations: Listing<LambdaFunctionAssociation>?
     maxTTL: Number?
     minTTL: Number?
-    originRequestPolicyId: String?
-    realtimeLogConfigArn: String?
-    responseHeadersPolicyId: String?
+    originRequestPolicyId: (String|formae.Resolvable)?
+    realtimeLogConfigArn: (String|formae.Resolvable)?
+    responseHeadersPolicyId: (String|formae.Resolvable)?
     smoothStreaming: Boolean?
     targetOriginId: String
     trustedKeyGroups: Listing<String>?
@@ -166,7 +166,7 @@ open class LambdaFunctionAssociation extends formae.SubResource {
 @aws.SubResourceHint
 open class CustomOrigin extends formae.SubResource {
     @aws.FieldHint{outputField = "DNSName"}
-    dnsName: String
+    dnsName: String|formae.Resolvable
     @aws.FieldHint{outputField = "HTTPPort"}
     httpPort: Int?
     @aws.FieldHint{outputField = "HTTPSPort"}
@@ -178,7 +178,7 @@ open class CustomOrigin extends formae.SubResource {
 @aws.SubResourceHint
 open class S3Origin extends formae.SubResource {
     @aws.FieldHint{outputField = "DNSName"}
-    dnsName: String
+    dnsName: String|formae.Resolvable
     originAccessIdentity: String?
 }
 
@@ -196,7 +196,7 @@ open class Origin extends formae.SubResource {
     customOriginConfig: CustomOriginConfig?
     domainName: String|formae.Resolvable
     id: String|formae.Resolvable
-    originAccessControlId: String?
+    originAccessControlId: (String|formae.Resolvable)?
     originCustomHeaders: Listing<OriginCustomHeader>?
     originPath: String?
     originShield: OriginShield?
@@ -265,9 +265,9 @@ open class StatusCodes extends formae.SubResource {
 
 @aws.SubResourceHint
 open class ViewerCertificate extends formae.SubResource {
-    acmCertificateArn: String?
+    acmCertificateArn: (String|formae.Resolvable)?
     cloudFrontDefaultCertificate: Boolean?
-    iamCertificateId: String?
+    iamCertificateId: (String|formae.Resolvable)?
     minimumProtocolVersion: String?
     sslSupportMethod: SSLSupportMethodType?
 }
@@ -276,7 +276,7 @@ open class ViewerCertificate extends formae.SubResource {
 open class VpcOriginConfig extends formae.SubResource {
     originKeepaliveTimeout: Int?
     originReadTimeout: Int?
-    vpcOriginId: String
+    vpcOriginId: String|formae.Resolvable
 }
 
 open class DistributionResolvable extends formae.Resolvable {

--- a/schema/pkl/dynamodb/globaltable.pkl
+++ b/schema/pkl/dynamodb/globaltable.pkl
@@ -52,7 +52,7 @@ typealias KinesisStreamSpecificationApproximateCreationDateTimePrecision = "MICR
 @aws.SubResourceHint
 open class KinesisStreamSpecification extends formae.SubResource {
     approximateCreationDateTimePrecision: KinesisStreamSpecificationApproximateCreationDateTimePrecision?
-    streamArn: String
+    streamArn: String|formae.Resolvable
 }
 
 @aws.SubResourceHint
@@ -95,7 +95,7 @@ open class ReplicaGlobalSecondaryIndexSpecification extends formae.SubResource {
 
 @aws.SubResourceHint
 open class ReplicaSSESpecification extends formae.SubResource {
-    kMSMasterKeyId: String
+    kMSMasterKeyId: String|formae.Resolvable
 }
 
 @aws.SubResourceHint

--- a/schema/pkl/dynamodb/table.pkl
+++ b/schema/pkl/dynamodb/table.pkl
@@ -63,7 +63,7 @@ typealias KinesisStreamSpecificationApproximateCreationDateTimePrecision = "MICR
 @aws.SubResourceHint
 open class KinesisStreamSpecification extends formae.SubResource {
     approximateCreationDateTimePrecision: KinesisStreamSpecificationApproximateCreationDateTimePrecision?
-    streamArn: String
+    streamArn: String|formae.Resolvable
 }
 
 @aws.SubResourceHint
@@ -112,7 +112,7 @@ open class TableS3BucketSource extends formae.SubResource {
 @aws.SubResourceHint
 open class SSESpecification extends formae.SubResource {
     @aws.FieldHint{outputField = "KMSMasterKeyId"}
-    kmsMasterKeyId: String?
+    kmsMasterKeyId: (String|formae.Resolvable)?
     @aws.FieldHint{outputField = "SSEEnabled"}
     sseEnabled: Boolean
     @aws.FieldHint{outputField = "SSEType"}

--- a/schema/pkl/ec2/capacityreservation.pkl
+++ b/schema/pkl/ec2/capacityreservation.pkl
@@ -28,7 +28,7 @@ open class CapacityReservation extends formae.Resource {
     availabilityZone: aws.AvailabilityZone
 
     @aws.FieldHint{createOnly = true}
-    availabilityZoneId: String
+    availabilityZoneId: String|formae.Resolvable
 
     @aws.FieldHint
     ebsOptimized: Boolean?
@@ -55,10 +55,10 @@ open class CapacityReservation extends formae.Resource {
     instanceType: String
 
     @aws.FieldHint
-    outPostArn: String?
+    outPostArn: (String|formae.Resolvable)?
 
     @aws.FieldHint
-    placementGroupArn: String?
+    placementGroupArn: (String|formae.Resolvable)?
 
     //TODO need to find solution for this because it's not a regular tag format
     @aws.FieldHint
@@ -68,5 +68,5 @@ open class CapacityReservation extends formae.Resource {
     tenancy: String?
 
     @aws.FieldHint{writeOnly = true}
-    unusedReservationBillingOwnerId: String?
+    unusedReservationBillingOwnerId: (String|formae.Resolvable)?
 }

--- a/schema/pkl/ec2/capacityreservationfleet.pkl
+++ b/schema/pkl/ec2/capacityreservationfleet.pkl
@@ -18,7 +18,7 @@ typealias Tenancy = "default"
 @aws.SubResourceHint
 open class InstanceTypeSpecification extends formae.SubResource {
     availabilityZone: aws.AvailabilityZone?
-    availabilityZoneId: String?
+    availabilityZoneId: (String|formae.Resolvable)?
     ebsOptimized: Boolean?
     instancePlatform: String?
     instanceType: String?

--- a/schema/pkl/ec2/clientvpnauthorizationrule.pkl
+++ b/schema/pkl/ec2/clientvpnauthorizationrule.pkl
@@ -19,7 +19,7 @@ const type = "AWS::EC2::ClientVpnAuthorizationRule"
 open class ClientVpnAuthorizationRule extends formae.Resource {
 
     @aws.FieldHint{createOnly = true}
-    accessGroupId: String?
+    accessGroupId: (String|formae.Resolvable)?
 
     @aws.FieldHint{createOnly = true}
     authorizeAllGroups: Boolean?

--- a/schema/pkl/ec2/clientvpnendpoint.pkl
+++ b/schema/pkl/ec2/clientvpnendpoint.pkl
@@ -13,7 +13,7 @@ const type = "AWS::EC2::ClientVpnEndpoint"
 
 @aws.SubResourceHint
 open class ClientVpnEndpointCertificateAuthenticationRequest extends formae.SubResource {
-    clientRootCertificateChainArn: String
+    clientRootCertificateChainArn: String|formae.Resolvable
 }
 
 @aws.SubResourceHint
@@ -27,7 +27,7 @@ open class AuthenticationOption extends formae.SubResource {
 @aws.SubResourceHint
 open class ClientConnectOptions extends formae.SubResource {
     enabled: Boolean
-    lambdaFunctionArn: String?
+    lambdaFunctionArn: (String|formae.Resolvable)?
 }
 
 @aws.SubResourceHint
@@ -45,13 +45,13 @@ open class ConnectionLogOptions extends formae.SubResource {
 
 @aws.SubResourceHint
 open class ClientVpnEndpointDirectoryServiceAuthenticationRequest extends formae.SubResource {
-    directoryId: String
+    directoryId: String|formae.Resolvable
 }
 
 @aws.SubResourceHint
 open class ClientVpnEndpointFederatedAuthenticationRequest extends formae.SubResource {
-    sAMLProviderArn: String
-    selfServiceSAMLProviderArn: String?
+    sAMLProviderArn: String|formae.Resolvable
+    selfServiceSAMLProviderArn: (String|formae.Resolvable)?
 }
 
 @aws.SubResourceHint
@@ -96,7 +96,7 @@ open class ClientVpnEndpoint extends formae.Resource {
     selfServicePortal: String?
 
     @aws.FieldHint
-    serverCertificateArn: String
+    serverCertificateArn: String|formae.Resolvable
 
     @aws.FieldHint
     sessionTimeoutHours: Int?

--- a/schema/pkl/ec2/clientvpnroute.pkl
+++ b/schema/pkl/ec2/clientvpnroute.pkl
@@ -19,7 +19,7 @@ const type = "AWS::EC2::ClientVpnRoute"
 open class ClientVpnRoute extends formae.Resource {
 
     @aws.FieldHint{createOnly = true}
-    clientVpnEndpointId: String
+    clientVpnEndpointId: String|formae.Resolvable
 
     @aws.FieldHint{createOnly = true}
     description: String?
@@ -28,5 +28,5 @@ open class ClientVpnRoute extends formae.Resource {
     destinationCidrBlock: String
 
     @aws.FieldHint{createOnly = true}
-    targetVpcSubnetId: String
+    targetVpcSubnetId: String|formae.Resolvable
 }

--- a/schema/pkl/ec2/clientvpntargetnetworkassociation.pkl
+++ b/schema/pkl/ec2/clientvpntargetnetworkassociation.pkl
@@ -19,8 +19,8 @@ const type = "AWS::EC2::ClientVpnTargetNetworkAssociation"
 open class ClientVpnTargetNetworkAssociation extends formae.Resource {
 
     @aws.FieldHint{createOnly = true}
-    clientVpnEndpointId: String
+    clientVpnEndpointId: String|formae.Resolvable
 
     @aws.FieldHint{createOnly = true}
-    subnetId: String
+    subnetId: String|formae.Resolvable
 }

--- a/schema/pkl/ec2/ec2fleet.pkl
+++ b/schema/pkl/ec2/ec2fleet.pkl
@@ -73,8 +73,8 @@ open class EBS extends formae.SubResource {
     deleteOnTermination: Boolean?
     encrypted: Boolean?
     iops: Int?
-    kmsKeyId: String?
-    snapshotId: String?
+    kmsKeyId: (String|formae.Resolvable)?
+    snapshotId: (String|formae.Resolvable)?
     volumeSize: Int?
     volumeType: EbsBlockDeviceVolumeType?
 }
@@ -99,7 +99,7 @@ open class Overrides extends formae.SubResource {
 
 @aws.SubResourceHint
 open class LaunchTemplateSpecification extends formae.SubResource {
-    launchTemplateId: String?
+    launchTemplateId: (String|formae.Resolvable)?
     launchTemplateName: (String(matches(Regex(#"[a-zA-Z0-9\(\)\.\-/_]+"#))))?
     version: String
 }
@@ -199,9 +199,9 @@ open class PerformanceFactorReference extends formae.SubResource {
 open class Placement extends formae.SubResource {
     affinity: String?
     availabilityZone: aws.AvailabilityZone?
-    groupName: String?
-    hostId: String?
-    hostResourceGroupArn: String?
+    groupName: (String|formae.Resolvable)?
+    hostId: (String|formae.Resolvable)?
+    hostResourceGroupArn: (String|formae.Resolvable)?
     partitionNumber: Int?
     spreadDomain: String?
     tenancy: String?

--- a/schema/pkl/ec2/eip.pkl
+++ b/schema/pkl/ec2/eip.pkl
@@ -39,13 +39,13 @@ open class EIP extends formae.Resource {
     domain: String?
 
     @aws.FieldHint
-    instanceId: String?
+    instanceId: (String|formae.Resolvable)?
 
     @aws.FieldHint{
         createOnly = true
         writeOnly = true
     }
-    ipamPoolId: String?
+    ipamPoolId: (String|formae.Resolvable)?
 
     @aws.FieldHint{createOnly = true; hasProviderDefault = true}
     networkBorderGroup: String?

--- a/schema/pkl/ec2/flowlog.pkl
+++ b/schema/pkl/ec2/flowlog.pkl
@@ -42,7 +42,7 @@ open class FlowLog extends formae.Resource {
     logFormat: String?
 
     @aws.FieldHint{createOnly = true}
-    logGroupName: String?
+    logGroupName: (String|formae.Resolvable)?
 
     @aws.FieldHint{createOnly = true; hasProviderDefault = true}
     maxAggregationInterval: Int?

--- a/schema/pkl/ec2/host.pkl
+++ b/schema/pkl/ec2/host.pkl
@@ -19,7 +19,7 @@ const type = "AWS::EC2::Host"
 open class Host extends formae.Resource {
 
     @aws.FieldHint{createOnly = true}
-    assetId: String?
+    assetId: (String|formae.Resolvable)?
 
     @aws.FieldHint
     autoPlacement: String?
@@ -40,5 +40,5 @@ open class Host extends formae.Resource {
     instanceType: String?
 
     @aws.FieldHint{createOnly = true}
-    outpostArn: String?
+    outpostArn: (String|formae.Resolvable)?
 }

--- a/schema/pkl/ec2/instance.pkl
+++ b/schema/pkl/ec2/instance.pkl
@@ -125,6 +125,10 @@ open class Volume extends formae.SubResource {
 open class InstanceResolvable extends formae.Resolvable {
     type = module.type
 
+
+    hidden id: InstanceResolvable = (this) {
+        property = "InstanceId"
+    }
     hidden instanceId: InstanceResolvable = (this) {
         property = "InstanceId"
     }

--- a/schema/pkl/ec2/instance.pkl
+++ b/schema/pkl/ec2/instance.pkl
@@ -37,7 +37,7 @@ open class EBS extends formae.SubResource {
     encrypted: Boolean?
     iops: Int?
     kmsKeyId: (String|formae.Resolvable)?
-    snapshotId: String?
+    snapshotId: (String|formae.Resolvable)?
     volumeSize: Int?
     volumeType: String?
 }
@@ -60,14 +60,14 @@ open class Ipv6Address extends formae.SubResource {
 
 @aws.SubResourceHint
 open class InstanceLaunchTemplateSpecification extends formae.SubResource {
-    launchTemplateId: String?
-    launchTemplateName: String?
+    launchTemplateId: (String|formae.Resolvable)?
+    launchTemplateName: (String|formae.Resolvable)?
     version: String?
 }
 
 @aws.SubResourceHint
 open class LicenseSpecification extends formae.SubResource {
-    licenseConfigurationArn: String
+    licenseConfigurationArn: String|formae.Resolvable
 }
 
 @aws.SubResourceHint
@@ -80,7 +80,7 @@ open class NetworkInterface extends formae.SubResource {
     groupSet: Listing<String>?
     ipv6AddressCount: Int?
     ipv6Addresses: Listing<Ipv6Address>?
-    networkInterfaceId: String?
+    networkInterfaceId: (String|formae.Resolvable)?
     privateIpAddress: String?
     privateIpAddresses: Listing<PrivateIpAddress>?
     secondaryPrivateIpAddressCount: Int?
@@ -105,7 +105,7 @@ open class PrivateIpAddress extends formae.SubResource {
 @aws.SubResourceHint
 open class SSMAssociation extends formae.SubResource {
     associationParameters: Listing<AssociationParameter>?
-    documentName: String
+    documentName: String|formae.Resolvable
 }
 
 
@@ -194,7 +194,7 @@ open class Instance extends formae.Resource {
     hibernationOptions: Dynamic?
 
     @aws.FieldHint
-    hostId: String?
+    hostId: (String|formae.Resolvable)?
 
     @aws.FieldHint{createOnly = true}
     hostResourceGroupArn: (String|formae.Resolvable)?
@@ -203,7 +203,7 @@ open class Instance extends formae.Resource {
     iamInstanceProfile: String?
 
     @aws.FieldHint{createOnly = true}
-    imageId: String?
+    imageId: (String|formae.Resolvable)?
 
     @aws.FieldHint
     instanceInitiatedShutdownBehavior: String?
@@ -224,7 +224,7 @@ open class Instance extends formae.Resource {
     ipv6Addresses: Listing<Ipv6Address>?
 
     @aws.FieldHint
-    kernelId: String?
+    kernelId: (String|formae.Resolvable)?
 
     @aws.FieldHint{createOnly = true}
     keyName: (String|formae.Resolvable)?
@@ -245,7 +245,7 @@ open class Instance extends formae.Resource {
     networkInterfaces: Listing<NetworkInterface>?
 
     @aws.FieldHint{createOnly = true}
-    placementGroupName: String?
+    placementGroupName: (String|formae.Resolvable)?
 
     @aws.FieldHint
     privateDnsNameOptions: Dynamic?
@@ -257,7 +257,7 @@ open class Instance extends formae.Resource {
     propagateTagsToVolumeOnCreation: Boolean?
 
     @aws.FieldHint
-    ramdiskId: String?
+    ramdiskId: (String|formae.Resolvable)?
 
     @aws.FieldHint
     securityGroupIds: Listing<String|formae.Resolvable>?

--- a/schema/pkl/ec2/ipampool.pkl
+++ b/schema/pkl/ec2/ipampool.pkl
@@ -22,7 +22,7 @@ open class ProvisionedCidr extends formae.SubResource {
 
 @aws.SubResourceHint
 open class SourceResource extends formae.SubResource {
-    resourceId: String
+    resourceId: String|formae.Resolvable
     resourceOwner: String
     resourceRegion: aws.Region
     resourceType: String

--- a/schema/pkl/ec2/keypair.pkl
+++ b/schema/pkl/ec2/keypair.pkl
@@ -18,6 +18,10 @@ typealias KeyType = "rsa"|"ed25519"
 open class KeypairResolvable extends formae.Resolvable {
     hidden type = module.type
 
+
+    hidden id: KeypairResolvable = (this) {
+        property = "KeyPairId"
+    }
     hidden keyName: KeypairResolvable = (this) {
         property = "KeyName"
     }

--- a/schema/pkl/ec2/launchtemplate.pkl
+++ b/schema/pkl/ec2/launchtemplate.pkl
@@ -53,7 +53,7 @@ open class CapacityReservationSpecification extends formae.SubResource {
 @aws.SubResourceHint
 open class CapacityReservationTarget extends formae.SubResource {
     capacityReservationId: (String|formae.Resolvable)?
-    capacityReservationResourceGroupArn: String?
+    capacityReservationResourceGroupArn: (String|formae.Resolvable)?
 }
 
 
@@ -89,8 +89,8 @@ open class EBS extends formae.SubResource {
     deleteOnTermination: Boolean?
     encrypted: Boolean?
     iops: Int?
-    kmsKeyId: String?
-    snapshotId: String?
+    kmsKeyId: (String|formae.Resolvable)?
+    snapshotId: (String|formae.Resolvable)?
     throughput: Int?
     volumeSize: Int?
     volumeType: String?
@@ -206,13 +206,13 @@ open class LaunchTemplateData extends formae.SubResource {
     enclaveOptions: EnclaveOptions?
     hibernationOptions: HibernationOptions?
     iamInstanceProfile: IamInstanceProfile?
-    imageId: String?
+    imageId: (String|formae.Resolvable)?
     instanceInitiatedShutdownBehavior: String?
     instanceMarketOptions: InstanceMarketOptions?
     instanceRequirements: InstanceRequirements?
     instanceType: String?
-    kernelId: String?
-    keyName: String?
+    kernelId: (String|formae.Resolvable)?
+    keyName: (String|formae.Resolvable)?
     licenseSpecifications: Listing<LicenseSpecification>?
     maintenanceOptions: MaintenanceOptions?
     metadataOptions: MetadataOptions?
@@ -220,8 +220,8 @@ open class LaunchTemplateData extends formae.SubResource {
     networkInterfaces: Listing<NetworkInterface>?
     placement: Placement?
     privateDnsNameOptions: PrivateDnsNameOptions?
-    ramDiskId: String?
-    securityGroupIds: Listing<String>?
+    ramDiskId: (String|formae.Resolvable)?
+    securityGroupIds: Listing<String|formae.Resolvable>?
     securityGroups: Listing<String|formae.Resolvable>?
     tagSpecifications: Listing<TagSpecification>?
     userData: String?
@@ -236,7 +236,7 @@ open class ElasticInferenceAccelerator extends formae.SubResource {
 
 @aws.SubResourceHint
 open class LicenseSpecification extends formae.SubResource {
-    licenseConfigurationArn: String?
+    licenseConfigurationArn: (String|formae.Resolvable)?
 }
 
 @aws.SubResourceHint
@@ -294,7 +294,7 @@ open class NetworkInterface extends formae.SubResource {
     ipv6PrefixCount: Int?
     ipv6Prefixes: Listing<Ipv6PrefixSpecification>?
     networkCardIndex: Int?
-    networkInterfaceId: String?
+    networkInterfaceId: (String|formae.Resolvable)?
     primaryIpv6: Boolean?
     privateIpAddress: String?
     privateIpAddresses: Listing<PrivateIpAddress>?
@@ -311,10 +311,10 @@ open class NetworkInterfaceCount extends formae.SubResource {
 open class Placement extends formae.SubResource {
     affinity: String?
     availabilityZone: aws.AvailabilityZone?
-    groupId: String?
-    groupName: String?
-    hostId: String?
-    hostResourceGroupArn: String?
+    groupId: (String|formae.Resolvable)?
+    groupName: (String|formae.Resolvable)?
+    hostId: (String|formae.Resolvable)?
+    hostResourceGroupArn: (String|formae.Resolvable)?
     partitionNumber: Int?
     spreadDomain: String?
     tenancy: String?

--- a/schema/pkl/ec2/networkinsightsaccessscopeanalysis.pkl
+++ b/schema/pkl/ec2/networkinsightsaccessscopeanalysis.pkl
@@ -18,7 +18,7 @@ const type = "AWS::EC2::NetworkInsightsAccessScopeAnalysis"
 open class NetworkInsightsAccessScopeAnalysis extends formae.Resource {
 
     @aws.FieldHint{createOnly = true}
-    networkInsightsAccessScopeId: String
+    networkInsightsAccessScopeId: String|formae.Resolvable
 
     @aws.FieldHint {
         updateMethod = "EntitySet"

--- a/schema/pkl/ec2/networkinsightsanalysis.pkl
+++ b/schema/pkl/ec2/networkinsightsanalysis.pkl
@@ -21,10 +21,10 @@ open class NetworkInsightsAnalysis extends formae.Resource {
     additionalAccounts: Listing<String>?
 
     @aws.FieldHint{createOnly = true}
-    filterInArns: Listing<String>?
+    filterInArns: Listing<String|formae.Resolvable>?
 
     @aws.FieldHint{createOnly = true}
-    networkInsightsPathId: String
+    networkInsightsPathId: String|formae.Resolvable
 
     @aws.FieldHint {
         updateMethod = "EntitySet"

--- a/schema/pkl/ec2/networkinterfacepermission.pkl
+++ b/schema/pkl/ec2/networkinterfacepermission.pkl
@@ -19,7 +19,7 @@ const type = "AWS::EC2::NetworkInterfacePermission"
 open class NetworkInterfacePermission extends formae.Resource {
 
     @aws.FieldHint{createOnly = true}
-    awsAccountId: String
+    awsAccountId: String|formae.Resolvable
 
     @aws.FieldHint{createOnly = true}
     networkInterfaceId: String|formae.Resolvable

--- a/schema/pkl/ec2/route.pkl
+++ b/schema/pkl/ec2/route.pkl
@@ -19,10 +19,10 @@ const type = "AWS::EC2::Route"
 open class Route extends formae.Resource {
 
     @aws.FieldHint
-    carrierGatewayId: String?
+    carrierGatewayId: (String|formae.Resolvable)?
 
     @aws.FieldHint
-    coreNetworkArn: String?
+    coreNetworkArn: (String|formae.Resolvable)?
 
     @aws.FieldHint{
         createOnly = true
@@ -37,10 +37,10 @@ open class Route extends formae.Resource {
     @aws.FieldHint{
         createOnly = true
     }
-    destinationPrefixListId: String?
+    destinationPrefixListId: (String|formae.Resolvable)?
 
     @aws.FieldHint{}
-    egressOnlyInternetGatewayId: String?
+    egressOnlyInternetGatewayId: (String|formae.Resolvable)?
 
     @aws.FieldHint{}
     gatewayId: (String|formae.Resolvable)?
@@ -63,12 +63,12 @@ open class Route extends formae.Resource {
     routeTableId: (String|formae.Resolvable)
 
     @aws.FieldHint{}
-    transitGatewayId: String?
+    transitGatewayId: (String|formae.Resolvable)?
 
     @aws.FieldHint{}
-    vpcEndpointId: String?
+    vpcEndpointId: (String|formae.Resolvable)?
 
     @aws.FieldHint{}
-    vpcPeeringConnectionId: String?
+    vpcPeeringConnectionId: (String|formae.Resolvable)?
 
 }

--- a/schema/pkl/ec2/securitygroupegress.pkl
+++ b/schema/pkl/ec2/securitygroupegress.pkl
@@ -26,7 +26,7 @@ open class SecurityGroupEgress extends formae.Resource {
     description: String?
 
     @aws.FieldHint{createOnly = true}
-    destinationPrefixListId: String?
+    destinationPrefixListId: (String|formae.Resolvable)?
 
     @aws.FieldHint{createOnly = true}
     destinationSecurityGroupId: (String|formae.Resolvable)?

--- a/schema/pkl/ec2/securitygroupingress.pkl
+++ b/schema/pkl/ec2/securitygroupingress.pkl
@@ -39,7 +39,7 @@ open class SecurityGroupIngress extends formae.Resource {
     ipProtocol: String
 
     @aws.FieldHint{createOnly = true}
-    sourcePrefixListId: String?
+    sourcePrefixListId: (String|formae.Resolvable)?
 
     @aws.FieldHint{createOnly = true}
     sourceSecurityGroupId: (String|formae.Resolvable)?

--- a/schema/pkl/ec2/spotfleet.pkl
+++ b/schema/pkl/ec2/spotfleet.pkl
@@ -64,21 +64,21 @@ open class EBS extends formae.SubResource {
     deleteOnTermination: Boolean?
     encrypted: Boolean?
     iops: Int?
-    snapshotId: String?
+    snapshotId: (String|formae.Resolvable)?
     volumeSize: Int?
     volumeType: VolumeType?
 }
 
 @aws.SubResourceHint
 open class LaunchTemplateSpecification extends formae.SubResource {
-    launchTemplateId: String?
+    launchTemplateId: (String|formae.Resolvable)?
     launchTemplateName: (String(matches(Regex(#"[a-zA-Z0-9\(\)\.\-/_]+"#))))?
     version: String
 }
 
 @aws.SubResourceHint
 open class SecurityGroupIdentifier extends formae.SubResource {
-    groupId: String
+    groupId: String|formae.Resolvable
 }
 
 @aws.SubResourceHint
@@ -101,10 +101,10 @@ open class NetworkInterface extends formae.SubResource {
     groups: Listing<String>?
     ipv6AddressCount: Int?
     ipv6Addresses: Listing<Ipv6Address>?
-    networkInterfaceId: String?
+    networkInterfaceId: (String|formae.Resolvable)?
     privateIpAddresses: Listing<PrivateIpAddress>?
     secondaryPrivateIpAddressCount: Int?
-    subnetId: String?
+    subnetId: (String|formae.Resolvable)?
 }
 
 typealias AcceleratorManufacturers = "amazon-web-services"|"amd"|"habana"|"nvidia"|"xilinx"
@@ -167,7 +167,7 @@ open class Overrides extends formae.SubResource {
     instanceType: String?
     priority: Number?
     spotPrice: String?
-    subnetId: String?
+    subnetId: (String|formae.Resolvable)?
     weightedCapacity: Number?
 }
 
@@ -225,18 +225,18 @@ open class LaunchSpecification extends formae.SubResource {
     blockDeviceMappings: Listing<BlockDeviceMapping>?
     ebsOptimized: Boolean?
     iamInstanceProfile: IamInstanceProfile?
-    imageId: String
+    imageId: String|formae.Resolvable
     instanceRequirements: InstanceRequirements?
     instanceType: String?
-    kernelId: String?
-    keyName: String?
+    kernelId: (String|formae.Resolvable)?
+    keyName: (String|formae.Resolvable)?
     monitoring: Monitoring?
     networkInterfaces: Listing<NetworkInterface>?
     placement: Placement?
-    ramdiskId: String?
+    ramdiskId: (String|formae.Resolvable)?
     securityGroups: Listing<SecurityGroupIdentifier>?
     spotPrice: String?
-    subnetId: String?
+    subnetId: (String|formae.Resolvable)?
 
     @aws.FieldHint{writeOnly = true}
     tagSpecifications: Listing<TagSpecification>?
@@ -305,7 +305,7 @@ typealias SpotPlacementTenancy = "dedicated"|"default"|"host"
 @aws.SubResourceHint
 open class Placement extends formae.SubResource {
     availabilityZone: aws.AvailabilityZone?
-    groupName: String?
+    groupName: (String|formae.Resolvable)?
     tenancy: SpotPlacementTenancy?
 }
 

--- a/schema/pkl/ec2/subnet.pkl
+++ b/schema/pkl/ec2/subnet.pkl
@@ -57,7 +57,7 @@ open class Subnet extends formae.Resource {
     availabilityZone: aws.AvailabilityZone?
 
     @aws.FieldHint{createOnly = true; hasProviderDefault = true}
-    availabilityZoneId: String?
+    availabilityZoneId: (String|formae.Resolvable)?
 
     @aws.FieldHint{createOnly = true}
     cidrBlock: String?
@@ -72,7 +72,7 @@ open class Subnet extends formae.Resource {
         createOnly = true
         writeOnly = true
     }
-    ipv4IpamPoolId: String?
+    ipv4IpamPoolId: (String|formae.Resolvable)?
 
     @aws.FieldHint{
         createOnly = true
@@ -87,7 +87,7 @@ open class Subnet extends formae.Resource {
         createOnly = true
         writeOnly = true
     }
-    ipv6IpamPoolId: String?
+    ipv6IpamPoolId: (String|formae.Resolvable)?
 
     @aws.FieldHint{createOnly = true; hasProviderDefault = true}
     ipv6Native: Boolean?
@@ -102,7 +102,7 @@ open class Subnet extends formae.Resource {
     mapPublicIpOnLaunch: Boolean? = false
 
     @aws.FieldHint{createOnly = true}
-    outpostArn: String?
+    outpostArn: (String|formae.Resolvable)?
 
     @aws.FieldHint { hasProviderDefault = true }
     privateDnsNameOptionsOnLaunch: PrivateDnsNameOptionsOnLaunch?

--- a/schema/pkl/ec2/subnetcidrblock.pkl
+++ b/schema/pkl/ec2/subnetcidrblock.pkl
@@ -24,7 +24,7 @@ open class SubnetCidrBlock extends formae.Resource {
         createOnly = true
         writeOnly = true
     }
-    ipv6IpamPoolId: String?
+    ipv6IpamPoolId: (String|formae.Resolvable)?
 
     @aws.FieldHint{
         createOnly = true

--- a/schema/pkl/ec2/transitgatewayconnect.pkl
+++ b/schema/pkl/ec2/transitgatewayconnect.pkl
@@ -32,5 +32,5 @@ open class TransitGatewayConnect extends formae.Resource {
     tags: Listing<aws.Tag>?
 
     @aws.FieldHint{createOnly = true}
-    transportTransitGatewayAttachmentId: String
+    transportTransitGatewayAttachmentId: String|formae.Resolvable
 }

--- a/schema/pkl/ec2/transitgatewaypeeringattachment.pkl
+++ b/schema/pkl/ec2/transitgatewaypeeringattachment.pkl
@@ -18,13 +18,13 @@ const type = "AWS::EC2::TransitGatewayPeeringAttachment"
 open class TransitGatewayPeeringAttachment extends formae.Resource {
 
     @aws.FieldHint{createOnly = true}
-    peerAccountId: String
+    peerAccountId: String|formae.Resolvable
 
     @aws.FieldHint{createOnly = true}
     peerRegion: aws.Region
 
     @aws.FieldHint{createOnly = true}
-    peerTransitGatewayId: String
+    peerTransitGatewayId: String|formae.Resolvable
 
     @aws.FieldHint {
         updateMethod = "EntitySet"
@@ -33,5 +33,5 @@ open class TransitGatewayPeeringAttachment extends formae.Resource {
     tags: Listing<aws.Tag>?
 
     @aws.FieldHint{createOnly = true}
-    transitGatewayId: String
+    transitGatewayId: String|formae.Resolvable
 }

--- a/schema/pkl/ec2/verifiedaccessendpoint.pkl
+++ b/schema/pkl/ec2/verifiedaccessendpoint.pkl
@@ -48,7 +48,7 @@ open class VerifiedAccessEndpoint extends formae.Resource {
     description: String?
 
     @aws.FieldHint{createOnly = true}
-    domainCertificateArn: String
+    domainCertificateArn: String|formae.Resolvable
 
     @aws.FieldHint{createOnly = true}
     endpointDomainPrefix: String
@@ -81,5 +81,5 @@ open class VerifiedAccessEndpoint extends formae.Resource {
     tags: Listing<aws.Tag>?
 
     @aws.FieldHint
-    verifiedAccessGroupId: String
+    verifiedAccessGroupId: String|formae.Resolvable
 }

--- a/schema/pkl/ec2/volume.pkl
+++ b/schema/pkl/ec2/volume.pkl
@@ -14,6 +14,10 @@ const type = "AWS::EC2::Volume"
 open class VolumeResolvable extends formae.Resolvable {
     hidden type = module.type
 
+
+    hidden id: VolumeResolvable = (this) {
+        property = "VolumeId"
+    }
     hidden volumeId: VolumeResolvable = (this) {
         property = "VolumeId"
     }

--- a/schema/pkl/ec2/vpc.pkl
+++ b/schema/pkl/ec2/vpc.pkl
@@ -57,7 +57,7 @@ open class VPC extends formae.Resource {
         createOnly = true
         writeOnly = true
     }
-    ipv4IpamPoolId: String?
+    ipv4IpamPoolId: (String|formae.Resolvable)?
 
     @aws.FieldHint{writeOnly = true}
     ipv4NetmaskLength: String?

--- a/schema/pkl/ec2/vpcendpoint.pkl
+++ b/schema/pkl/ec2/vpcendpoint.pkl
@@ -44,7 +44,7 @@ open class VPCEndpoint extends formae.Resource {
     privateDnsEnabled: Boolean?
 
     @aws.FieldHint{createOnly = true; hasProviderDefault = true}
-    resourceConfigurationArn: String?
+    resourceConfigurationArn: (String|formae.Resolvable)?
 
     @aws.FieldHint { hasProviderDefault = true }
     routeTableIds: Listing<String|formae.Resolvable>?
@@ -53,10 +53,10 @@ open class VPCEndpoint extends formae.Resource {
     securityGroupIds: Listing<String|formae.Resolvable>?
 
     @aws.FieldHint{createOnly = true}
-    serviceName: String?
+    serviceName: (String|formae.Resolvable)?
 
     @aws.FieldHint{createOnly = true; hasProviderDefault = true}
-    serviceNetworkArn: String?
+    serviceNetworkArn: (String|formae.Resolvable)?
 
     @aws.FieldHint { hasProviderDefault = true }
     subnetIds: Listing<String|formae.Resolvable>?

--- a/schema/pkl/ec2/vpcendpointservice.pkl
+++ b/schema/pkl/ec2/vpcendpointservice.pkl
@@ -24,10 +24,10 @@ open class VPCEndpointService extends formae.Resource {
     contributorInsightsEnabled: Boolean?
 
     @aws.FieldHint
-    gatewayLoadBalancerArns: Listing<String>?
+    gatewayLoadBalancerArns: Listing<String|formae.Resolvable>?
 
     @aws.FieldHint
-    networkLoadBalancerArns: Listing<String>?
+    networkLoadBalancerArns: Listing<String|formae.Resolvable>?
 
     @aws.FieldHint
     payerResponsibility: String?

--- a/schema/pkl/ec2/vpcgatewayattachment.pkl
+++ b/schema/pkl/ec2/vpcgatewayattachment.pkl
@@ -11,6 +11,27 @@ import "../aws.pkl"
 
 const type = "AWS::EC2::VPCGatewayAttachment"
 
+/// Resolvable reference to a VPCGatewayAttachment.
+/// Use this to create dependency edges from resources that need the gateway
+/// to be attached before they can operate. For example, Routes should reference
+/// `igwAttachment.res.internetGatewayId` instead of `igw.res.id` to ensure
+/// correct create AND destroy ordering.
+open class VPCGatewayAttachmentResolvable extends formae.Resolvable {
+    hidden type = module.type
+
+    hidden internetGatewayId: VPCGatewayAttachmentResolvable = (this) {
+        property = "InternetGatewayId"
+    }
+
+    hidden vpnGatewayId: VPCGatewayAttachmentResolvable = (this) {
+        property = "VpnGatewayId"
+    }
+
+    hidden vpcId: VPCGatewayAttachmentResolvable = (this) {
+        property = "VpcId"
+    }
+}
+
 @aws.ResourceHint {
     type = module.type
     identifier = "Ref"
@@ -25,4 +46,10 @@ open class VPCGatewayAttachment extends formae.Resource {
 
     @aws.FieldHint
     vpnGatewayId: (String|formae.Resolvable)?
+
+    local parent = this
+    hidden res: VPCGatewayAttachmentResolvable = new {
+        label = parent.label
+        stack = parent.stack?.label
+    }
 }

--- a/schema/pkl/ec2/vpcpeeringconnection.pkl
+++ b/schema/pkl/ec2/vpcpeeringconnection.pkl
@@ -18,7 +18,7 @@ const type = "AWS::EC2::VPCPeeringConnection"
 open class VPCPeeringConnection extends formae.Resource {
 
     @aws.FieldHint{createOnly = true}
-    peerOwnerId: String?
+    peerOwnerId: (String|formae.Resolvable)?
 
     @aws.FieldHint{createOnly = true}
     peerRegion: aws.Region?
@@ -27,10 +27,10 @@ open class VPCPeeringConnection extends formae.Resource {
         createOnly = true
         writeOnly = true
     }
-    peerRoleArn: String?
+    peerRoleArn: (String|formae.Resolvable)?
 
     @aws.FieldHint{createOnly = true}
-    peerVpcId: String
+    peerVpcId: String|formae.Resolvable
 
     @aws.FieldHint {
         updateMethod = "EntitySet"
@@ -39,5 +39,5 @@ open class VPCPeeringConnection extends formae.Resource {
     tags: Listing<aws.Tag>?
 
     @aws.FieldHint{createOnly = true}
-    vpcId: String
+    vpcId: String|formae.Resolvable
 }

--- a/schema/pkl/ecr/publicrepository.pkl
+++ b/schema/pkl/ecr/publicrepository.pkl
@@ -14,6 +14,14 @@ const type = "AWS::ECR::PublicRepository"
 open class PublicRepositoryResolvable extends formae.Resolvable {
     hidden type = module.type
 
+
+    hidden id: PublicRepositoryResolvable = (this) {
+        property = "RepositoryName"
+    }
+
+    hidden name: PublicRepositoryResolvable = (this) {
+        property = "RepositoryName"
+    }
     hidden repositoryName: PublicRepositoryResolvable = (this) {
         property = "RepositoryName"
     }

--- a/schema/pkl/ecr/replicationconfiguration.pkl
+++ b/schema/pkl/ecr/replicationconfiguration.pkl
@@ -19,7 +19,7 @@ open class Configuration extends formae.SubResource {
 @aws.SubResourceHint
 open class Destination extends formae.SubResource {
     region: aws.Region
-    registryId: String
+    registryId: String|formae.Resolvable
 }
 
 @aws.SubResourceHint

--- a/schema/pkl/ecr/repository.pkl
+++ b/schema/pkl/ecr/repository.pkl
@@ -25,7 +25,7 @@ open class ImageScanningConfiguration extends formae.SubResource {
 @aws.SubResourceHint
 open class LifecyclePolicy extends formae.SubResource {
     lifecyclePolicyText: String?
-    registryId: String?
+    registryId: (String|formae.Resolvable)?
 }
 
 typealias ImageTagMutability = "MUTABLE"|"IMMUTABLE"

--- a/schema/pkl/ecs/ecscluster.pkl
+++ b/schema/pkl/ecs/ecscluster.pkl
@@ -32,7 +32,7 @@ open class ClusterClusterSettings extends formae.SubResource {
 
 @aws.SubResourceHint
 open class ExecuteCommandConfiguration extends formae.SubResource {
-    kmsKeyId: String?
+    kmsKeyId: (String|formae.Resolvable)?
     logConfiguration: ClusterExecuteCommandLogConfiguration?
     logging: String?
 }
@@ -40,8 +40,8 @@ open class ExecuteCommandConfiguration extends formae.SubResource {
 @aws.SubResourceHint
 open class ClusterExecuteCommandLogConfiguration extends formae.SubResource {
     cloudWatchEncryptionEnabled: Boolean?
-    cloudWatchLogGroupName: String?
-    s3BucketName: String?
+    cloudWatchLogGroupName: (String|formae.Resolvable)?
+    s3BucketName: (String|formae.Resolvable)?
     s3EncryptionEnabled: Boolean?
     s3KeyPrefix: String?
 }

--- a/schema/pkl/ecs/expressgatewayservice.pkl
+++ b/schema/pkl/ecs/expressgatewayservice.pkl
@@ -66,6 +66,14 @@ open class NetworkConfiguration extends formae.SubResource {
 open class ExpressGatewayServiceResolvable extends formae.Resolvable {
     hidden type = module.type
 
+
+    hidden id: ExpressGatewayServiceResolvable = (this) {
+        property = "ServiceArn"
+    }
+
+    hidden arn: ExpressGatewayServiceResolvable = (this) {
+        property = "ServiceArn"
+    }
     hidden serviceArn: ExpressGatewayServiceResolvable = (this) {
         property = "ServiceArn"
     }

--- a/schema/pkl/ecs/service.pkl
+++ b/schema/pkl/ecs/service.pkl
@@ -82,7 +82,7 @@ open class TagSpecification extends formae.SubResource {
 open class LoadBalancer extends formae.SubResource {
     containerName: String?
     containerPort: Int?
-    loadBalancerName: String?
+    loadBalancerName: (String|formae.Resolvable)?
     targetGroupArn: (String|formae.Resolvable)?
 }
 
@@ -146,7 +146,7 @@ open class ServiceConnectService extends formae.SubResource {
 
 @aws.SubResourceHint
 open class ServiceConnectTlsCertificateAuthority extends formae.SubResource {
-    awsPcaAuthorityArn: String?
+    awsPcaAuthorityArn: (String|formae.Resolvable)?
 }
 
 @aws.SubResourceHint
@@ -161,7 +161,7 @@ open class ManagedEBSVolumeConfiguration extends formae.SubResource {
     filesystemType: String?
     iops: Int?
     kmsKeyId: (String|formae.Resolvable)?
-    roleArn: String
+    roleArn: String|formae.Resolvable
     sizeInGiB: Int?
     snapshotId: (String|formae.Resolvable)?
     tagSpecifications: Listing<TagSpecification>?
@@ -175,7 +175,7 @@ open class ServiceRegistry extends formae.SubResource {
     containerName: String?
     containerPort: Int?
     port: Int?
-    registryArn: String?
+    registryArn: (String|formae.Resolvable)?
 }
 
 @aws.SubResourceHint
@@ -193,7 +193,7 @@ open class TimeoutConfiguration extends formae.SubResource {
 @aws.SubResourceHint
 open class VpcLatticeConfiguration extends formae.SubResource {
     portName: String
-    roleArn: String
+    roleArn: String|formae.Resolvable
     targetGroupArn: String|formae.Resolvable
 }
 

--- a/schema/pkl/ecs/taskdefinition.pkl
+++ b/schema/pkl/ecs/taskdefinition.pkl
@@ -156,7 +156,7 @@ open class FSxAuthorizationConfig extends formae.SubResource {
 @aws.SubResourceHint
 open class FSxWindowsFileServerVolumeConfiguration extends formae.SubResource {
     authorizationConfig: FSxAuthorizationConfig?
-    fileSystemId: String
+    fileSystemId: String|formae.Resolvable
     rootDirectory: String
 }
 

--- a/schema/pkl/ecs/taskset.pkl
+++ b/schema/pkl/ecs/taskset.pkl
@@ -31,7 +31,7 @@ open class CapacityProviderStrategy extends formae.SubResource {
 open class LoadBalancer extends formae.SubResource {
     containerName: String?
     containerPort: Int?
-    targetGroupArn: String?
+    targetGroupArn: (String|formae.Resolvable)?
 }
 
 @aws.SubResourceHint
@@ -52,7 +52,7 @@ open class ServiceRegistry extends formae.SubResource {
     containerName: String?
     containerPort: Int?
     port: Int?
-    registryArn: String?
+    registryArn: (String|formae.Resolvable)?
 }
 @aws.ResourceHint {
     type = module.type
@@ -70,7 +70,7 @@ open class TaskSet extends formae.Resource {
     cluster: String
 
     @aws.FieldHint{createOnly = true}
-    externalId: String?
+    externalId: (String|formae.Resolvable)?
 
     @aws.FieldHint{createOnly = true}
     launchType: LaunchType?

--- a/schema/pkl/efs/filesystem.pkl
+++ b/schema/pkl/efs/filesystem.pkl
@@ -41,9 +41,9 @@ open class ReplicationConfiguration extends formae.SubResource {
 open class Destination extends formae.SubResource {
     availabilityZoneName: String?
     fileSystemId: (String(matches(Regex(#"^(arn:aws[-a-z]*:elasticfilesystem:[0-9a-z-:]+:file-system/fs-[0-9a-f]{8,40}|fs-[0-9a-f]{8,40})$"#))))?
-    kmsKeyId: String?
+    kmsKeyId: (String|formae.Resolvable)?
     region: String?
-    roleArn: String?
+    roleArn: (String|formae.Resolvable)?
     status: String?
     statusMessage: String?
 }

--- a/schema/pkl/eks/accessentry.pkl
+++ b/schema/pkl/eks/accessentry.pkl
@@ -22,7 +22,7 @@ open class AccessScope extends formae.SubResource {
 @aws.SubResourceHint
 open class AccessPolicy extends formae.SubResource {
     accessScope: AccessScope
-    policyArn: String
+    policyArn: String|formae.Resolvable
 }
 
 open class AccessEntryResolvable extends formae.Resolvable {

--- a/schema/pkl/eks/accessentry.pkl
+++ b/schema/pkl/eks/accessentry.pkl
@@ -28,6 +28,14 @@ open class AccessPolicy extends formae.SubResource {
 open class AccessEntryResolvable extends formae.Resolvable {
     hidden type = module.type
 
+
+    hidden id: AccessEntryResolvable = (this) {
+        property = "AccessEntryArn"
+    }
+
+    hidden arn: AccessEntryResolvable = (this) {
+        property = "AccessEntryArn"
+    }
     hidden accessEntryArn: AccessEntryResolvable = (this) {
         property = "AccessEntryArn"
     }

--- a/schema/pkl/eks/podidentityassociation.pkl
+++ b/schema/pkl/eks/podidentityassociation.pkl
@@ -14,6 +14,14 @@ const type = "AWS::EKS::PodIdentityAssociation"
 open class PodIdentityAssociationResolvable extends formae.Resolvable {
     hidden type = module.type
 
+
+    hidden id: PodIdentityAssociationResolvable = (this) {
+        property = "AssociationArn"
+    }
+
+    hidden arn: PodIdentityAssociationResolvable = (this) {
+        property = "AssociationArn"
+    }
     hidden associationArn: PodIdentityAssociationResolvable = (this) {
         property = "AssociationArn"
     }

--- a/schema/pkl/elasticbeanstalk/application.pkl
+++ b/schema/pkl/elasticbeanstalk/application.pkl
@@ -40,6 +40,14 @@ open class MaxCountRule extends formae.SubResource {
 open class ApplicationResolvable extends formae.Resolvable {
     hidden type = module.type
 
+
+    hidden id: ApplicationResolvable = (this) {
+        property = "ApplicationName"
+    }
+
+    hidden name: ApplicationResolvable = (this) {
+        property = "ApplicationName"
+    }
     hidden applicationName: ApplicationResolvable = (this) {
         property = "ApplicationName"
     }

--- a/schema/pkl/elasticbeanstalk/application.pkl
+++ b/schema/pkl/elasticbeanstalk/application.pkl
@@ -13,7 +13,7 @@ const type = "AWS::ElasticBeanstalk::Application"
 
 @aws.SubResourceHint
 open class ResourceLifecycleConfig extends formae.SubResource {
-    serviceRole: String|formae.Resolvable
+    serviceRole: (String|formae.Resolvable)?
     versionLifecycleConfig: VersionLifecycleConfig?
 }
 

--- a/schema/pkl/elasticbeanstalk/configurationtemplate.pkl
+++ b/schema/pkl/elasticbeanstalk/configurationtemplate.pkl
@@ -21,7 +21,7 @@ open class ConfigurationOptionSetting extends formae.SubResource {
 
 @aws.SubResourceHint
 open class SourceConfiguration extends formae.SubResource {
-    applicationName: String
+    applicationName: String|formae.Resolvable
     templateName: String
 }
 

--- a/schema/pkl/elasticbeanstalk/environment.pkl
+++ b/schema/pkl/elasticbeanstalk/environment.pkl
@@ -66,7 +66,7 @@ open class Environment extends formae.Resource {
     tags: Listing<aws.Tag>?
 
     @aws.FieldHint{writeOnly = true}
-    templateName: String?
+    templateName: (String|formae.Resolvable)?
 
     @aws.FieldHint
     tier: Tier?

--- a/schema/pkl/elasticloadbalancingv2/listener.pkl
+++ b/schema/pkl/elasticloadbalancingv2/listener.pkl
@@ -31,8 +31,8 @@ open class AuthenticateCognitoConfig extends formae.SubResource {
     scope: String?
     sessionCookieName: String?
     sessionTimeout: String?
-    userPoolArn: String
-    userPoolClientId: String
+    userPoolArn: String|formae.Resolvable
+    userPoolClientId: String|formae.Resolvable
     userPoolDomain: String
 }
 
@@ -55,7 +55,7 @@ open class AuthenticateOidcConfig extends formae.SubResource {
 
 @aws.SubResourceHint
 open class Certificate extends formae.SubResource {
-    certificateArn: String?
+    certificateArn: (String|formae.Resolvable)?
 }
 
 @aws.SubResourceHint
@@ -83,7 +83,7 @@ open class MutualAuthentication extends formae.SubResource {
     advertiseTrustStoreCaNames: String?
     ignoreClientCertificateExpiry: Boolean?
     mode: String?
-    trustStoreArn: String?
+    trustStoreArn: (String|formae.Resolvable)?
 }
 
 @aws.SubResourceHint

--- a/schema/pkl/elasticloadbalancingv2/listener.pkl
+++ b/schema/pkl/elasticloadbalancingv2/listener.pkl
@@ -111,6 +111,14 @@ open class TargetGroupTuple extends formae.SubResource {
 open class ListenerResolvable extends formae.Resolvable {
     hidden type = module.type
 
+
+    hidden id: ListenerResolvable = (this) {
+        property = "ListenerArn"
+    }
+
+    hidden arn: ListenerResolvable = (this) {
+        property = "ListenerArn"
+    }
     hidden listenerArn: ListenerResolvable = (this) {
         property = "ListenerArn"
     }

--- a/schema/pkl/elasticloadbalancingv2/listenerrule.pkl
+++ b/schema/pkl/elasticloadbalancingv2/listenerrule.pkl
@@ -30,8 +30,8 @@ open class AuthenticateCognitoConfig extends formae.SubResource {
     scope: String?
     sessionCookieName: String?
     sessionTimeout: Int?
-    userPoolArn: String
-    userPoolClientId: String
+    userPoolArn: String|formae.Resolvable
+    userPoolClientId: String|formae.Resolvable
     userPoolDomain: String
 }
 

--- a/schema/pkl/elasticloadbalancingv2/loadbalancer.pkl
+++ b/schema/pkl/elasticloadbalancingv2/loadbalancer.pkl
@@ -29,6 +29,14 @@ open class SubnetMapping extends formae.SubResource {
 open class LoadBalancerResolvable extends formae.Resolvable {
     hidden type = module.type
 
+
+    hidden id: LoadBalancerResolvable = (this) {
+        property = "LoadBalancerArn"
+    }
+
+    hidden arn: LoadBalancerResolvable = (this) {
+        property = "LoadBalancerArn"
+    }
     hidden canonicalHostedZoneID: LoadBalancerResolvable = (this) {
         property = "CanonicalHostedZoneID"
     }

--- a/schema/pkl/elasticloadbalancingv2/loadbalancer.pkl
+++ b/schema/pkl/elasticloadbalancingv2/loadbalancer.pkl
@@ -19,7 +19,7 @@ open class LoadBalancerAttribute extends formae.SubResource {
 
 @aws.SubResourceHint
 open class SubnetMapping extends formae.SubResource {
-    allocationId: String?
+    allocationId: (String|formae.Resolvable)?
     iPv6Address: String?
     privateIPv4Address: String?
     sourceNatIpv6Prefix: String?

--- a/schema/pkl/elasticloadbalancingv2/targetgroup.pkl
+++ b/schema/pkl/elasticloadbalancingv2/targetgroup.pkl
@@ -33,6 +33,14 @@ open class TargetGroupAttribute extends formae.SubResource {
 open class TargetGroupResolvable extends formae.Resolvable {
     hidden type = module.type
 
+
+    hidden id: TargetGroupResolvable = (this) {
+        property = "TargetGroupArn"
+    }
+
+    hidden arn: TargetGroupResolvable = (this) {
+        property = "TargetGroupArn"
+    }
     hidden loadBalancerArns: TargetGroupResolvable = (this) {
         property = "LoadBalancerArns"
     }

--- a/schema/pkl/elasticloadbalancingv2/truststorerevocation.pkl
+++ b/schema/pkl/elasticloadbalancingv2/truststorerevocation.pkl
@@ -34,5 +34,5 @@ open class TrustStoreRevocation extends formae.Resource {
     revocationContents: Listing<RevocationContent>?
 
     @aws.FieldHint{createOnly = true}
-    trustStoreArn: String?
+    trustStoreArn: (String|formae.Resolvable)?
 }

--- a/schema/pkl/iam/group.pkl
+++ b/schema/pkl/iam/group.pkl
@@ -39,7 +39,7 @@ open class Group extends formae.Resource {
     groupName: String?
 
     @aws.FieldHint{hasProviderDefault = true}
-    managedPolicyArns: Listing<String>?
+    managedPolicyArns: Listing<String|formae.Resolvable>?
 
     @aws.FieldHint
     path: String?

--- a/schema/pkl/iam/role.pkl
+++ b/schema/pkl/iam/role.pkl
@@ -47,7 +47,7 @@ open class Role extends formae.Resource {
     description: String?
 
     @aws.FieldHint
-    managedPolicyArns: Listing<String>?
+    managedPolicyArns: Listing<String|formae.Resolvable>?
 
     @aws.FieldHint{hasProviderDefault = true}
     maxSessionDuration: Int?

--- a/schema/pkl/iam/usertogroupaddition.pkl
+++ b/schema/pkl/iam/usertogroupaddition.pkl
@@ -19,7 +19,7 @@ const type = "AWS::IAM::UserToGroupAddition"
 open class UserToGroupAddition extends formae.Resource {
 
     @aws.FieldHint
-    groupName: String
+    groupName: String|formae.Resolvable
 
     @aws.FieldHint
     users: Listing<String>

--- a/schema/pkl/kms/kmsalias.pkl
+++ b/schema/pkl/kms/kmsalias.pkl
@@ -13,6 +13,18 @@ const type = "AWS::KMS::Alias"
 
 open class AliasResolvable extends formae.Resolvable {
     type = module.type
+
+    hidden aliasName: AliasResolvable = (this) {
+        property = "AliasName"
+    }
+
+    hidden id: AliasResolvable = (this) {
+        property = "AliasName"
+    }
+
+    hidden name: AliasResolvable = (this) {
+        property = "AliasName"
+    }
 }
 
 @aws.ResourceHint {

--- a/schema/pkl/lambda/func.pkl
+++ b/schema/pkl/lambda/func.pkl
@@ -81,7 +81,7 @@ typealias RuntimeManagementConfigUpdateRuntimeOn = "Auto"|"FunctionUpdate"|"Manu
 
 @aws.SubResourceHint
 open class RuntimeManagementConfig extends formae.SubResource {
-    runtimeVersionArn: String?
+    runtimeVersionArn: (String|formae.Resolvable)?
     updateRuntimeOn: RuntimeManagementConfigUpdateRuntimeOn
 }
 

--- a/schema/pkl/lambda/layerversionpermission.pkl
+++ b/schema/pkl/lambda/layerversionpermission.pkl
@@ -27,7 +27,7 @@ open class LayerVersionPermission extends formae.Resource {
     layerVersionArn: String|formae.Resolvable
 
     @aws.FieldHint{createOnly = true}
-    organizationId: String?
+    organizationId: (String|formae.Resolvable)?
 
     @aws.FieldHint{createOnly = true}
     principal: String

--- a/schema/pkl/logs/loggroup.pkl
+++ b/schema/pkl/logs/loggroup.pkl
@@ -63,4 +63,11 @@ open class LogGroup extends formae.Resource {
         indexField = "Key"
     }
     tags: Listing<aws.Tag>?
+
+    local parent = this
+
+    hidden res: LogGroupResolvable = new {
+        label = parent.label
+        stack = parent.stack?.label
+    }
 }

--- a/schema/pkl/rds/customdbengineversion.pkl
+++ b/schema/pkl/rds/customdbengineversion.pkl
@@ -16,6 +16,14 @@ typealias VersionStatus = "available"|"inactive"|"inactive-except-restore"
 open class CustomDBEngineVersionResolvable extends formae.Resolvable {
     hidden type = module.type
 
+
+    hidden id: CustomDBEngineVersionResolvable = (this) {
+        property = "DBEngineVersionArn"
+    }
+
+    hidden arn: CustomDBEngineVersionResolvable = (this) {
+        property = "DBEngineVersionArn"
+    }
     hidden dbEngineVersionArn: CustomDBEngineVersionResolvable = (this) {
         property = "DBEngineVersionArn"
     }

--- a/schema/pkl/rds/customdbengineversion.pkl
+++ b/schema/pkl/rds/customdbengineversion.pkl
@@ -28,7 +28,7 @@ open class CustomDBEngineVersionResolvable extends formae.Resolvable {
 open class CustomDBEngineVersion extends formae.Resource {
 
     @aws.FieldHint{createOnly = true}
-    databaseInstallationFilesS3BucketName: String?
+    databaseInstallationFilesS3BucketName: (String|formae.Resolvable)?
 
     @aws.FieldHint{createOnly = true}
     databaseInstallationFilesS3Prefix: String?
@@ -43,13 +43,13 @@ open class CustomDBEngineVersion extends formae.Resource {
     engineVersion: String
 
     @aws.FieldHint{createOnly = true}
-    imageId: String?
+    imageId: (String|formae.Resolvable)?
 
     @aws.FieldHint{
         createOnly = true
         outputField = "KMSKeyId"
     }
-    kmsKeyId: String?
+    kmsKeyId: (String|formae.Resolvable)?
 
     @aws.FieldHint{
         createOnly = true
@@ -61,7 +61,7 @@ open class CustomDBEngineVersion extends formae.Resource {
         createOnly = true
         writeOnly = true
     }
-    sourceCustomDbEngineVersionIdentifier: String?
+    sourceCustomDbEngineVersionIdentifier: (String|formae.Resolvable)?
 
     @aws.FieldHint
     status: VersionStatus?

--- a/schema/pkl/rds/dbcluster.pkl
+++ b/schema/pkl/rds/dbcluster.pkl
@@ -19,7 +19,7 @@ open class Role extends formae.SubResource {
 
 @aws.SubResourceHint
 open class MasterUserSecret extends formae.SubResource {
-    kmsKeyId: String?
+    kmsKeyId: (String|formae.Resolvable)?
     secretArn: (String|formae.Resolvable)?
 }
 
@@ -118,13 +118,13 @@ open class DBCluster extends formae.Resource {
 
     // Update this value can cause some downtime because the DB needs to reboot
     @aws.FieldHint {outputField = "DBClusterParameterGroupName"}
-    dbClusterParameterGroupName: String?
+    dbClusterParameterGroupName: (String|formae.Resolvable)?
 
     @aws.FieldHint{
         writeOnly = true
         outputField = "DBInstanceParameterGroupName"
     }
-    dbInstanceParameterGroupName: String?
+    dbInstanceParameterGroupName: (String|formae.Resolvable)?
 
     @aws.FieldHint{
         createOnly = true
@@ -151,7 +151,7 @@ open class DBCluster extends formae.Resource {
     domain: String?
 
     @aws.FieldHint
-    domainIAMRoleName: String?
+    domainIAMRoleName: (String|formae.Resolvable)?
 
     @aws.FieldHint
     enableCloudwatchLogsExports: Listing<String>?
@@ -188,7 +188,7 @@ open class DBCluster extends formae.Resource {
     iops: Int?
 
     @aws.FieldHint{createOnly = true}
-    kmsKeyId: String?
+    kmsKeyId: (String|formae.Resolvable)?
 
     @aws.FieldHint
     manageMasterUserPassword: Boolean?
@@ -206,7 +206,7 @@ open class DBCluster extends formae.Resource {
     monitoringInterval: Int?
 
     @aws.FieldHint
-    monitoringRoleArn: String?
+    monitoringRoleArn: (String|formae.Resolvable)?
 
     @aws.FieldHint
     networkType: String?
@@ -215,7 +215,7 @@ open class DBCluster extends formae.Resource {
     performanceInsightsEnabled: Boolean?
 
     @aws.FieldHint
-    performanceInsightsKmsKeyId: String?
+    performanceInsightsKmsKeyId: (String|formae.Resolvable)?
 
     @aws.FieldHint
     performanceInsightsRetentionPeriod: Int?
@@ -236,7 +236,7 @@ open class DBCluster extends formae.Resource {
     readEndpoint: ReadEndpoint?
 
     @aws.FieldHint
-    replicationSourceIdentifier: String?
+    replicationSourceIdentifier: (String|formae.Resolvable)?
 
     @aws.FieldHint{createOnly = true}
     restoreToTime: String?
@@ -257,13 +257,13 @@ open class DBCluster extends formae.Resource {
         createOnly = true
         writeOnly = true
     }
-    snapshotIdentifier: String?
+    snapshotIdentifier: (String|formae.Resolvable)?
 
     @aws.FieldHint{
         createOnly = true
         writeOnly = true
     }
-    sourceDBClusterIdentifier: String?
+    sourceDBClusterIdentifier: (String|formae.Resolvable)?
 
     @aws.FieldHint{
         createOnly = true

--- a/schema/pkl/rds/dbcluster.pkl
+++ b/schema/pkl/rds/dbcluster.pkl
@@ -48,6 +48,14 @@ open class ServerlessV2ScalingConfiguration extends formae.SubResource {
 open class DBClusterResolvable extends formae.Resolvable {
     hidden type = module.type
 
+
+    hidden id: DBClusterResolvable = (this) {
+        property = "DBClusterArn"
+    }
+
+    hidden arn: DBClusterResolvable = (this) {
+        property = "DBClusterArn"
+    }
     hidden dbClusterIdentifier: DBClusterResolvable = (this) {
         property = "DBClusterIdentifier"
     }

--- a/schema/pkl/rds/dbinstance.pkl
+++ b/schema/pkl/rds/dbinstance.pkl
@@ -23,20 +23,20 @@ open class CertificateDetails extends formae.SubResource {
 @aws.SubResourceHint
 open class Role extends formae.SubResource {
     featureName: String
-    roleArn: String
+    roleArn: String|formae.Resolvable
 }
 
 @aws.SubResourceHint
 open class Endpoint extends formae.SubResource {
     address: String?
-    hostedZoneId: String?
+    hostedZoneId: (String|formae.Resolvable)?
     port: String?
 }
 
 @aws.SubResourceHint
 open class MasterUserSecret extends formae.SubResource {
-    kmsKeyId: String?
-    secretArn: String?
+    kmsKeyId: (String|formae.Resolvable)?
+    secretArn: (String|formae.Resolvable)?
 }
 
 typealias ProcessorFeatureName = "coreCount"|"threadsPerCore"
@@ -104,7 +104,7 @@ open class DBInstance extends formae.Resource {
     autoMinorVersionUpgrade: Boolean?
 
     @aws.FieldHint{writeOnly = true}
-    automaticBackupReplicationKmsKeyId: String?
+    automaticBackupReplicationKmsKeyId: (String|formae.Resolvable)?
 
     @aws.FieldHint
     automaticBackupReplicationRegion: aws.Region?
@@ -145,7 +145,7 @@ open class DBInstance extends formae.Resource {
     @aws.FieldHint{
         outputField = "DBClusterSnapshotIdentifier"
     }
-    dbClusterSnapshotIdentifier: String?
+    dbClusterSnapshotIdentifier: (String|formae.Resolvable)?
 
     @aws.FieldHint{
         outputField = "DBInstanceClass"
@@ -168,7 +168,7 @@ open class DBInstance extends formae.Resource {
         outputField = "DBParameterGroupName"
         hasProviderDefault = true
     }
-    dbParameterGroupName: String?
+    dbParameterGroupName: (String|formae.Resolvable)?
 
     @aws.FieldHint{
         outputField = "dbSecurityGroups"
@@ -178,7 +178,7 @@ open class DBInstance extends formae.Resource {
     @aws.FieldHint{
         outputField = "DBSnapshotIdentifier"
     }
-    dbSnapshotIdentifier: String?
+    dbSnapshotIdentifier: (String|formae.Resolvable)?
 
     @aws.FieldHint{
         createOnly = true
@@ -205,7 +205,7 @@ open class DBInstance extends formae.Resource {
     domain: String?
 
     @aws.FieldHint
-    domainAuthSecretArn: String?
+    domainAuthSecretArn: (String|formae.Resolvable)?
 
     @aws.FieldHint
     domainDnsIps: Listing<String>?
@@ -268,7 +268,7 @@ open class DBInstance extends formae.Resource {
     monitoringInterval: Int?
 
     @aws.FieldHint
-    monitoringRoleArn: String?
+    monitoringRoleArn: (String|formae.Resolvable)?
 
     @aws.FieldHint{hasProviderDefault = true}
     multiAZ: Boolean?
@@ -280,10 +280,10 @@ open class DBInstance extends formae.Resource {
     networkType: String?
 
     @aws.FieldHint{hasProviderDefault = true}
-    optionGroupName: String?
+    optionGroupName: (String|formae.Resolvable)?
 
     @aws.FieldHint{createOnly = true}
-    performanceInsightsKMSKeyId: String?
+    performanceInsightsKMSKeyId: (String|formae.Resolvable)?
 
     @aws.FieldHint
     performanceInsightsRetentionPeriod: Int?
@@ -313,10 +313,10 @@ open class DBInstance extends formae.Resource {
     restoreTime: String?
 
     @aws.FieldHint
-    sourceDBClusterIdentifier: String?
+    sourceDBClusterIdentifier: (String|formae.Resolvable)?
 
     @aws.FieldHint{writeOnly = true}
-    sourceDBInstanceAutomatedBackupsArn: String?
+    sourceDBInstanceAutomatedBackupsArn: (String|formae.Resolvable)?
 
     @aws.FieldHint{writeOnly = true}
     sourceDBInstanceIdentifier: (String|formae.Resolvable)?
@@ -350,7 +350,7 @@ open class DBInstance extends formae.Resource {
     tags: Listing<aws.Tag>?
 
     @aws.FieldHint
-    tdeCredentialArn: String?
+    tdeCredentialArn: (String|formae.Resolvable)?
 
     @aws.FieldHint{writeOnly = true}
     tdeCredentialPassword: String?

--- a/schema/pkl/rds/dbinstance.pkl
+++ b/schema/pkl/rds/dbinstance.pkl
@@ -50,6 +50,14 @@ open class ProcessorFeature extends formae.SubResource {
 open class DBInstanceResolvable extends formae.Resolvable {
     hidden type = module.type
 
+
+    hidden id: DBInstanceResolvable = (this) {
+        property = "DBInstanceArn"
+    }
+
+    hidden arn: DBInstanceResolvable = (this) {
+        property = "DBInstanceArn"
+    }
     hidden certificateDetailsCAIdentifier: DBInstanceResolvable = (this) {
         property = "CertificateDetails.CAIdentifier"
     }

--- a/schema/pkl/rds/dbparametergroup.pkl
+++ b/schema/pkl/rds/dbparametergroup.pkl
@@ -14,6 +14,14 @@ const type = "AWS::RDS::DBParameterGroup"
 open class DBParameterGroupResolvable extends formae.Resolvable {
     hidden type = module.type
 
+
+    hidden id: DBParameterGroupResolvable = (this) {
+        property = "DBParameterGroupName"
+    }
+
+    hidden name: DBParameterGroupResolvable = (this) {
+        property = "DBParameterGroupName"
+    }
     hidden dbParameterGroupName: DBParameterGroupResolvable = (this) {
         property = "DBParameterGroupName"
     }

--- a/schema/pkl/rds/dbproxy.pkl
+++ b/schema/pkl/rds/dbproxy.pkl
@@ -36,6 +36,14 @@ open class DBProxyAuthFormat extends formae.SubResource {
 open class DBProxyResolvable extends formae.Resolvable {
     hidden type = module.type
 
+
+    hidden id: DBProxyResolvable = (this) {
+        property = "DBProxyArn"
+    }
+
+    hidden arn: DBProxyResolvable = (this) {
+        property = "DBProxyArn"
+    }
     hidden dbProxyArn: DBProxyResolvable = (this) {
         property = "DBProxyArn"
     }

--- a/schema/pkl/rds/dbproxyendpoint.pkl
+++ b/schema/pkl/rds/dbproxyendpoint.pkl
@@ -16,6 +16,14 @@ typealias DBProxyEndpointTargetRole = "READ_WRITE"|"READ_ONLY"
 open class DBProxyEndpointResolvable extends formae.Resolvable {
     hidden type = module.type
 
+
+    hidden id: DBProxyEndpointResolvable = (this) {
+        property = "DBProxyEndpointArn"
+    }
+
+    hidden arn: DBProxyEndpointResolvable = (this) {
+        property = "DBProxyEndpointArn"
+    }
     hidden dbProxyEndpointArn: DBProxyEndpointResolvable = (this) {
         property = "DBProxyEndpointArn"
     }

--- a/schema/pkl/rds/dbproxytargetgroup.pkl
+++ b/schema/pkl/rds/dbproxytargetgroup.pkl
@@ -24,9 +24,17 @@ open class ConnectionPoolConfigurationInfoFormat extends formae.SubResource {
 }
 
 open class DBProxyTargetGroupResolvable extends formae.Resolvable {
-    type = module.type
+    hidden type = module.type
 
-    targetGroupArn: DBProxyTargetGroupResolvable = (this) {
+    hidden id: DBProxyTargetGroupResolvable = (this) {
+        property = "TargetGroupArn"
+    }
+
+    hidden arn: DBProxyTargetGroupResolvable = (this) {
+        property = "TargetGroupArn"
+    }
+
+    hidden targetGroupArn: DBProxyTargetGroupResolvable = (this) {
         property = "TargetGroupArn"
     }
 }

--- a/schema/pkl/rds/dbsecuritygroup.pkl
+++ b/schema/pkl/rds/dbsecuritygroup.pkl
@@ -15,7 +15,7 @@ const type = "AWS::RDS::DBSecurityGroup"
 open class DBSecurityGroupIngress extends formae.SubResource {
     cIDRIP: String?
     eC2SecurityGroupId: (String|formae.Resolvable)?
-    eC2SecurityGroupName: String?
+    eC2SecurityGroupName: (String|formae.Resolvable)?
     eC2SecurityGroupOwnerId: (String|formae.Resolvable)?
 }
 

--- a/schema/pkl/rds/dbsecuritygroup.pkl
+++ b/schema/pkl/rds/dbsecuritygroup.pkl
@@ -22,6 +22,10 @@ open class DBSecurityGroupIngress extends formae.SubResource {
 open class DBSecurityGroupResolvable extends formae.Resolvable {
     hidden type = module.type
 
+
+    hidden id: DBSecurityGroupResolvable = (this) {
+        property = "Ref"
+    }
     hidden ref: DBSecurityGroupResolvable = (this) {
         property = "Ref"
     }

--- a/schema/pkl/rds/dbsecuritygroupingress.pkl
+++ b/schema/pkl/rds/dbsecuritygroupingress.pkl
@@ -26,7 +26,7 @@ open class DBSecurityGroupIngress extends formae.Resource {
     @aws.FieldHint{
         outputField = "DBSecurityGroupName"
     }
-    dbSecurityGroupName: String
+    dbSecurityGroupName: String|formae.Resolvable
 
     @aws.FieldHint{
         outputField = "EC2SecurityGroupId"

--- a/schema/pkl/rds/dbshardgroup.pkl
+++ b/schema/pkl/rds/dbshardgroup.pkl
@@ -15,6 +15,10 @@ const type = "AWS::RDS::DBShardGroup"
 open class DBShardGroupResolvable extends formae.Resolvable {
     hidden type = module.type
 
+
+    hidden id: DBShardGroupResolvable = (this) {
+        property = "DBShardGroupIdentifier"
+    }
     hidden dbShardGroupResourceId: DBShardGroupResolvable = (this) {
         property = "DBShardGroupResourceId"
     }

--- a/schema/pkl/rds/dbsubnetgroup.pkl
+++ b/schema/pkl/rds/dbsubnetgroup.pkl
@@ -14,6 +14,14 @@ const type = "AWS::RDS::DBSubnetGroup"
 open class DBSubnetGroupResolvable extends formae.Resolvable {
     type = module.type
 
+
+    hidden id: DBSubnetGroupResolvable = (this) {
+        property = "DBSubnetGroupName"
+    }
+
+    hidden name: DBSubnetGroupResolvable = (this) {
+        property = "DBSubnetGroupName"
+    }
     hidden dbSubnetGroupDescription: DBSubnetGroupResolvable = (this) {
         property = "DBSubnetGroupDescription"
     }

--- a/schema/pkl/rds/eventsubscription.pkl
+++ b/schema/pkl/rds/eventsubscription.pkl
@@ -24,7 +24,7 @@ open class EventSubscription extends formae.Resource {
     eventCategories: Listing<String>?
 
     @aws.FieldHint{createOnly = true}
-    snsTopicArn: String
+    snsTopicArn: String|formae.Resolvable
 
     @aws.FieldHint
     sourceIds: (Listing<String|formae.Resolvable>)?

--- a/schema/pkl/rds/integration.pkl
+++ b/schema/pkl/rds/integration.pkl
@@ -45,7 +45,7 @@ open class Integration extends formae.Resource {
         createOnly = true
         outputField = "KMSKeyId"
     }
-    kmsKeyId: String?
+    kmsKeyId: (String|formae.Resolvable)?
 
     @aws.FieldHint{createOnly = true}
     sourceArn: String|formae.Resolvable

--- a/schema/pkl/rds/integration.pkl
+++ b/schema/pkl/rds/integration.pkl
@@ -14,6 +14,14 @@ const type = "AWS::RDS::Integration"
 open class IntegrationResolvable extends formae.Resolvable {
     hidden type = module.type
 
+
+    hidden id: IntegrationResolvable = (this) {
+        property = "IntegrationArn"
+    }
+
+    hidden arn: IntegrationResolvable = (this) {
+        property = "IntegrationArn"
+    }
     hidden createTime: IntegrationResolvable = (this) {
         property = "CreateTime"
     }

--- a/schema/pkl/route53/healthcheck.pkl
+++ b/schema/pkl/route53/healthcheck.pkl
@@ -39,7 +39,7 @@ open class HealthCheckConfig extends formae.SubResource {
     failureThreshold: Int?
 
     @aws.FieldHint
-    fullyQualifiedDomainName: String?
+    fullyQualifiedDomainName: (String|formae.Resolvable)?
 
     @aws.FieldHint
     healthThreshold: Int?
@@ -69,7 +69,7 @@ open class HealthCheckConfig extends formae.SubResource {
     resourcePath: String?
 
     @aws.FieldHint
-    routingControlArn: String?
+    routingControlArn: (String|formae.Resolvable)?
 
     @aws.FieldHint
     searchString: String?

--- a/schema/pkl/route53/hostedzone.pkl
+++ b/schema/pkl/route53/hostedzone.pkl
@@ -18,7 +18,7 @@ open class HostedZoneConfig  extends formae.SubResource{
 
 @aws.SubResourceHint
 open class QueryLoggingConfig  extends formae.SubResource {
-    cloudWatchLogsLogGroupArn: String
+    cloudWatchLogsLogGroupArn: String|formae.Resolvable
 }
 
 @aws.SubResourceHint
@@ -26,7 +26,7 @@ open class VPC extends formae.SubResource {
     @aws.FieldHint {
         outputField = "VPCId"
     }
-    vpcId: String
+    vpcId: String|formae.Resolvable
 
     @aws.FieldHint {
         outputField = "VPCRegion"

--- a/schema/pkl/route53/keysigningkey.pkl
+++ b/schema/pkl/route53/keysigningkey.pkl
@@ -23,7 +23,7 @@ open class KeySigningKey extends formae.Resource {
     hostedZoneId: String(matches(Regex(#"^[A-Z0-9]{1,32}$"#)))|formae.Resolvable
 
     @aws.FieldHint{createOnly = true}
-    keyManagementServiceArn: String
+    keyManagementServiceArn: String|formae.Resolvable
 
     @aws.FieldHint{createOnly = true}
     name: String(matches(Regex(#"^[a-zA-Z0-9_]{3,128}$"#)))

--- a/schema/pkl/route53/recordset.pkl
+++ b/schema/pkl/route53/recordset.pkl
@@ -81,7 +81,7 @@ open class RecordSet extends formae.Resource {
     geoProximityLocation: (GeoProximityLocation)?
 
     @aws.FieldHint
-    healthCheckId: String?
+    healthCheckId: (String|formae.Resolvable)?
 
     @aws.FieldHint {
         createOnly = true
@@ -91,7 +91,7 @@ open class RecordSet extends formae.Resource {
     @aws.FieldHint {
         createOnly = true
     }
-    hostedZoneName: String?
+    hostedZoneName: (String|formae.Resolvable)?
 
     @aws.FieldHint
     multiValueAnswer: Boolean?

--- a/schema/pkl/route53/recordsetgroup.pkl
+++ b/schema/pkl/route53/recordsetgroup.pkl
@@ -16,14 +16,14 @@ open class AliasTarget extends formae.SubResource {
     @aws.FieldHint {
         outputField = "DNSName"
     }
-    dnsName: String
+    dnsName: String|formae.Resolvable
     evaluateTargetHealth: Boolean?
-    hostedZoneId: String
+    hostedZoneId: String|formae.Resolvable
 }
 
 @aws.SubResourceHint
 open class CidrRoutingConfig extends formae.SubResource {
-    collectionId: String
+    collectionId: String|formae.Resolvable
     locationName: String
 }
 
@@ -59,9 +59,9 @@ open class RecordSet extends formae.SubResource {
     failover: String?
     geoLocation: GeoLocation?
     geoProximityLocation: GeoProximityLocation?
-    healthCheckId: String?
-    hostedZoneId: String?
-    hostedZoneName: String?
+    healthCheckId: (String|formae.Resolvable)?
+    hostedZoneId: (String|formae.Resolvable)?
+    hostedZoneName: (String|formae.Resolvable)?
     multiValueAnswer: Boolean?
     name: String
     region: aws.Region?
@@ -86,7 +86,7 @@ open class RecordSetGroup extends formae.Resource {
     hostedZoneId: (String|formae.Resolvable)?
 
     @aws.FieldHint{createOnly = true}
-    hostedZoneName: String?
+    hostedZoneName: (String|formae.Resolvable)?
 
     @aws.FieldHint
     recordSets: (Listing<RecordSet>)?

--- a/schema/pkl/s3/accessgrant.pkl
+++ b/schema/pkl/s3/accessgrant.pkl
@@ -22,7 +22,7 @@ open class AccessGrantsLocationConfiguration extends formae.SubResource{
 
 @aws.SubResourceHint
 open class AccessGrantGrantee extends formae.SubResource {
-    granteeIdentifier: String
+    granteeIdentifier: String|formae.Resolvable
     granteeType: GranteeGranteeType
 }
 
@@ -37,7 +37,7 @@ open class AccessGrant extends formae.Resource {
     accessGrantsLocationConfiguration: AccessGrantsLocationConfiguration?
 
     @aws.FieldHint
-    accessGrantsLocationId: String
+    accessGrantsLocationId: String|formae.Resolvable
 
     @aws.FieldHint
     applicationArn: (String|formae.Resolvable)?

--- a/schema/pkl/s3/bucket.pkl
+++ b/schema/pkl/s3/bucket.pkl
@@ -98,7 +98,7 @@ typealias DestinationFormat = "CSV"|"ORC"|"Parquet"
 
 @aws.SubResourceHint
 open class Destination extends formae.SubResource {
-    bucketAccountId: String?
+    bucketAccountId: (String|formae.Resolvable)?
 
     bucketArn: String|formae.Resolvable
 
@@ -185,7 +185,7 @@ open class LifecycleConfiguration extends formae.SubResource {
 
 @aws.SubResourceHint
 open class LoggingConfiguration extends formae.SubResource {
-    destinationBucketName: String?
+    destinationBucketName: (String|formae.Resolvable)?
 
     logFilePrefix: String?
 
@@ -203,7 +203,7 @@ open class Metrics extends formae.SubResource {
 
 @aws.SubResourceHint
 open class MetricsConfiguration extends formae.SubResource {
-    accessPointArn: String?
+    accessPointArn: (String|formae.Resolvable)?
 
     id: String
 

--- a/schema/pkl/s3/storagelens.pkl
+++ b/schema/pkl/s3/storagelens.pkl
@@ -89,7 +89,7 @@ typealias S3BucketDestinationOutputSchemaVersion = "V_1"
 
 @aws.SubResourceHint
 open class S3BucketDestination extends formae.SubResource {
-    accountId: String
+    accountId: String|formae.Resolvable
     arn: String
     encryption: Dynamic?
     format: S3BucketDestinationFormat
@@ -99,7 +99,7 @@ open class S3BucketDestination extends formae.SubResource {
 
 @aws.SubResourceHint
 open class StorageLensSSEKMS extends formae.SubResource {
-    keyId: String
+    keyId: String|formae.Resolvable
 }
 
 @aws.SubResourceHint

--- a/schema/pkl/sagemaker/domain.pkl
+++ b/schema/pkl/sagemaker/domain.pkl
@@ -207,6 +207,14 @@ open class DefaultUserSettings extends formae.SubResource {
 open class DomainResolvable extends formae.Resolvable {
     hidden type = module.type
 
+
+    hidden id: DomainResolvable = (this) {
+        property = "DomainArn"
+    }
+
+    hidden arn: DomainResolvable = (this) {
+        property = "DomainArn"
+    }
     hidden domainArn: DomainResolvable = (this) {
         property = "DomainArn"
     }

--- a/schema/pkl/sagemaker/endpoint.pkl
+++ b/schema/pkl/sagemaker/endpoint.pkl
@@ -70,6 +70,18 @@ open class VariantProperty extends formae.SubResource {
 open class EndpointResolvable extends formae.Resolvable {
     hidden type = module.type
 
+
+    hidden id: EndpointResolvable = (this) {
+        property = "EndpointArn"
+    }
+
+    hidden arn: EndpointResolvable = (this) {
+        property = "EndpointArn"
+    }
+
+    hidden name: EndpointResolvable = (this) {
+        property = "EndpointName"
+    }
     hidden endpointName: EndpointResolvable = (this) {
         property = "EndpointName"
     }

--- a/schema/pkl/sagemaker/endpoint.pkl
+++ b/schema/pkl/sagemaker/endpoint.pkl
@@ -17,7 +17,7 @@ typealias VariantPropertyType = "DesiredInstanceCount"|"DesiredWeight"
 
 @aws.SubResourceHint
 open class Alarm extends formae.SubResource {
-    alarmName: String
+    alarmName: String|formae.Resolvable
 }
 
 @aws.SubResourceHint

--- a/schema/pkl/sagemaker/modelpackagegroup.pkl
+++ b/schema/pkl/sagemaker/modelpackagegroup.pkl
@@ -15,6 +15,18 @@ const type = "AWS::SageMaker::ModelPackageGroup"
 open class ModelPackageGroupResolvable extends formae.Resolvable {
     hidden type = module.type
 
+
+    hidden id: ModelPackageGroupResolvable = (this) {
+        property = "ModelPackageGroupArn"
+    }
+
+    hidden arn: ModelPackageGroupResolvable = (this) {
+        property = "ModelPackageGroupArn"
+    }
+
+    hidden name: ModelPackageGroupResolvable = (this) {
+        property = "ModelPackageGroupName"
+    }
     hidden modelPackageGroupArn: ModelPackageGroupResolvable = (this) {
         property = "ModelPackageGroupArn"
     }

--- a/schema/pkl/sagemaker/userprofile.pkl
+++ b/schema/pkl/sagemaker/userprofile.pkl
@@ -158,6 +158,18 @@ open class UserSettings extends formae.SubResource {
 open class UserProfileResolvable extends formae.Resolvable {
     hidden type = module.type
 
+
+    hidden id: UserProfileResolvable = (this) {
+        property = "UserProfileArn"
+    }
+
+    hidden arn: UserProfileResolvable = (this) {
+        property = "UserProfileArn"
+    }
+
+    hidden name: UserProfileResolvable = (this) {
+        property = "UserProfileName"
+    }
     hidden userProfileArn: UserProfileResolvable = (this) {
         property = "UserProfileArn"
     }

--- a/schema/pkl/secretsmanager/rotationschedule.pkl
+++ b/schema/pkl/secretsmanager/rotationschedule.pkl
@@ -15,9 +15,9 @@ const type = "AWS::SecretsManager::RotationSchedule"
 open class HostedRotationLambda extends formae.SubResource {
     excludeCharacters: String?
     kmsKeyArn: (String|formae.Resolvable)?
-    masterSecretArn: String?
+    masterSecretArn: (String|formae.Resolvable)?
     masterSecretKmsKeyArn: (String|formae.Resolvable)?
-    rotationLambdaName: String?
+    rotationLambdaName: (String|formae.Resolvable)?
     rotationType: String
     runtime: String?
     superuserSecretArn: (String|formae.Resolvable)?
@@ -52,5 +52,5 @@ open class RotationSchedule extends formae.Resource {
     rotationRules: RotationRules?
 
     @aws.FieldHint{createOnly = true}
-    secretId: String
+    secretId: String|formae.Resolvable
 }

--- a/schema/pkl/sqs/queue.pkl
+++ b/schema/pkl/sqs/queue.pkl
@@ -63,7 +63,7 @@ open class Queue extends formae.Resource {
     kmsDataKeyReusePeriodSeconds: Duration(isBetween(60.s, 86400.s))?
 
     @aws.FieldHint
-    kmsMasterKeyId: String?
+    kmsMasterKeyId: (String|formae.Resolvable)?
 
     @aws.FieldHint {
         outputTransformation = (it) -> it.toUnit("b").value


### PR DESCRIPTION
## Summary

- Widens ~225 reference-bearing properties (IDs, ARNs, reference-style names) across 77 PKL schema files to accept `String | formae.Resolvable` (or `Listing<String|formae.Resolvable>` for lists), so users can compose resources with `.res.id` / `.res.arn` references without needing per-property schema patches.
- Adds the missing `hidden res: LogGroupResolvable` wiring on `LogGroup` so other resources can reference it.
- Also includes a prior `make serviceRole optional` commit that was already on the branch.

## Scope

Follows the pattern established in `e2ce8d5` (EFSVolumeConfiguration.filesystemId) and `9f4022a` (TaskDefinition hidden res wiring), applied broadly. Largest service buckets: ec2 (~90 edits), rds (~34), cloudfront (~19), route53 (~14), ecs (~11).

## Explicitly skipped (not cross-resource references)

- **Own-identity fields** — e.g. `Application.applicationName`, `Bucket.bucketName`, `Role.roleName`, inline `policyName` on Group/Role/User policies
- **Arbitrary string labels** — device paths (`/dev/sdf`), virtualName, DynamoDB `attributeName`/`indexName`, ECS `containerName`, CloudFront internal `originId`/`targetOriginId`, `sessionCookieName`, `httpHeaderName`
- **Enum-like literals** — `solutionStackName`, `engineName`, `characterSetName`, `featureName`, `optionName`, `addonName`
- **External IdP identifiers** — OIDC `clientId`, SAML `tenantId`, Kafka `consumerGroupId`

Triage rationale in `.planning/resolvable-audit.md` (not committed).

## Known follow-up

`Route.gatewayId` now accepts Resolvable but there's still no explicit schema-level dependency on `VPCGatewayAttachment`, so a Route can still be created before the IGW is attached to the VPC. Deferred — needs a design decision (add an optional `vpcGatewayAttachmentId` field, or split `gatewayId` into gateway-attachment-keyed refs).

## Test plan

- [x] `pkl eval` passes on every schema file (exit 0, 0 errors)
- [x] `make verify-schema` — PASSED (220 modules, 220 resource types, 0 duplicates)
- [ ] Smoke-test provisioning with one of the services that was previously broken (e.g. an ECS stack wiring a security group ID into a service)