### PR TITLE
chore(deps): bump GitHub Actions to Node.js 24 versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,6 @@ on:
         default: 'false'
         type: boolean
 
-# Prevent concurrent conformance tests (CI and nightly share test resources)
-concurrency:
-  group: aws-conformance-tests
-  cancel-in-progress: false
-
 jobs:
   checks:
     runs-on: ubuntu-latest
@@ -133,6 +128,13 @@ jobs:
   # Each test case runs in its own isolated job via matrix strategy.
   # Cleanup is handled by separate pre/post-cleanup jobs, NOT per test.
   conformance-tests:
+    # Prevent concurrent conformance runs across this workflow and nightly,
+    # since they share live AWS test resources. Scoped to this job (not the
+    # whole workflow) so PR-only checks don't queue behind in-flight
+    # conformance runs.
+    concurrency:
+      group: aws-conformance-tests
+      cancel-in-progress: false
     needs: [discover-tests, pre-cleanup]
     runs-on: ubuntu-latest
     timeout-minutes: 120

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Set up Pkl
         uses: pkl-community/setup-pkl@v0.0.8
@@ -66,7 +66,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v6
@@ -154,7 +154,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Set up Pkl
         uses: pkl-community/setup-pkl@v0.0.8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,15 +23,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.25"
 
       - name: Set up Pkl
-        uses: pkl-community/setup-pkl@v0
+        uses: pkl-community/setup-pkl@v0.0.8
         with:
           pkl-version: 0.30.0
 
@@ -66,15 +66,15 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.25"
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::942849037363:role/admin-test-pel
@@ -92,7 +92,7 @@ jobs:
       test-cases: ${{ steps.discover.outputs.test-cases }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Discover test cases
         id: discover
@@ -117,10 +117,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::942849037363:role/admin-test-pel
@@ -147,20 +147,20 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.25"
 
       - name: Set up Pkl
-        uses: pkl-community/setup-pkl@v0
+        uses: pkl-community/setup-pkl@v0.0.8
         with:
           pkl-version: 0.30.0
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::942849037363:role/admin-test-pel
@@ -171,7 +171,7 @@ jobs:
         run: make install
 
       - name: Run conformance test (${{ matrix.test-case }})
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4
         env:
           AWS_REGION: us-east-1
           FORMAE_TEST_RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}
@@ -192,10 +192,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::942849037363:role/admin-test-pel
@@ -212,7 +212,7 @@ jobs:
     steps:
       - name: Check if previous run failed
         id: check_previous
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const runs = await github.rest.actions.listWorkflowRuns({
@@ -235,7 +235,7 @@ jobs:
 
       - name: Notify Slack (Fixed)
         if: steps.check_previous.outputs.result == 'true'
-        uses: slackapi/slack-github-action@v2.1.1
+        uses: slackapi/slack-github-action@v3.0.1
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
@@ -273,7 +273,7 @@ jobs:
     if: failure() && github.event_name == 'push'
     steps:
       - name: Notify Slack
-        uses: slackapi/slack-github-action@v2.1.1
+        uses: slackapi/slack-github-action@v3.0.1
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,15 +30,15 @@ jobs:
       contents: read
     steps:
       - name: Checkout plugin
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.25"
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::942849037363:role/admin-test-pel
@@ -55,7 +55,7 @@ jobs:
       test-cases: ${{ steps.discover.outputs.test-cases }}
     steps:
       - name: Checkout plugin
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Discover test cases
         id: discover
@@ -80,10 +80,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout plugin
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::942849037363:role/admin-test-pel
@@ -110,15 +110,15 @@ jobs:
 
     steps:
       - name: Checkout plugin
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.25"
 
       - name: Set up Pkl
-        uses: pkl-community/setup-pkl@v0
+        uses: pkl-community/setup-pkl@v0.0.8
         with:
           pkl-version: 0.30.0
 
@@ -192,7 +192,7 @@ jobs:
           go mod tidy
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::942849037363:role/admin-test-pel
@@ -203,7 +203,7 @@ jobs:
         run: make install
 
       - name: Run conformance test (${{ matrix.test-case }})
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4
         env:
           AWS_REGION: us-east-1
           FORMAE_TEST_RUN_ID: nightly-main-${{ github.run_id }}
@@ -224,10 +224,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout plugin
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::942849037363:role/admin-test-pel
@@ -244,7 +244,7 @@ jobs:
     steps:
       - name: Check if previous run failed
         id: check_previous
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const runs = await github.rest.actions.listWorkflowRuns({
@@ -266,7 +266,7 @@ jobs:
 
       - name: Notify Slack (Fixed)
         if: steps.check_previous.outputs.result == 'true'
-        uses: slackapi/slack-github-action@v2.1.1
+        uses: slackapi/slack-github-action@v3.0.1
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
@@ -304,7 +304,7 @@ jobs:
     if: failure()
     steps:
       - name: Notify Slack
-        uses: slackapi/slack-github-action@v2.1.1
+        uses: slackapi/slack-github-action@v3.0.1
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,11 +14,6 @@ on:
         default: "main"
         type: string
 
-# Prevent concurrent conformance tests (CI and nightly share test resources)
-concurrency:
-  group: aws-conformance-tests
-  cancel-in-progress: false
-
 jobs:
   # Integration tests run against real AWS resources (Route53, EC2, etc.)
   # These are self-contained: each test creates and cleans up its own resources.
@@ -96,6 +91,12 @@ jobs:
   # Each test case runs in its own isolated job via matrix strategy.
   # Cleanup is handled by separate pre/post-cleanup jobs, NOT per test.
   conformance-tests:
+    # Prevent concurrent conformance runs across this workflow and CI,
+    # since they share live AWS test resources. Scoped to this job (not
+    # the whole workflow) so other nightly steps aren't blocked.
+    concurrency:
+      group: aws-conformance-tests
+      cancel-in-progress: false
     needs: [discover-tests, pre-cleanup]
     runs-on: ubuntu-latest
     timeout-minutes: 120

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v6
@@ -116,7 +116,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Set up Pkl
         uses: pkl-community/setup-pkl@v0.0.8


### PR DESCRIPTION
## Summary

GitHub deprecated Node.js 20 in runner images (forced to Node.js 24 by default starting June 2nd 2026). Every recent CI run has been emitting the deprecation warning across most jobs. This bumps each affected action to a version that publishes a Node.js 24 runtime, and pins the only mutable version reference (\`pkl-community/setup-pkl@v0\`) to a deterministic tag.

| Action | From | To |
|---|---|---|
| \`actions/checkout\` | v4 | v6 |
| \`actions/setup-go\` | v5 | v6 |
| \`aws-actions/configure-aws-credentials\` | v4 | v6 |
| \`actions/github-script\` | v7 | v9 |
| \`nick-fields/retry\` | v3 | v4 |
| \`slackapi/slack-github-action\` | v2.1.1 | v3.0.1 |
| \`pkl-community/setup-pkl\` | v0 (mutable) | v0.0.8 |

Bumping \`setup-go\` to v6 also typically clears the \`Failed to restore: /usr/bin/tar failed with exit code 2\` warning we've been seeing on every job — that was tar conflicting with the runner image's pre-installed Go toolchain during cache extraction.

Supersedes the four open dependabot PRs that covered \`configure-aws-credentials\`, \`retry\`, \`github-script\`, and \`slack-github-action\`. Will close those once this lands.