### PR TITLE
Switch to orbital-based distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+# © 2026 Platform Engineering Labs Inc.
+# SPDX-License-Identifier: FSL-1.1-ALv2
+
+name: release
+on:
+  push:
+    tags:
+      - '[0-9]*'
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          GH_TOKEN: ${{ secrets.HUB_DISPATCH_PAT }}
+        run: |
+          gh workflow run plugin-build.yml \
+            -R platform-engineering-labs/formae-actions \
+            --ref main \
+            -f plugin-name=aws \
+            -f plugin-repo=$GITHUB_REPOSITORY \
+            -f ref=$GITHUB_REF_NAME

--- a/Opkgfile
+++ b/Opkgfile
@@ -1,0 +1,39 @@
+/*
+ * © 2026 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "orbital:/opkg.pkl"
+
+import "orbital:/requirement.pkl"
+import "pkl:semver"
+import "./formae-plugin.pkl" as plugin
+
+name        = plugin.name
+version     = semver.Version(plugin.version)
+publisher   = read("env:OPS_PUBLISHER")
+originator  = read("env:OPS_ORIGINATOR")
+license     = plugin.license
+summary     = if (plugin.hasProperty("summary")) plugin.summary else plugin.name
+description = if (plugin.hasProperty("description")) plugin.description else plugin.summary
+
+requirements = new Listing<requirement.Requirement> {
+  new {
+    name     = "formae"
+    method   = "depends"
+    operator = "GTE"
+    version  = semver.Version(plugin.minFormaeVersion)
+  }
+}
+
+metadata {
+  ["display"] {
+    ["kind"]     = "plugin"
+    ["category"] = if (plugin.hasProperty("category")) plugin.category else "other"
+  }
+  ["plugin"] {
+    ["type"]      = if (plugin.hasProperty("type")) plugin.type else "resource"
+    ["namespace"] = plugin.namespace
+  }
+}

--- a/formae-plugin.pkl
+++ b/formae-plugin.pkl
@@ -7,7 +7,9 @@
 name = "aws"
 version = "0.1.5"
 namespace = "AWS"
+summary = "AWS resource plugin (CloudControl-based)"
 description = "AWS CloudControl resource plugin for Formae"
+category = "cloud"
 license = "FSL-1.1-ALv2"
 minFormaeVersion = "0.84.0"
 


### PR DESCRIPTION
## Summary

Migrates this plugin to the centralized build pipeline defined by RFC-0033 (orbital plugin distribution). The plugin is built and signed by `formae-actions/.github/workflows/plugin-build.yml`; this repo only needs:

- `Opkgfile` — the orbital package manifest, derived from `formae-plugin.pkl`.
- `formae-plugin.pkl` — `summary` + `category` fields added.
- `.github/workflows/release.yml` — a tag-push wrapper that dispatches the centralized build via the fine-grained `HUB_DISPATCH_PAT` secret.

The wrapper is inactive until the secret is added. Once the Hub GitHub App lands, this wrapper file is deleted entirely and dispatch comes from the App.

See:
- RFC-0033: https://github.com/platform-engineering-labs/rfcs/pull/13
- Forward-compat amendment (workflow_dispatch + allowlist + tag-only + SHA-pinning): in the formae repo at \`docs/superpowers/specs/2026-04-22-orbital-plugin-distribution-design.md\` and the engineering-notes mirror.

## Test plan

- [ ] Manually dispatch \`plugin-build.yml\` against this repo's existing tag (\`v0.1.5\`) once the \`community\` orbital repo and AWS IAM trust extension are in place.
- [ ] Verify the published opkg has \`originator = "platform.engineering"\`.
- [ ] Confirm \`formae plugin install aws\` resolves the published opkg from \`community/stable\`.

## Out of scope

- Plugin CI (\`ci.yml\`/\`nightly.yml\`) is left alone. The existing \`make install\` flow keeps working until orbital-distributed plugins are the canonical source. We'll revisit when needed.
- The \`HUB_DISPATCH_PAT\` repo secret will be set as part of the rollout.