### PR TITLE
fix(elbv2): mark Action.forwardConfig as hasProviderDefault

### DIFF
--- a/schema/pkl/ecs/ecscluster.pkl
+++ b/schema/pkl/ecs/ecscluster.pkl
@@ -77,7 +77,11 @@ open class Cluster extends formae.Resource {
     @aws.FieldHint{createOnly = true}
     clusterName: String?
 
-    @aws.FieldHint
+    // AWS ECS populates ClusterSettings with default entries (e.g.
+    // `containerInsights: disabled`) when the user doesn't specify any, so
+    // the field must be stripped from existing-side comparisons to avoid a
+    // spurious update on reapply.
+    @aws.FieldHint{hasProviderDefault = true}
     clusterSettings: Listing<ClusterClusterSettings>?
 
     @aws.FieldHint

--- a/schema/pkl/elasticloadbalancingv2/listener.pkl
+++ b/schema/pkl/elasticloadbalancingv2/listener.pkl
@@ -16,6 +16,12 @@ open class Action extends formae.SubResource {
     authenticateCognitoConfig: AuthenticateCognitoConfig?
     authenticateOidcConfig: AuthenticateOidcConfig?
     fixedResponseConfig: FixedResponseConfig?
+    // AWS ELBv2 derives ForwardConfig (TargetGroups + stickiness defaults) from
+    // the Action's TargetGroupArn when the user specifies a simple forward
+    // target. The derived value shows up in Read and must be stripped from
+    // existing-side comparisons, else every reapply reports a stale diff on
+    // Listener.DefaultActions.
+    @aws.FieldHint{hasProviderDefault = true}
     forwardConfig: ForwardConfig?
     order: Int?
     redirectConfig: RedirectConfig?


### PR DESCRIPTION
## Summary

Two adjacent `hasProviderDefault` gaps that surface as spurious reapply-time updates on resources where the user leaves AWS-derived fields unset:

- **`Listener.DefaultActions[*].ForwardConfig`** — ELBv2 derives `ForwardConfig` (TargetGroups + stickiness defaults) on Read from the Action's `TargetGroupArn` when the user sets a simple forward target. Without `hasProviderDefault` on `Action.forwardConfig`, the recursive provider-default stripper has no 2-level anchor on `DefaultActions.ForwardConfig`, leaves the derived subtree in place on the existing side, and every reapply emits a `remove /DefaultActions/0` + `add /DefaultActions/0 {Type: forward}` no-op patch. The 3-level hint on `ForwardConfig.TargetGroupStickinessConfig` continues to work — this change adds the missing 2-level anchor for its parent.

- **`Cluster.ClusterSettings`** — ECS populates `ClusterSettings` with default entries (e.g. `containerInsights: disabled`) when the user doesn't configure any. Without the annotation, the stripper leaves the populated field in place on the existing side and every reapply reports a stale diff on ECS::Cluster.

Both annotations are scoped to fields AWS is already known to populate as defaults on Read. Confirmed via `pkl eval` that `DefaultActions.ForwardConfig` and `ClusterSettings` both now appear in `Schema.Hints` with `HasProviderDefault=true`. `make verify-schema` + `make test-unit` pass on the branch.