### PR TITLE
feat(ecs): annotate Service backend-attachment fields with attachesTo

### DIFF
--- a/schema/pkl/PklProject
+++ b/schema/pkl/PklProject
@@ -2,7 +2,11 @@ amends "pkl:Project"
 
 dependencies {
   ["formae"] {
-    uri = "package://hub.platform.engineering/plugins/pkl/schema/pkl/formae/formae@0.83.0"
+    // Pre-release dev-channel formae schema introduces FieldHint.attachesTo,
+    // consumed by the targetGroupArn annotations on ECS::Service.
+    // Bump back to a stable URL once the AttachesTo hint ships in a stable
+    // formae release.
+    uri = "package://hub.platform.engineering/plugins/pkl/schema/pkl/formae/dev/formae@0.85.0"
   }
 }
 

--- a/schema/pkl/ecs/service.pkl
+++ b/schema/pkl/ecs/service.pkl
@@ -83,6 +83,7 @@ open class LoadBalancer extends formae.SubResource {
     containerName: String?
     containerPort: Int?
     loadBalancerName: (String|formae.Resolvable)?
+    @aws.FieldHint{attachesTo = true}
     targetGroupArn: (String|formae.Resolvable)?
 }
 
@@ -194,6 +195,7 @@ open class TimeoutConfiguration extends formae.SubResource {
 open class VpcLatticeConfiguration extends formae.SubResource {
     portName: String
     roleArn: String|formae.Resolvable
+    @aws.FieldHint{attachesTo = true}
     targetGroupArn: String|formae.Resolvable
 }
 


### PR DESCRIPTION
## Summary

- Adds \`attachesTo = true\` (introduced in formae 0.85.0) to the two \`ECS::Service\` fields that express "this service attaches as a backend to the referenced resource": \`LoadBalancer.targetGroupArn\` and \`VpcLatticeConfiguration.targetGroupArn\`.
- Bumps \`schema/pkl/PklProject\`'s formae dep to the dev-channel pre-release that introduced \`FieldHint.attachesTo\`.

## Why

Without the hint, formae's destroy-DAG builder reverses the construction-ref direction for these fields — letting the Service tear down in parallel with whatever holds the listener/lattice service alive. With the hint, the engine inverts the edge so the Service waits for the listener (or Lattice service) to delete first. Combined with the pre-existing target-reachability edge on plugin targets, this keeps the endpoint chain alive while plugin resources on it are still being CRUD'd.

The motivating bug: an LGTM forma where the Grafana plugin's target points at an ALB Listener served by an ECS Service. Today the Service deletes in parallel with Grafana resource deletes, hanging Grafana plugin calls and panicking the formae \`ResourceUpdater\` actor on late \`plugin.TrackedProgress\` callbacks. With this PR the Service stays alive until Grafana resources, target, and listener are all gone.

## Files

- \`schema/pkl/PklProject\` — formae dep bumped to \`package://.../formae/dev/formae@0.85.0\`. Comment notes the dev-channel URL is temporary; bumps back to stable when attachesTo ships in a stable formae release.
- \`schema/pkl/ecs/service.pkl\` — two \`@aws.FieldHint{attachesTo = true}\` annotations on the targetGroupArn fields.

## Compatibility

- AttachesTo defaults to false in formae's FieldHint. Plugin schemas built before formae 0.85.0 ignore the field — no consumer breaks.
- An older formae binary (< 0.85.0) reading this plugin's published schema would unmarshal AttachesTo silently as false. Behaviour identical to today.
- Stable users continue to consume this plugin's previous releases — they're untouched.

## Verification

\`pkl project resolve\` against the updated dep + \`pkl eval ecs/service.pkl\` both succeed locally. The annotation parses cleanly because \`aws.FieldHint extends formae.FieldHint\` and the pre-release formae schema has \`hidden attachesTo: Boolean = false\` declared.

## Follow-ups

A broader audit may be warranted for other plausible attach-points — \`Lambda::EventSourceMapping.EventSourceArn\`, \`AutoScaling::ScalingPolicy.AutoScalingGroupName\`, \`ElasticLoadBalancingV2::ListenerRule.ListenerArn\` — but those aren't on the LGTM critical path. Tracking separately.

## Related

- Engine support: formae \`feat(changeset): add AttachesTo field hint for reachability-aware destroy\`.
- Channel-aware schema publish path: formae \`build(pkl): route publish-pkl to per-channel S3 sub-path\` + \`fix(pkl): make published package's manifest channel-aware\`.
- See RFC-0034.