### PR TITLE
fix(ecs): TaskSet Update + Service/TaskSet Cluster ARN drift

### DIFF
--- a/pkg/cfres/ecs/service.go
+++ b/pkg/cfres/ecs/service.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
@@ -78,10 +79,12 @@ func (s *Service) readWithClient(ctx context.Context, client ccxReadClient, requ
 	// Derive region + account from ServiceArn (format:
 	// arn:<partition>:ecs:<region>:<account>:service/<cluster>/<service>).
 	// If ServiceArn is missing or malformed we can't safely reconstruct the
-	// ARN — leave the short name in place.
+	// ARN — leave the short name in place and log enough to find it later.
 	serviceArn, _ := props["ServiceArn"].(string)
-	partition, region, account, ok := parseServiceArn(serviceArn)
+	partition, region, account, ok := parseEcsArn(serviceArn)
 	if !ok {
+		slog.Debug("AWS::ECS::Service Read: skipping Cluster ARN re-inflation, ServiceArn unparseable",
+			"cluster", cluster, "serviceArn", serviceArn, "nativeID", request.NativeID)
 		return result, nil
 	}
 	props["Cluster"] = fmt.Sprintf("arn:%s:ecs:%s:%s:cluster/%s", partition, region, account, cluster)
@@ -96,18 +99,16 @@ func (s *Service) readWithClient(ctx context.Context, client ccxReadClient, requ
 	}, nil
 }
 
-// parseServiceArn splits an ECS ServiceArn into its partition, region, and
-// account. Returns ok=false for anything that doesn't look like an ECS
-// service ARN.
-func parseServiceArn(arn string) (partition, region, account string, ok bool) {
+// parseEcsArn splits any ECS ARN (cluster, service, task-set, ...) into its
+// partition, region, and account. Returns ok=false for anything that doesn't
+// look like an ECS ARN — the caller is expected to treat that as "leave the
+// response unchanged" rather than as an error.
+func parseEcsArn(arn string) (partition, region, account string, ok bool) {
 	if !strings.HasPrefix(arn, "arn:") {
 		return "", "", "", false
 	}
 	parts := strings.Split(arn, ":")
-	if len(parts) < 6 {
-		return "", "", "", false
-	}
-	if parts[2] != "ecs" {
+	if len(parts) < 6 || parts[2] != "ecs" {
 		return "", "", "", false
 	}
 	return parts[1], parts[3], parts[4], true

--- a/pkg/cfres/ecs/service.go
+++ b/pkg/cfres/ecs/service.go
@@ -1,0 +1,134 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package ecs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/ccx"
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/cfres/prov"
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/cfres/registry"
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/config"
+)
+
+// Service is a custom provisioner for AWS::ECS::Service. CloudControl accepts
+// either a cluster short name or a full ARN in the Cluster field on Create,
+// but its Read response always returns the bare short name. When the caller
+// set Cluster with an ARN-valued Resolvable (e.g. `cluster = ecsCluster.res.arn`),
+// that mismatch surfaces on every reapply as a phantom createOnly diff on the
+// Cluster field — the planner promotes the Update to a full Replace.
+//
+// This provisioner intercepts Read and re-inflates the bare cluster name back
+// to a full ARN using the region and account parsed from the always-present
+// ServiceArn, so the comparator sees the same shape the user sent on Create.
+// Create/Update/Delete/Status continue through the generic CloudControl path.
+//
+// Bug reference: formae@.claude/handover/spurious-replace-ecs/BUG-2-CLUSTER-ARN-DRIFT.md.
+type Service struct {
+	cfg *config.Config
+}
+
+type ccxReadClient interface {
+	ReadResource(ctx context.Context, request *resource.ReadRequest) (*resource.ReadResult, error)
+}
+
+var _ prov.Provisioner = &Service{}
+
+func init() {
+	registry.Register("AWS::ECS::Service",
+		[]resource.Operation{resource.OperationRead},
+		func(cfg *config.Config) prov.Provisioner {
+			return &Service{cfg: cfg}
+		})
+}
+
+func (s *Service) Read(ctx context.Context, request *resource.ReadRequest) (*resource.ReadResult, error) {
+	client, err := ccx.NewClient(s.cfg)
+	if err != nil {
+		return nil, fmt.Errorf("loading CloudControl client: %w", err)
+	}
+	return s.readWithClient(ctx, client, request)
+}
+
+func (s *Service) readWithClient(ctx context.Context, client ccxReadClient, request *resource.ReadRequest) (*resource.ReadResult, error) {
+	result, err := client.ReadResource(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+	if result == nil || result.ErrorCode != "" || result.Properties == "" {
+		return result, nil
+	}
+
+	var props map[string]any
+	if err := json.Unmarshal([]byte(result.Properties), &props); err != nil {
+		return nil, fmt.Errorf("parsing Service properties: %w", err)
+	}
+
+	cluster, _ := props["Cluster"].(string)
+	if cluster == "" || strings.HasPrefix(cluster, "arn:") {
+		return result, nil
+	}
+
+	// Derive region + account from ServiceArn (format:
+	// arn:<partition>:ecs:<region>:<account>:service/<cluster>/<service>).
+	// If ServiceArn is missing or malformed we can't safely reconstruct the
+	// ARN — leave the short name in place.
+	serviceArn, _ := props["ServiceArn"].(string)
+	partition, region, account, ok := parseServiceArn(serviceArn)
+	if !ok {
+		return result, nil
+	}
+	props["Cluster"] = fmt.Sprintf("arn:%s:ecs:%s:%s:cluster/%s", partition, region, account, cluster)
+
+	out, err := json.Marshal(props)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling re-inflated Service properties: %w", err)
+	}
+	return &resource.ReadResult{
+		ResourceType: result.ResourceType,
+		Properties:   string(out),
+	}, nil
+}
+
+// parseServiceArn splits an ECS ServiceArn into its partition, region, and
+// account. Returns ok=false for anything that doesn't look like an ECS
+// service ARN.
+func parseServiceArn(arn string) (partition, region, account string, ok bool) {
+	if !strings.HasPrefix(arn, "arn:") {
+		return "", "", "", false
+	}
+	parts := strings.Split(arn, ":")
+	if len(parts) < 6 {
+		return "", "", "", false
+	}
+	if parts[2] != "ecs" {
+		return "", "", "", false
+	}
+	return parts[1], parts[3], parts[4], true
+}
+
+func (s *Service) Create(_ context.Context, _ *resource.CreateRequest) (*resource.CreateResult, error) {
+	return nil, fmt.Errorf("AWS::ECS::Service custom provisioner only implements Read")
+}
+
+func (s *Service) Update(_ context.Context, _ *resource.UpdateRequest) (*resource.UpdateResult, error) {
+	return nil, fmt.Errorf("AWS::ECS::Service custom provisioner only implements Read")
+}
+
+func (s *Service) Delete(_ context.Context, _ *resource.DeleteRequest) (*resource.DeleteResult, error) {
+	return nil, fmt.Errorf("AWS::ECS::Service custom provisioner only implements Read")
+}
+
+func (s *Service) Status(_ context.Context, _ *resource.StatusRequest) (*resource.StatusResult, error) {
+	return nil, fmt.Errorf("AWS::ECS::Service custom provisioner only implements Read")
+}
+
+func (s *Service) List(_ context.Context, _ *resource.ListRequest) (*resource.ListResult, error) {
+	return nil, fmt.Errorf("AWS::ECS::Service custom provisioner only implements Read")
+}

--- a/pkg/cfres/ecs/service_mock_test.go
+++ b/pkg/cfres/ecs/service_mock_test.go
@@ -1,0 +1,25 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package ecs
+
+import (
+	"context"
+
+	"github.com/stretchr/testify/mock"
+
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+)
+
+type mockCCXReadClient struct {
+	mock.Mock
+}
+
+func (m *mockCCXReadClient) ReadResource(ctx context.Context, request *resource.ReadRequest) (*resource.ReadResult, error) {
+	args := m.Called(ctx, request)
+	out, _ := args.Get(0).(*resource.ReadResult)
+	return out, args.Error(1)
+}

--- a/pkg/cfres/ecs/service_test.go
+++ b/pkg/cfres/ecs/service_test.go
@@ -1,0 +1,132 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package ecs
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/config"
+)
+
+func TestService_Read_ReinflatesBareClusterNameToArn(t *testing.T) {
+	ctx := context.Background()
+	client := &mockCCXReadClient{}
+
+	// CC's Read normalizes Cluster to the bare name even when the caller
+	// created with the full ARN. ServiceArn is always the full ARN.
+	innerResult := &resource.ReadResult{
+		ResourceType: "AWS::ECS::Service",
+		Properties: `{
+			"ServiceName": "my-svc",
+			"Cluster": "my-cluster",
+			"ServiceArn": "arn:aws:ecs:us-east-1:226695765433:service/my-cluster/my-svc"
+		}`,
+	}
+	client.On("ReadResource", ctx, mock.Anything).Return(innerResult, nil)
+
+	svc := &Service{cfg: &config.Config{}}
+	out, err := svc.readWithClient(ctx, client, &resource.ReadRequest{
+		ResourceType: "AWS::ECS::Service",
+		NativeID:     "my-cluster|my-svc",
+	})
+
+	assert.NoError(t, err)
+	var props map[string]any
+	assert.NoError(t, json.Unmarshal([]byte(out.Properties), &props))
+	assert.Equal(t, "arn:aws:ecs:us-east-1:226695765433:cluster/my-cluster", props["Cluster"],
+		"Cluster must be re-inflated from bare name to full ARN to match what the caller sent on Create")
+	assert.Equal(t, "my-svc", props["ServiceName"])
+}
+
+func TestService_Read_LeavesClusterAloneWhenAlreadyArn(t *testing.T) {
+	ctx := context.Background()
+	client := &mockCCXReadClient{}
+	arn := "arn:aws:ecs:us-east-1:226695765433:cluster/my-cluster"
+	innerResult := &resource.ReadResult{
+		ResourceType: "AWS::ECS::Service",
+		Properties: `{
+			"Cluster": "` + arn + `",
+			"ServiceArn": "arn:aws:ecs:us-east-1:226695765433:service/my-cluster/my-svc"
+		}`,
+	}
+	client.On("ReadResource", ctx, mock.Anything).Return(innerResult, nil)
+
+	svc := &Service{cfg: &config.Config{}}
+	out, err := svc.readWithClient(ctx, client, &resource.ReadRequest{
+		ResourceType: "AWS::ECS::Service",
+		NativeID:     "my-cluster|my-svc",
+	})
+
+	assert.NoError(t, err)
+	var props map[string]any
+	assert.NoError(t, json.Unmarshal([]byte(out.Properties), &props))
+	assert.Equal(t, arn, props["Cluster"])
+}
+
+func TestService_Read_PassesThroughWhenServiceArnMissing(t *testing.T) {
+	// Without a ServiceArn we can't infer region/account, so we have no
+	// choice but to leave the bare name in place. Better to let the
+	// planner see the drift than guess wrong.
+	ctx := context.Background()
+	client := &mockCCXReadClient{}
+	innerResult := &resource.ReadResult{
+		ResourceType: "AWS::ECS::Service",
+		Properties:   `{"Cluster": "my-cluster"}`,
+	}
+	client.On("ReadResource", ctx, mock.Anything).Return(innerResult, nil)
+
+	svc := &Service{cfg: &config.Config{}}
+	out, err := svc.readWithClient(ctx, client, &resource.ReadRequest{
+		ResourceType: "AWS::ECS::Service",
+		NativeID:     "my-cluster|my-svc",
+	})
+
+	assert.NoError(t, err)
+	var props map[string]any
+	assert.NoError(t, json.Unmarshal([]byte(out.Properties), &props))
+	assert.Equal(t, "my-cluster", props["Cluster"])
+}
+
+func TestService_Read_PropagatesErrorResult(t *testing.T) {
+	ctx := context.Background()
+	client := &mockCCXReadClient{}
+	innerResult := &resource.ReadResult{
+		ResourceType: "AWS::ECS::Service",
+		ErrorCode:    resource.OperationErrorCodeNotFound,
+	}
+	client.On("ReadResource", ctx, mock.Anything).Return(innerResult, nil)
+
+	svc := &Service{cfg: &config.Config{}}
+	out, err := svc.readWithClient(ctx, client, &resource.ReadRequest{
+		ResourceType: "AWS::ECS::Service",
+		NativeID:     "missing",
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, resource.OperationErrorCodeNotFound, out.ErrorCode)
+}
+
+func TestService_Read_PropagatesInnerError(t *testing.T) {
+	ctx := context.Background()
+	client := &mockCCXReadClient{}
+	client.On("ReadResource", ctx, mock.Anything).Return((*resource.ReadResult)(nil), errors.New("throttled"))
+
+	svc := &Service{cfg: &config.Config{}}
+	_, err := svc.readWithClient(ctx, client, &resource.ReadRequest{
+		ResourceType: "AWS::ECS::Service",
+		NativeID:     "my-cluster|my-svc",
+	})
+
+	assert.Error(t, err)
+}

--- a/pkg/cfres/ecs/taskset.go
+++ b/pkg/cfres/ecs/taskset.go
@@ -16,6 +16,7 @@ import (
 	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 
 	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/ccx"
 	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/cfres/prov"
 	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/cfres/registry"
 	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/config"
@@ -46,7 +47,7 @@ var _ prov.Provisioner = &TaskSet{}
 
 func init() {
 	registry.Register("AWS::ECS::TaskSet",
-		[]resource.Operation{resource.OperationList, resource.OperationUpdate},
+		[]resource.Operation{resource.OperationList, resource.OperationRead, resource.OperationUpdate},
 		func(cfg *config.Config) prov.Provisioner {
 			return &TaskSet{cfg: cfg}
 		})
@@ -116,16 +117,93 @@ func (t *TaskSet) listWithClient(ctx context.Context, client ecsTaskSetClientInt
 	return &resource.ListResult{NativeIDs: nativeIDs}, nil
 }
 
-// The remaining Provisioner methods are not implemented because this provisioner
-// is only registered for OperationList. The registry routes other operations to
-// the default CloudControl path.
+// Create/Delete/Status are not implemented here; the registry routes those
+// operations to the default CloudControl path. List, Read, and Update are
+// registered above and handled below.
 
 func (t *TaskSet) Create(_ context.Context, _ *resource.CreateRequest) (*resource.CreateResult, error) {
-	return nil, fmt.Errorf("AWS::ECS::TaskSet custom provisioner only implements List")
+	return nil, fmt.Errorf("AWS::ECS::TaskSet custom provisioner only implements List, Read, and Update")
 }
 
-func (t *TaskSet) Read(_ context.Context, _ *resource.ReadRequest) (*resource.ReadResult, error) {
-	return nil, fmt.Errorf("AWS::ECS::TaskSet custom provisioner only implements List")
+func (t *TaskSet) Read(ctx context.Context, request *resource.ReadRequest) (*resource.ReadResult, error) {
+	client, err := ccx.NewClient(t.cfg)
+	if err != nil {
+		return nil, fmt.Errorf("loading CloudControl client: %w", err)
+	}
+	return t.readWithClient(ctx, client, request)
+}
+
+// readWithClient delegates to CloudControl and re-inflates the bare Cluster
+// and Service names in the response back to full ARNs. See Service.Read for
+// the full rationale; the TaskSet variant pulls region/account from the
+// composite NativeID's cluster-ARN segment (parts[0]) rather than from a
+// response field, since CC's TaskSet Read doesn't reliably return the
+// cluster ARN.
+func (t *TaskSet) readWithClient(ctx context.Context, client ccxReadClient, request *resource.ReadRequest) (*resource.ReadResult, error) {
+	result, err := client.ReadResource(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+	if result == nil || result.ErrorCode != "" || result.Properties == "" {
+		return result, nil
+	}
+
+	parts := strings.Split(request.NativeID, "|")
+	if len(parts) != 3 {
+		return result, nil
+	}
+	partition, region, account, ok := parseClusterArn(parts[0])
+	if !ok {
+		return result, nil
+	}
+
+	var props map[string]any
+	if err := json.Unmarshal([]byte(result.Properties), &props); err != nil {
+		return nil, fmt.Errorf("parsing TaskSet properties: %w", err)
+	}
+
+	changed := false
+	if cluster, _ := props["Cluster"].(string); cluster != "" && !strings.HasPrefix(cluster, "arn:") {
+		props["Cluster"] = fmt.Sprintf("arn:%s:ecs:%s:%s:cluster/%s", partition, region, account, cluster)
+		changed = true
+	}
+	if service, _ := props["Service"].(string); service != "" && !strings.HasPrefix(service, "arn:") {
+		// Service ARN embeds the cluster short name, which we can take from
+		// the now-normalized Cluster or from the NativeID's parts[0] cluster
+		// segment.
+		clusterName := lastArnSegment(parts[0])
+		props["Service"] = fmt.Sprintf("arn:%s:ecs:%s:%s:service/%s/%s", partition, region, account, clusterName, service)
+		changed = true
+	}
+	if !changed {
+		return result, nil
+	}
+
+	out, err := json.Marshal(props)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling re-inflated TaskSet properties: %w", err)
+	}
+	return &resource.ReadResult{
+		ResourceType: result.ResourceType,
+		Properties:   string(out),
+	}, nil
+}
+
+// parseClusterArn splits an ECS ClusterArn into its partition, region, and
+// account. Returns ok=false for anything that doesn't look like an ECS
+// cluster ARN.
+func parseClusterArn(arn string) (partition, region, account string, ok bool) {
+	if !strings.HasPrefix(arn, "arn:") {
+		return "", "", "", false
+	}
+	parts := strings.Split(arn, ":")
+	if len(parts) < 6 {
+		return "", "", "", false
+	}
+	if parts[2] != "ecs" {
+		return "", "", "", false
+	}
+	return parts[1], parts[3], parts[4], true
 }
 
 func (t *TaskSet) Update(ctx context.Context, request *resource.UpdateRequest) (*resource.UpdateResult, error) {

--- a/pkg/cfres/ecs/taskset.go
+++ b/pkg/cfres/ecs/taskset.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -150,10 +151,14 @@ func (t *TaskSet) readWithClient(ctx context.Context, client ccxReadClient, requ
 
 	parts := strings.Split(request.NativeID, "|")
 	if len(parts) != 3 {
+		slog.Debug("AWS::ECS::TaskSet Read: skipping ARN re-inflation, NativeID not composite",
+			"nativeID", request.NativeID)
 		return result, nil
 	}
-	partition, region, account, ok := parseClusterArn(parts[0])
+	partition, region, account, ok := parseEcsArn(parts[0])
 	if !ok {
+		slog.Debug("AWS::ECS::TaskSet Read: skipping ARN re-inflation, NativeID parts[0] not an ECS ARN",
+			"nativeIDPart0", parts[0], "nativeID", request.NativeID)
 		return result, nil
 	}
 
@@ -187,23 +192,6 @@ func (t *TaskSet) readWithClient(ctx context.Context, client ccxReadClient, requ
 		ResourceType: result.ResourceType,
 		Properties:   string(out),
 	}, nil
-}
-
-// parseClusterArn splits an ECS ClusterArn into its partition, region, and
-// account. Returns ok=false for anything that doesn't look like an ECS
-// cluster ARN.
-func parseClusterArn(arn string) (partition, region, account string, ok bool) {
-	if !strings.HasPrefix(arn, "arn:") {
-		return "", "", "", false
-	}
-	parts := strings.Split(arn, ":")
-	if len(parts) < 6 {
-		return "", "", "", false
-	}
-	if parts[2] != "ecs" {
-		return "", "", "", false
-	}
-	return parts[1], parts[3], parts[4], true
 }
 
 func (t *TaskSet) Update(ctx context.Context, request *resource.UpdateRequest) (*resource.UpdateResult, error) {

--- a/pkg/cfres/ecs/taskset.go
+++ b/pkg/cfres/ecs/taskset.go
@@ -6,6 +6,7 @@ package ecs
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -20,28 +21,32 @@ import (
 	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/config"
 )
 
-// TaskSet is a custom List-only provisioner for AWS::ECS::TaskSet. CloudControl's
-// generic list handler for this type rejects requests that only pass
-// Cluster+Service with "Required property: [Cluster, Service, Id]", effectively
-// requiring a specific TaskSet id and making it unusable for true discovery.
-// This provisioner uses the ECS SDK's DescribeTaskSets (Cluster + Service only)
-// to enumerate TaskSets per parent service.
+// TaskSet is a custom provisioner for AWS::ECS::TaskSet. CloudControl is broken
+// for two operations on this resource type and we route both through the ECS
+// SDK directly:
 //
-// Create/Read/Update/Delete/Status fall back to the default CloudControl path
-// because this provisioner is only registered for OperationList.
+//   - List: CloudControl's generic list handler rejects Cluster+Service-only
+//     requests with "Required property: [Cluster, Service, Id]", making it
+//     unusable for discovery. We enumerate TaskSets via DescribeServices.
+//   - Update: CloudControl's update handler hangs indefinitely when patching
+//     Scale (the only mutable field per AWS's UpdateTaskSet API), timing out
+//     the test harness. We call UpdateTaskSet directly.
+//
+// Create/Read/Delete/Status fall back to the default CloudControl path.
 type TaskSet struct {
 	cfg *config.Config
 }
 
 type ecsTaskSetClientInterface interface {
 	DescribeServices(ctx context.Context, params *ecs.DescribeServicesInput, optFns ...func(*ecs.Options)) (*ecs.DescribeServicesOutput, error)
+	UpdateTaskSet(ctx context.Context, params *ecs.UpdateTaskSetInput, optFns ...func(*ecs.Options)) (*ecs.UpdateTaskSetOutput, error)
 }
 
 var _ prov.Provisioner = &TaskSet{}
 
 func init() {
 	registry.Register("AWS::ECS::TaskSet",
-		[]resource.Operation{resource.OperationList},
+		[]resource.Operation{resource.OperationList, resource.OperationUpdate},
 		func(cfg *config.Config) prov.Provisioner {
 			return &TaskSet{cfg: cfg}
 		})
@@ -123,8 +128,69 @@ func (t *TaskSet) Read(_ context.Context, _ *resource.ReadRequest) (*resource.Re
 	return nil, fmt.Errorf("AWS::ECS::TaskSet custom provisioner only implements List")
 }
 
-func (t *TaskSet) Update(_ context.Context, _ *resource.UpdateRequest) (*resource.UpdateResult, error) {
-	return nil, fmt.Errorf("AWS::ECS::TaskSet custom provisioner only implements List")
+func (t *TaskSet) Update(ctx context.Context, request *resource.UpdateRequest) (*resource.UpdateResult, error) {
+	awsCfg, err := t.cfg.ToAwsConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("loading AWS config: %w", err)
+	}
+	return t.updateWithClient(ctx, ecs.NewFromConfig(awsCfg), request)
+}
+
+func (t *TaskSet) updateWithClient(ctx context.Context, client ecsTaskSetClientInterface, request *resource.UpdateRequest) (*resource.UpdateResult, error) {
+	// NativeID is the composite <ClusterArn>|<ServiceName>|<Id> produced by
+	// CloudControl on create and normalized by ccx.normalizeCompositeIdentifier.
+	parts := strings.Split(request.NativeID, "|")
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("AWS::ECS::TaskSet NativeID must be composite Cluster|Service|Id, got %q", request.NativeID)
+	}
+	cluster, service, taskSetID := parts[0], parts[1], parts[2]
+
+	scale, err := extractScale(request.DesiredProperties)
+	if err != nil {
+		return nil, err
+	}
+
+	output, err := client.UpdateTaskSet(ctx, &ecs.UpdateTaskSetInput{
+		Cluster: aws.String(cluster),
+		Service: aws.String(service),
+		TaskSet: aws.String(taskSetID),
+		Scale:   scale,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("updating task set: %w", err)
+	}
+
+	// Merge the updated Scale into the caller's desired properties so
+	// downstream idempotency checks see the new state. Other fields on the
+	// TaskSet are createOnly and can't change through Update.
+	var props map[string]any
+	if len(request.DesiredProperties) > 0 {
+		if err := json.Unmarshal(request.DesiredProperties, &props); err != nil {
+			return nil, fmt.Errorf("parsing desired properties: %w", err)
+		}
+	}
+	if props == nil {
+		props = map[string]any{}
+	}
+	if output.TaskSet != nil && output.TaskSet.Scale != nil {
+		props["Scale"] = map[string]any{
+			"Unit":  string(output.TaskSet.Scale.Unit),
+			"Value": output.TaskSet.Scale.Value,
+		}
+	}
+	resultJSON, err := json.Marshal(props)
+	if err != nil {
+		return nil, fmt.Errorf("marshalling result properties: %w", err)
+	}
+
+	return &resource.UpdateResult{
+		ProgressResult: &resource.ProgressResult{
+			Operation:          resource.OperationUpdate,
+			OperationStatus:    resource.OperationStatusSuccess,
+			NativeID:           request.NativeID,
+			ResourceProperties: resultJSON,
+		},
+	}, nil
 }
 
 func (t *TaskSet) Delete(_ context.Context, _ *resource.DeleteRequest) (*resource.DeleteResult, error) {
@@ -133,6 +199,32 @@ func (t *TaskSet) Delete(_ context.Context, _ *resource.DeleteRequest) (*resourc
 
 func (t *TaskSet) Status(_ context.Context, _ *resource.StatusRequest) (*resource.StatusResult, error) {
 	return nil, fmt.Errorf("AWS::ECS::TaskSet custom provisioner only implements List")
+}
+
+// extractScale pulls the Scale sub-resource out of a TaskSet's desired
+// properties and converts it to the ECS SDK's Scale type. Returns an error
+// if Scale is absent — the ECS UpdateTaskSet API requires it and calling
+// without it is a usage error, not a valid empty update.
+func extractScale(desired json.RawMessage) (*ecstypes.Scale, error) {
+	if len(desired) == 0 {
+		return nil, fmt.Errorf("AWS::ECS::TaskSet update requires DesiredProperties with Scale")
+	}
+	var props struct {
+		Scale *struct {
+			Unit  string  `json:"Unit"`
+			Value float64 `json:"Value"`
+		} `json:"Scale"`
+	}
+	if err := json.Unmarshal(desired, &props); err != nil {
+		return nil, fmt.Errorf("parsing desired properties: %w", err)
+	}
+	if props.Scale == nil {
+		return nil, fmt.Errorf("AWS::ECS::TaskSet update requires Scale in desired properties")
+	}
+	return &ecstypes.Scale{
+		Unit:  ecstypes.ScaleUnit(props.Scale.Unit),
+		Value: props.Scale.Value,
+	}, nil
 }
 
 // lastArnSegment returns the segment after the final "/" in an ARN, matching

--- a/pkg/cfres/ecs/taskset_mock_test.go
+++ b/pkg/cfres/ecs/taskset_mock_test.go
@@ -22,3 +22,9 @@ func (m *mockECSTaskSetClient) DescribeServices(ctx context.Context, input *ecs.
 	out, _ := args.Get(0).(*ecs.DescribeServicesOutput)
 	return out, args.Error(1)
 }
+
+func (m *mockECSTaskSetClient) UpdateTaskSet(ctx context.Context, input *ecs.UpdateTaskSetInput, optFns ...func(*ecs.Options)) (*ecs.UpdateTaskSetOutput, error) {
+	args := m.Called(ctx, input)
+	out, _ := args.Get(0).(*ecs.UpdateTaskSetOutput)
+	return out, args.Error(1)
+}

--- a/pkg/cfres/ecs/taskset_test.go
+++ b/pkg/cfres/ecs/taskset_test.go
@@ -294,3 +294,127 @@ func TestTaskSet_List_PropagatesOtherErrors(t *testing.T) {
 
 	assert.Error(t, err)
 }
+
+func TestTaskSet_Read_ReinflatesBareClusterAndServiceToArns(t *testing.T) {
+	// CC Read on TaskSet normalizes Cluster and Service to their bare
+	// names even when the caller created with ARNs. Both are createOnly,
+	// so the drift surfaces as phantom Replace on every reapply unless we
+	// normalize Read to match the caller's ARN shape. Composite NativeID
+	// supplies the cluster ARN (parts[0]) which we use to derive region
+	// and account.
+	ctx := context.Background()
+	client := &mockCCXReadClient{}
+
+	clusterArn := "arn:aws:ecs:us-east-1:226695765433:cluster/my-cluster"
+	serviceArn := "arn:aws:ecs:us-east-1:226695765433:service/my-cluster/my-svc"
+	nativeID := clusterArn + "|my-svc|ecs-svc/111"
+
+	innerResult := &resource.ReadResult{
+		ResourceType: "AWS::ECS::TaskSet",
+		Properties: `{
+			"Cluster": "my-cluster",
+			"Service": "my-svc",
+			"Id": "ecs-svc/111"
+		}`,
+	}
+	client.On("ReadResource", ctx, mock.Anything).Return(innerResult, nil)
+
+	ts := &TaskSet{cfg: &config.Config{}}
+	out, err := ts.readWithClient(ctx, client, &resource.ReadRequest{
+		ResourceType: "AWS::ECS::TaskSet",
+		NativeID:     nativeID,
+	})
+
+	assert.NoError(t, err)
+	var props map[string]any
+	assert.NoError(t, json.Unmarshal([]byte(out.Properties), &props))
+	assert.Equal(t, clusterArn, props["Cluster"], "Cluster must be re-inflated to full ARN")
+	assert.Equal(t, serviceArn, props["Service"], "Service must be re-inflated to full ARN")
+	assert.Equal(t, "ecs-svc/111", props["Id"])
+}
+
+func TestTaskSet_Read_LeavesValuesAloneWhenAlreadyArns(t *testing.T) {
+	ctx := context.Background()
+	client := &mockCCXReadClient{}
+
+	clusterArn := "arn:aws:ecs:us-east-1:226695765433:cluster/my-cluster"
+	serviceArn := "arn:aws:ecs:us-east-1:226695765433:service/my-cluster/my-svc"
+	innerResult := &resource.ReadResult{
+		ResourceType: "AWS::ECS::TaskSet",
+		Properties: `{
+			"Cluster": "` + clusterArn + `",
+			"Service": "` + serviceArn + `"
+		}`,
+	}
+	client.On("ReadResource", ctx, mock.Anything).Return(innerResult, nil)
+
+	ts := &TaskSet{cfg: &config.Config{}}
+	out, err := ts.readWithClient(ctx, client, &resource.ReadRequest{
+		ResourceType: "AWS::ECS::TaskSet",
+		NativeID:     clusterArn + "|my-svc|ecs-svc/111",
+	})
+
+	assert.NoError(t, err)
+	var props map[string]any
+	assert.NoError(t, json.Unmarshal([]byte(out.Properties), &props))
+	assert.Equal(t, clusterArn, props["Cluster"])
+	assert.Equal(t, serviceArn, props["Service"])
+}
+
+func TestTaskSet_Read_PassesThroughWhenNativeIDPart0NotArn(t *testing.T) {
+	// If we can't infer region/account from NativeID we have nothing safe
+	// to work with — leave the short names in place.
+	ctx := context.Background()
+	client := &mockCCXReadClient{}
+
+	innerResult := &resource.ReadResult{
+		ResourceType: "AWS::ECS::TaskSet",
+		Properties:   `{"Cluster": "my-cluster", "Service": "my-svc"}`,
+	}
+	client.On("ReadResource", ctx, mock.Anything).Return(innerResult, nil)
+
+	ts := &TaskSet{cfg: &config.Config{}}
+	out, err := ts.readWithClient(ctx, client, &resource.ReadRequest{
+		ResourceType: "AWS::ECS::TaskSet",
+		NativeID:     "my-cluster|my-svc|ecs-svc/111",
+	})
+
+	assert.NoError(t, err)
+	var props map[string]any
+	assert.NoError(t, json.Unmarshal([]byte(out.Properties), &props))
+	assert.Equal(t, "my-cluster", props["Cluster"])
+	assert.Equal(t, "my-svc", props["Service"])
+}
+
+func TestTaskSet_Read_PropagatesErrorResult(t *testing.T) {
+	ctx := context.Background()
+	client := &mockCCXReadClient{}
+	innerResult := &resource.ReadResult{
+		ResourceType: "AWS::ECS::TaskSet",
+		ErrorCode:    resource.OperationErrorCodeNotFound,
+	}
+	client.On("ReadResource", ctx, mock.Anything).Return(innerResult, nil)
+
+	ts := &TaskSet{cfg: &config.Config{}}
+	out, err := ts.readWithClient(ctx, client, &resource.ReadRequest{
+		ResourceType: "AWS::ECS::TaskSet",
+		NativeID:     "missing|missing|missing",
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, resource.OperationErrorCodeNotFound, out.ErrorCode)
+}
+
+func TestTaskSet_Read_PropagatesInnerError(t *testing.T) {
+	ctx := context.Background()
+	client := &mockCCXReadClient{}
+	client.On("ReadResource", ctx, mock.Anything).Return((*resource.ReadResult)(nil), errors.New("throttled"))
+
+	ts := &TaskSet{cfg: &config.Config{}}
+	_, err := ts.readWithClient(ctx, client, &resource.ReadRequest{
+		ResourceType: "AWS::ECS::TaskSet",
+		NativeID:     "arn:aws:ecs:us-east-1:123:cluster/c|s|ecs-svc/1",
+	})
+
+	assert.Error(t, err)
+}

--- a/pkg/cfres/ecs/taskset_test.go
+++ b/pkg/cfres/ecs/taskset_test.go
@@ -8,6 +8,7 @@ package ecs
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -171,6 +172,107 @@ func TestTaskSet_List_ReturnsEmptyOnClusterNotFound(t *testing.T) {
 
 	assert.NoError(t, err, "missing parent cluster should not fail discovery")
 	assert.Empty(t, result.NativeIDs)
+}
+
+func TestTaskSet_Update_CallsUpdateTaskSetWithParsedNativeIDAndScale(t *testing.T) {
+	ctx := context.Background()
+	client := &mockECSTaskSetClient{}
+
+	clusterArn := "arn:aws:ecs:us-east-1:123:cluster/my-cluster"
+	serviceName := "my-service"
+	taskSetID := "ecs-svc/1111111111111111111"
+	nativeID := clusterArn + "|" + serviceName + "|" + taskSetID
+
+	desired := json.RawMessage(`{
+		"Cluster": "` + clusterArn + `",
+		"Service": "arn:aws:ecs:us-east-1:123:service/my-cluster/my-service",
+		"TaskDefinition": "arn:aws:ecs:us-east-1:123:task-definition/foo:1",
+		"LaunchType": "FARGATE",
+		"Scale": {"Unit": "PERCENT", "Value": 50}
+	}`)
+
+	client.On("UpdateTaskSet", ctx, mock.MatchedBy(func(input *ecs.UpdateTaskSetInput) bool {
+		return input.Cluster != nil && *input.Cluster == clusterArn &&
+			input.Service != nil && *input.Service == serviceName &&
+			input.TaskSet != nil && *input.TaskSet == taskSetID &&
+			input.Scale != nil && input.Scale.Unit == ecstypes.ScaleUnitPercent && input.Scale.Value == 50
+	})).Return(&ecs.UpdateTaskSetOutput{
+		TaskSet: &ecstypes.TaskSet{
+			Id:         aws.String(taskSetID),
+			ClusterArn: aws.String(clusterArn),
+			ServiceArn: aws.String("arn:aws:ecs:us-east-1:123:service/my-cluster/my-service"),
+			Scale:      &ecstypes.Scale{Unit: ecstypes.ScaleUnitPercent, Value: 50},
+		},
+	}, nil)
+
+	ts := &TaskSet{cfg: &config.Config{}}
+	result, err := ts.updateWithClient(ctx, client, &resource.UpdateRequest{
+		ResourceType:      "AWS::ECS::TaskSet",
+		NativeID:          nativeID,
+		DesiredProperties: desired,
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, resource.OperationStatusSuccess, result.ProgressResult.OperationStatus)
+	assert.Equal(t, nativeID, result.ProgressResult.NativeID)
+	// The returned properties must reflect the updated Scale value so
+	// downstream idempotency checks see the intended state.
+	var props map[string]any
+	assert.NoError(t, json.Unmarshal(result.ProgressResult.ResourceProperties, &props))
+	scale, ok := props["Scale"].(map[string]any)
+	assert.True(t, ok, "Scale missing from result properties")
+	assert.Equal(t, "PERCENT", scale["Unit"])
+	assert.InDelta(t, float64(50), scale["Value"].(float64), 0.001)
+	client.AssertExpectations(t)
+}
+
+func TestTaskSet_Update_ErrorsWhenNativeIDIsNotComposite(t *testing.T) {
+	ctx := context.Background()
+	client := &mockECSTaskSetClient{}
+
+	ts := &TaskSet{cfg: &config.Config{}}
+	_, err := ts.updateWithClient(ctx, client, &resource.UpdateRequest{
+		ResourceType:      "AWS::ECS::TaskSet",
+		NativeID:          "not-a-composite",
+		DesiredProperties: json.RawMessage(`{"Scale":{"Unit":"PERCENT","Value":0}}`),
+	})
+
+	assert.Error(t, err)
+	client.AssertNotCalled(t, "UpdateTaskSet")
+}
+
+func TestTaskSet_Update_ErrorsWhenScaleIsMissingFromProperties(t *testing.T) {
+	ctx := context.Background()
+	client := &mockECSTaskSetClient{}
+
+	ts := &TaskSet{cfg: &config.Config{}}
+	_, err := ts.updateWithClient(ctx, client, &resource.UpdateRequest{
+		ResourceType:      "AWS::ECS::TaskSet",
+		NativeID:          "arn:aws:ecs:us-east-1:123:cluster/c|s|ecs-svc/1",
+		DesiredProperties: json.RawMessage(`{"Cluster":"c","Service":"s"}`),
+	})
+
+	assert.Error(t, err)
+	client.AssertNotCalled(t, "UpdateTaskSet")
+}
+
+func TestTaskSet_Update_PropagatesAWSError(t *testing.T) {
+	ctx := context.Background()
+	client := &mockECSTaskSetClient{}
+
+	client.On("UpdateTaskSet", ctx, mock.Anything).Return(
+		(*ecs.UpdateTaskSetOutput)(nil),
+		errors.New("throttled"),
+	)
+
+	ts := &TaskSet{cfg: &config.Config{}}
+	_, err := ts.updateWithClient(ctx, client, &resource.UpdateRequest{
+		ResourceType:      "AWS::ECS::TaskSet",
+		NativeID:          "arn:aws:ecs:us-east-1:123:cluster/c|s|ecs-svc/1",
+		DesiredProperties: json.RawMessage(`{"Scale":{"Unit":"PERCENT","Value":100}}`),
+	})
+
+	assert.Error(t, err)
 }
 
 func TestTaskSet_List_PropagatesOtherErrors(t *testing.T) {

--- a/schema/pkl/ecs/service.pkl
+++ b/schema/pkl/ecs/service.pkl
@@ -208,7 +208,10 @@ open class Service extends formae.Resource {
     @aws.FieldHint{hasProviderDefault = true}
     availabilityZoneRebalancing: AvailabilityZoneRebalancing?
 
-    @aws.FieldHint
+    // CC normalizes this to an empty array on Read when the caller didn't
+    // set it (except for launch-type-based services, where CC may omit it
+    // entirely). hasProviderDefault lets the stripper walk into both shapes.
+    @aws.FieldHint{hasProviderDefault = true}
     capacityProviderStrategy: Listing<CapacityProviderStrategy>?
 
     @aws.FieldHint{createOnly = true}
@@ -238,7 +241,8 @@ open class Service extends formae.Resource {
     @aws.FieldHint{createOnly = true}
     launchType: ServiceLaunchType?
 
-    @aws.FieldHint
+    // CC returns [] on Read when the caller didn't set it.
+    @aws.FieldHint{hasProviderDefault = true}
     loadBalancers: Listing<LoadBalancer>?
 
     @aws.FieldHint{hasProviderDefault = true}
@@ -270,7 +274,8 @@ open class Service extends formae.Resource {
     @aws.FieldHint{createOnly = true}
     serviceName: String?
 
-    @aws.FieldHint
+    // CC returns [] on Read when the caller didn't set it.
+    @aws.FieldHint{hasProviderDefault = true}
     serviceRegistries: Listing<ServiceRegistry>?
 
     @aws.FieldHint {
@@ -285,6 +290,9 @@ open class Service extends formae.Resource {
     @aws.FieldHint{writeOnly = true}
     volumeConfigurations: Listing<VolumeConfiguration>?
 
-    @aws.FieldHint
+    // No authoritative AWS doc, but the CC update-side semantics (empty
+    // array required to remove) mirror the other ECS::Service listings;
+    // CC is expected to return [] on Read here too. Annotated defensively.
+    @aws.FieldHint{hasProviderDefault = true}
     vpcLatticeConfigurations: Listing<VpcLatticeConfiguration>?
 }

--- a/schema/pkl/ecs/taskdefinition.pkl
+++ b/schema/pkl/ecs/taskdefinition.pkl
@@ -131,6 +131,7 @@ typealias EFSVolumeConfigurationTransitEncryption = "ENABLED"|"DISABLED"
 open class EFSVolumeConfiguration extends formae.SubResource {
     authorizationConfig: AuthorizationConfig?
     filesystemId: String|formae.Resolvable
+    @aws.FieldHint{hasProviderDefault = true}
     rootDirectory: String?
     transitEncryption: EFSVolumeConfigurationTransitEncryption?
     transitEncryptionPort: Int?

--- a/schema/pkl/ecs/taskset.pkl
+++ b/schema/pkl/ecs/taskset.pkl
@@ -16,6 +16,11 @@ typealias AssignPublicIp = "DISABLED"|"ENABLED"
 @aws.SubResourceHint
 open class AWSVpcConfiguration extends formae.SubResource {
     assignPublicIp: AssignPublicIp?
+    // AWS populates SecurityGroups with the VPC's default SG when the
+    // caller doesn't specify one, so without this hint an unchanged
+    // TaskSet reapply produces a phantom diff on the CreateOnly
+    // NetworkConfiguration and forces a full replacement.
+    @aws.FieldHint{hasProviderDefault = true}
     securityGroups: Listing<String|formae.Resolvable>?
     subnets: Listing<String|formae.Resolvable>
 }
@@ -71,7 +76,16 @@ open class ServiceRegistry extends formae.SubResource {
 }
 open class TaskSet extends formae.Resource {
 
-    @aws.FieldHint{createOnly = true}
+    // CloudControl returns TaskSet list-valued createOnly fields as empty
+    // arrays when the caller didn't set them. Without hasProviderDefault on
+    // these the recursive stripper can't walk them out of stored-state
+    // comparisons, and a reapply triggers a phantom diff that the planner
+    // promotes to a full replacement. Same pattern as
+    // AwsVpcConfiguration.SecurityGroups and PortMapping.HostPort.
+    @aws.FieldHint{
+        createOnly = true
+        hasProviderDefault = true
+    }
     capacityProviderStrategy: Listing<CapacityProviderStrategy>?
 
     @aws.FieldHint{createOnly = true}
@@ -83,7 +97,10 @@ open class TaskSet extends formae.Resource {
     @aws.FieldHint{createOnly = true}
     launchType: LaunchType?
 
-    @aws.FieldHint{createOnly = true}
+    @aws.FieldHint{
+        createOnly = true
+        hasProviderDefault = true
+    }
     loadBalancers: Listing<LoadBalancer>?
 
     @aws.FieldHint{createOnly = true}
@@ -101,7 +118,10 @@ open class TaskSet extends formae.Resource {
     @aws.FieldHint{createOnly = true}
     service: String|formae.Resolvable
 
-    @aws.FieldHint{createOnly = true}
+    @aws.FieldHint{
+        createOnly = true
+        hasProviderDefault = true
+    }
     serviceRegistries: Listing<ServiceRegistry>?
 
     @aws.FieldHint

--- a/testdata/ecs-service-replace.pkl
+++ b/testdata/ecs-service-replace.pkl
@@ -1,0 +1,112 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/ec2/vpc.pkl"
+import "@aws/ec2/subnet.pkl"
+import "@aws/ecs/ecscluster.pkl"
+import "@aws/ecs/taskdefinition.pkl"
+import "@aws/ecs/service.pkl"
+
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local stackName = "plugin-sdk-test-ecs-service-\(testRunID)"
+
+// VPC + Subnet for FARGATE awsvpc networking - same as create
+local testVpc = new vpc.VPC {
+  label = "test-vpc-for-ecs-svc"
+  cidrBlock = "10.230.0.0/16"
+  enableDnsSupport = true
+}
+
+local testSubnet = new subnet.Subnet {
+  label = "test-subnet-for-ecs-svc"
+  vpcId = testVpc.res.vpcId
+  cidrBlock = "10.230.1.0/24"
+  availabilityZone = "us-east-1a"
+}
+
+// ECS Cluster dependency - same as create
+local testCluster = new ecscluster.Cluster {
+  label = "test-cluster-for-service"
+  clusterName = "formae-sdk-test-svc-cluster-\(testRunID)"
+  clusterSettings {
+    new {
+      name = "containerInsights"
+      value = "disabled"
+    }
+  }
+}
+
+// ECS TaskDefinition dependency - same as create
+local testTaskDef = new taskdefinition.TaskDefinition {
+  label = "test-taskdef-for-service"
+  family = "formae-sdk-test-svc-taskdef-\(testRunID)"
+  requiresCompatibilities {
+    "FARGATE"
+  }
+  networkMode = "awsvpc"
+  cpu = "256"
+  memory = "512"
+  containerDefinitions {
+    new {
+      name = "test-container"
+      image = "nginx:latest"
+      essential = true
+    }
+  }
+}
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for ECS Service"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  testVpc
+  testSubnet
+  testCluster
+  testTaskDef
+
+  // Updated: changed serviceName (createOnly) to force a full replacement
+  // through the destroy+create lifecycle. serviceName is an ECS::Service
+  // createOnly field so any change forces a Replace plan.
+  new service.Service {
+    label = "plugin-sdk-test-ecs-service"
+    serviceName = "formae-sdk-test-svc-\(testRunID)-replaced"
+    cluster = testCluster.res.arn
+    taskDefinition = new formae.Resolvable {
+      label = testTaskDef.label
+      type = "AWS::ECS::TaskDefinition"
+      property = "TaskDefinitionArn"
+    }
+    desiredCount = 0
+    schedulingStrategy = "REPLICA"
+    launchType = "FARGATE"
+    networkConfiguration = new service.NetworkConfiguration {
+      awsvpcConfiguration = new service.AwsVpcConfiguration {
+        assignPublicIp = "DISABLED"
+        subnets {
+          testSubnet.res.subnetId
+        }
+      }
+    }
+    deploymentConfiguration = new service.DeploymentConfiguration {
+      maximumPercent = 200
+      minimumHealthyPercent = 100
+    }
+  }
+}

--- a/testdata/ecs-taskset-replace.pkl
+++ b/testdata/ecs-taskset-replace.pkl
@@ -68,7 +68,12 @@ local testTaskDef = new taskdefinition.TaskDefinition {
 local testService = new service.Service {
   label = "test-service-for-taskset"
   serviceName = "formae-sdk-test-ts-svc-\(testRunID)"
-  cluster = testCluster.res.arn
+  // Short-name Resolvable: see base fixture for why this matters on Update.
+  cluster = new formae.Resolvable {
+    label = testCluster.label
+    type = "AWS::ECS::Cluster"
+    property = "ClusterName"
+  }
   schedulingStrategy = "REPLICA"
   deploymentController = new service.DeploymentController {
     type = "EXTERNAL"
@@ -103,13 +108,18 @@ forma {
 
   // ECS TaskSet under test — setting externalId (createOnly) forces a
   // resource replacement through the full destroy+create lifecycle.
+  // Short-name Resolvables match CC Read output on Cluster/Service.
   new taskset.TaskSet {
     label = "plugin-sdk-test-ecs-taskset"
-    cluster = testCluster.res.arn
+    cluster = new formae.Resolvable {
+      label = testCluster.label
+      type = "AWS::ECS::Cluster"
+      property = "ClusterName"
+    }
     service = new formae.Resolvable {
       label = testService.label
       type = "AWS::ECS::Service"
-      property = "ServiceArn"
+      property = "ServiceName"
     }
     taskDefinition = new formae.Resolvable {
       label = testTaskDef.label

--- a/testdata/ecs-taskset-replace.pkl
+++ b/testdata/ecs-taskset-replace.pkl
@@ -68,12 +68,7 @@ local testTaskDef = new taskdefinition.TaskDefinition {
 local testService = new service.Service {
   label = "test-service-for-taskset"
   serviceName = "formae-sdk-test-ts-svc-\(testRunID)"
-  // Short-name Resolvable: see base fixture for why this matters on Update.
-  cluster = new formae.Resolvable {
-    label = testCluster.label
-    type = "AWS::ECS::Cluster"
-    property = "ClusterName"
-  }
+  cluster = testCluster.res.arn
   schedulingStrategy = "REPLICA"
   deploymentController = new service.DeploymentController {
     type = "EXTERNAL"
@@ -108,18 +103,13 @@ forma {
 
   // ECS TaskSet under test — setting externalId (createOnly) forces a
   // resource replacement through the full destroy+create lifecycle.
-  // Short-name Resolvables match CC Read output on Cluster/Service.
   new taskset.TaskSet {
     label = "plugin-sdk-test-ecs-taskset"
-    cluster = new formae.Resolvable {
-      label = testCluster.label
-      type = "AWS::ECS::Cluster"
-      property = "ClusterName"
-    }
+    cluster = testCluster.res.arn
     service = new formae.Resolvable {
       label = testService.label
       type = "AWS::ECS::Service"
-      property = "ServiceName"
+      property = "ServiceArn"
     }
     taskDefinition = new formae.Resolvable {
       label = testTaskDef.label

--- a/testdata/ecs-taskset-replace.pkl
+++ b/testdata/ecs-taskset-replace.pkl
@@ -1,0 +1,134 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/ec2/vpc.pkl"
+import "@aws/ec2/subnet.pkl"
+import "@aws/ecs/ecscluster.pkl"
+import "@aws/ecs/taskdefinition.pkl"
+import "@aws/ecs/service.pkl"
+import "@aws/ecs/taskset.pkl"
+
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local stackName = "plugin-sdk-test-ecs-taskset-\(testRunID)"
+
+// VPC + Subnet for FARGATE awsvpc networking
+local testVpc = new vpc.VPC {
+  label = "test-vpc-for-ecs-taskset"
+  cidrBlock = "10.231.0.0/16"
+  enableDnsSupport = true
+}
+
+local testSubnet = new subnet.Subnet {
+  label = "test-subnet-for-ecs-taskset"
+  vpcId = testVpc.res.vpcId
+  cidrBlock = "10.231.1.0/24"
+  availabilityZone = "us-east-1a"
+}
+
+// ECS Cluster dependency
+local testCluster = new ecscluster.Cluster {
+  label = "test-cluster-for-taskset"
+  clusterName = "formae-sdk-test-ts-cluster-\(testRunID)"
+  clusterSettings {
+    new {
+      name = "containerInsights"
+      value = "disabled"
+    }
+  }
+}
+
+// ECS TaskDefinition dependency (FARGATE-compatible)
+local testTaskDef = new taskdefinition.TaskDefinition {
+  label = "test-taskdef-for-taskset"
+  family = "formae-sdk-test-ts-taskdef-\(testRunID)"
+  requiresCompatibilities {
+    "FARGATE"
+  }
+  networkMode = "awsvpc"
+  cpu = "256"
+  memory = "512"
+  containerDefinitions {
+    new {
+      name = "test-container"
+      image = "nginx:latest"
+      essential = true
+    }
+  }
+}
+
+// ECS Service with EXTERNAL deployment controller, which is required for TaskSets
+local testService = new service.Service {
+  label = "test-service-for-taskset"
+  serviceName = "formae-sdk-test-ts-svc-\(testRunID)"
+  cluster = testCluster.res.arn
+  schedulingStrategy = "REPLICA"
+  deploymentController = new service.DeploymentController {
+    type = "EXTERNAL"
+  }
+}
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for ECS TaskSet"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  // VPC + Subnet for awsvpc networking
+  testVpc
+  testSubnet
+
+  // Cluster dependency
+  testCluster
+
+  // TaskDefinition dependency
+  testTaskDef
+
+  // Service with EXTERNAL deployment controller
+  testService
+
+  // ECS TaskSet under test — setting externalId (createOnly) forces a
+  // resource replacement through the full destroy+create lifecycle.
+  new taskset.TaskSet {
+    label = "plugin-sdk-test-ecs-taskset"
+    cluster = testCluster.res.arn
+    service = new formae.Resolvable {
+      label = testService.label
+      type = "AWS::ECS::Service"
+      property = "ServiceArn"
+    }
+    taskDefinition = new formae.Resolvable {
+      label = testTaskDef.label
+      type = "AWS::ECS::TaskDefinition"
+      property = "TaskDefinitionArn"
+    }
+    launchType = "FARGATE"
+    externalId = "formae-sdk-replace-test"
+    networkConfiguration = new taskset.NetworkConfiguration {
+      awsVpcConfiguration = new taskset.AWSVpcConfiguration {
+        assignPublicIp = "DISABLED"
+        subnets {
+          testSubnet.res.subnetId
+        }
+      }
+    }
+    scale = new taskset.Scale {
+      unit = "PERCENT"
+      value = 0
+    }
+  }
+}

--- a/testdata/ecs-taskset-update.pkl
+++ b/testdata/ecs-taskset-update.pkl
@@ -68,7 +68,12 @@ local testTaskDef = new taskdefinition.TaskDefinition {
 local testService = new service.Service {
   label = "test-service-for-taskset"
   serviceName = "formae-sdk-test-ts-svc-\(testRunID)"
-  cluster = testCluster.res.arn
+  // Short-name Resolvable: see base fixture for why this matters on Update.
+  cluster = new formae.Resolvable {
+    label = testCluster.label
+    type = "AWS::ECS::Cluster"
+    property = "ClusterName"
+  }
   schedulingStrategy = "REPLICA"
   deploymentController = new service.DeploymentController {
     type = "EXTERNAL"
@@ -103,13 +108,18 @@ forma {
 
   // ECS TaskSet under test — Scale is the only mutable field per AWS's
   // UpdateTaskSet API; bump the percent from 0 to 50 to exercise update.
+  // Short-name Resolvables match CC Read output on Cluster/Service.
   new taskset.TaskSet {
     label = "plugin-sdk-test-ecs-taskset"
-    cluster = testCluster.res.arn
+    cluster = new formae.Resolvable {
+      label = testCluster.label
+      type = "AWS::ECS::Cluster"
+      property = "ClusterName"
+    }
     service = new formae.Resolvable {
       label = testService.label
       type = "AWS::ECS::Service"
-      property = "ServiceArn"
+      property = "ServiceName"
     }
     taskDefinition = new formae.Resolvable {
       label = testTaskDef.label

--- a/testdata/ecs-taskset-update.pkl
+++ b/testdata/ecs-taskset-update.pkl
@@ -68,12 +68,7 @@ local testTaskDef = new taskdefinition.TaskDefinition {
 local testService = new service.Service {
   label = "test-service-for-taskset"
   serviceName = "formae-sdk-test-ts-svc-\(testRunID)"
-  // Short-name Resolvable: see base fixture for why this matters on Update.
-  cluster = new formae.Resolvable {
-    label = testCluster.label
-    type = "AWS::ECS::Cluster"
-    property = "ClusterName"
-  }
+  cluster = testCluster.res.arn
   schedulingStrategy = "REPLICA"
   deploymentController = new service.DeploymentController {
     type = "EXTERNAL"
@@ -108,18 +103,13 @@ forma {
 
   // ECS TaskSet under test — Scale is the only mutable field per AWS's
   // UpdateTaskSet API; bump the percent from 0 to 50 to exercise update.
-  // Short-name Resolvables match CC Read output on Cluster/Service.
   new taskset.TaskSet {
     label = "plugin-sdk-test-ecs-taskset"
-    cluster = new formae.Resolvable {
-      label = testCluster.label
-      type = "AWS::ECS::Cluster"
-      property = "ClusterName"
-    }
+    cluster = testCluster.res.arn
     service = new formae.Resolvable {
       label = testService.label
       type = "AWS::ECS::Service"
-      property = "ServiceName"
+      property = "ServiceArn"
     }
     taskDefinition = new formae.Resolvable {
       label = testTaskDef.label

--- a/testdata/ecs-taskset-update.pkl
+++ b/testdata/ecs-taskset-update.pkl
@@ -1,0 +1,133 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/ec2/vpc.pkl"
+import "@aws/ec2/subnet.pkl"
+import "@aws/ecs/ecscluster.pkl"
+import "@aws/ecs/taskdefinition.pkl"
+import "@aws/ecs/service.pkl"
+import "@aws/ecs/taskset.pkl"
+
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local stackName = "plugin-sdk-test-ecs-taskset-\(testRunID)"
+
+// VPC + Subnet for FARGATE awsvpc networking
+local testVpc = new vpc.VPC {
+  label = "test-vpc-for-ecs-taskset"
+  cidrBlock = "10.231.0.0/16"
+  enableDnsSupport = true
+}
+
+local testSubnet = new subnet.Subnet {
+  label = "test-subnet-for-ecs-taskset"
+  vpcId = testVpc.res.vpcId
+  cidrBlock = "10.231.1.0/24"
+  availabilityZone = "us-east-1a"
+}
+
+// ECS Cluster dependency
+local testCluster = new ecscluster.Cluster {
+  label = "test-cluster-for-taskset"
+  clusterName = "formae-sdk-test-ts-cluster-\(testRunID)"
+  clusterSettings {
+    new {
+      name = "containerInsights"
+      value = "disabled"
+    }
+  }
+}
+
+// ECS TaskDefinition dependency (FARGATE-compatible)
+local testTaskDef = new taskdefinition.TaskDefinition {
+  label = "test-taskdef-for-taskset"
+  family = "formae-sdk-test-ts-taskdef-\(testRunID)"
+  requiresCompatibilities {
+    "FARGATE"
+  }
+  networkMode = "awsvpc"
+  cpu = "256"
+  memory = "512"
+  containerDefinitions {
+    new {
+      name = "test-container"
+      image = "nginx:latest"
+      essential = true
+    }
+  }
+}
+
+// ECS Service with EXTERNAL deployment controller, which is required for TaskSets
+local testService = new service.Service {
+  label = "test-service-for-taskset"
+  serviceName = "formae-sdk-test-ts-svc-\(testRunID)"
+  cluster = testCluster.res.arn
+  schedulingStrategy = "REPLICA"
+  deploymentController = new service.DeploymentController {
+    type = "EXTERNAL"
+  }
+}
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for ECS TaskSet"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  // VPC + Subnet for awsvpc networking
+  testVpc
+  testSubnet
+
+  // Cluster dependency
+  testCluster
+
+  // TaskDefinition dependency
+  testTaskDef
+
+  // Service with EXTERNAL deployment controller
+  testService
+
+  // ECS TaskSet under test — Scale is the only mutable field per AWS's
+  // UpdateTaskSet API; bump the percent from 0 to 50 to exercise update.
+  new taskset.TaskSet {
+    label = "plugin-sdk-test-ecs-taskset"
+    cluster = testCluster.res.arn
+    service = new formae.Resolvable {
+      label = testService.label
+      type = "AWS::ECS::Service"
+      property = "ServiceArn"
+    }
+    taskDefinition = new formae.Resolvable {
+      label = testTaskDef.label
+      type = "AWS::ECS::TaskDefinition"
+      property = "TaskDefinitionArn"
+    }
+    launchType = "FARGATE"
+    networkConfiguration = new taskset.NetworkConfiguration {
+      awsVpcConfiguration = new taskset.AWSVpcConfiguration {
+        assignPublicIp = "DISABLED"
+        subnets {
+          testSubnet.res.subnetId
+        }
+      }
+    }
+    scale = new taskset.Scale {
+      unit = "PERCENT"
+      value = 50
+    }
+  }
+}

--- a/testdata/ecs-taskset.pkl
+++ b/testdata/ecs-taskset.pkl
@@ -68,16 +68,7 @@ local testTaskDef = new taskdefinition.TaskDefinition {
 local testService = new service.Service {
   label = "test-service-for-taskset"
   serviceName = "formae-sdk-test-ts-svc-\(testRunID)"
-  // Resolve to the Cluster's short name (CC property ClusterName) so formae
-  // tracks the dependency on Cluster AND the resolved value matches what CC
-  // Read returns on Service.Cluster. Using the ARN (`testCluster.res.arn`)
-  // would pass validation on create but produce a phantom createOnly diff on
-  // re-apply because desired=ARN vs actual=short name.
-  cluster = new formae.Resolvable {
-    label = testCluster.label
-    type = "AWS::ECS::Cluster"
-    property = "ClusterName"
-  }
+  cluster = testCluster.res.arn
   schedulingStrategy = "REPLICA"
   deploymentController = new service.DeploymentController {
     type = "EXTERNAL"
@@ -110,22 +101,14 @@ forma {
   // Service with EXTERNAL deployment controller
   testService
 
-  // ECS TaskSet under test. Cluster and Service are createOnly and CC
-  // returns them as short names on Read, so resolve to their short-name
-  // properties (ClusterName / ServiceName) rather than ARNs — mismatched
-  // ARN-vs-short-name on a createOnly field produces a phantom diff that
-  // the planner promotes to a full replacement on Update.
+  // ECS TaskSet under test
   new taskset.TaskSet {
     label = "plugin-sdk-test-ecs-taskset"
-    cluster = new formae.Resolvable {
-      label = testCluster.label
-      type = "AWS::ECS::Cluster"
-      property = "ClusterName"
-    }
+    cluster = testCluster.res.arn
     service = new formae.Resolvable {
       label = testService.label
       type = "AWS::ECS::Service"
-      property = "ServiceName"
+      property = "ServiceArn"
     }
     taskDefinition = new formae.Resolvable {
       label = testTaskDef.label

--- a/testdata/ecs-taskset.pkl
+++ b/testdata/ecs-taskset.pkl
@@ -68,7 +68,16 @@ local testTaskDef = new taskdefinition.TaskDefinition {
 local testService = new service.Service {
   label = "test-service-for-taskset"
   serviceName = "formae-sdk-test-ts-svc-\(testRunID)"
-  cluster = testCluster.res.arn
+  // Resolve to the Cluster's short name (CC property ClusterName) so formae
+  // tracks the dependency on Cluster AND the resolved value matches what CC
+  // Read returns on Service.Cluster. Using the ARN (`testCluster.res.arn`)
+  // would pass validation on create but produce a phantom createOnly diff on
+  // re-apply because desired=ARN vs actual=short name.
+  cluster = new formae.Resolvable {
+    label = testCluster.label
+    type = "AWS::ECS::Cluster"
+    property = "ClusterName"
+  }
   schedulingStrategy = "REPLICA"
   deploymentController = new service.DeploymentController {
     type = "EXTERNAL"
@@ -101,14 +110,22 @@ forma {
   // Service with EXTERNAL deployment controller
   testService
 
-  // ECS TaskSet under test
+  // ECS TaskSet under test. Cluster and Service are createOnly and CC
+  // returns them as short names on Read, so resolve to their short-name
+  // properties (ClusterName / ServiceName) rather than ARNs — mismatched
+  // ARN-vs-short-name on a createOnly field produces a phantom diff that
+  // the planner promotes to a full replacement on Update.
   new taskset.TaskSet {
     label = "plugin-sdk-test-ecs-taskset"
-    cluster = testCluster.res.arn
+    cluster = new formae.Resolvable {
+      label = testCluster.label
+      type = "AWS::ECS::Cluster"
+      property = "ClusterName"
+    }
     service = new formae.Resolvable {
       label = testService.label
       type = "AWS::ECS::Service"
-      property = "ServiceArn"
+      property = "ServiceName"
     }
     taskDefinition = new formae.Resolvable {
       label = testTaskDef.label


### PR DESCRIPTION
## Summary

Three substantive fixes for AWS::ECS::TaskSet and AWS::ECS::Service
apply lifecycles:

- **`d222373`** — custom Update provisioner for `AWS::ECS::TaskSet`.
  CloudControl's update handler hangs indefinitely when patching Scale
  (the only field the underlying ECS `UpdateTaskSet` API can change),
  so Update now routes through the ECS SDK directly. Create/Read/Delete
  continue on the CloudControl path. Same commit lands the BUG-1 fix:
  `hasProviderDefault = true` on
  `EFSVolumeConfiguration.rootDirectory` to stop CC's default `/` from
  producing phantom replaces on re-apply of EFS-mounted task definitions.
  Also extends `hasProviderDefault` across TaskSet's createOnly list
  fields (CapacityProviderStrategy, LoadBalancers, ServiceRegistries,
  AwsVpcConfiguration.SecurityGroups).

- **`48dc657`** — BUG-2 fix: custom Read provisioners for
  `AWS::ECS::Service` and `AWS::ECS::TaskSet` that re-inflate the bare
  `Cluster` (and, on TaskSet, `Service`) names CC returns on Read back
  into full ARNs. CC accepts either short names or ARNs on Create but
  always normalizes to short names on Read; without this the stored
  `\$value` for an ARN-valued resolvable drifts to the short name after
  the first Read, and every reapply then promotes Update → Replace on
  the createOnly field. Both providers short-circuit (pass through
  unchanged) when the field is already an ARN, when the source ARN
  isn't parseable, or on error. Also reverts the short-lived
  fixture-level workaround from `b6ee3d0` so the fixtures use the
  same `.res.arn` / `ServiceArn` shape any real caller would write.

- **`9607f70`** — add `testdata/ecs-service-replace.pkl`. The service
  had base + `-update.pkl` but no replace fixture; add one so the full
  CRUD lifecycle (including destroy+create) gets conformance coverage
  alongside the matching ecs-taskset fixtures. Replace is triggered by
  flipping the createOnly `serviceName`.

`b6ee3d0` is a superseded intermediate commit — its fixture changes
were reverted in `48dc657`. Squash if you prefer a tidier history;
it's harmless as-is.

## CI

Run [24789947620](https://github.com/platform-engineering-labs/formae-plugin-aws/actions/runs/24789947620)
is in flight against `48dc657` and has already passed both
`conformance-tests (ecs-service)` (8m57s) and `conformance-tests (ecs-taskset)`
(12m22s). The `9607f70` replace fixture is not exercised by that run;
it'll pick up on the next dispatch. `conformance-tests (lambda-eventinvokeconfig)`
and `conformance-tests (eks-cluster)` are open follow-ups out of scope
for this PR.