### PR TITLE
fix(ec2): mark PlacementGroup.spreadLevel as hasProviderDefault

### DIFF
--- a/schema/pkl/ec2/placementgroup.pkl
+++ b/schema/pkl/ec2/placementgroup.pkl
@@ -20,7 +20,10 @@ open class PlacementGroup extends formae.Resource {
     @aws.FieldHint{createOnly = true}
     partitionCount: Int?
 
-    @aws.FieldHint{createOnly = true}
+    @aws.FieldHint{
+        createOnly = true
+        hasProviderDefault = true
+    }
     spreadLevel: String?
 
     @aws.FieldHint{createOnly = true}


### PR DESCRIPTION
## Summary

- Adds `hasProviderDefault = true` to `spreadLevel` on `AWS::EC2::PlacementGroup`. Resolves the conformance test failure on `ec2-placementgroup-replace.pkl`:

  ```
  [Replace] Property SpreadLevel is not expected and not a provider default (after replace)
  ```

- The replace fixture switches `strategy` from `spread` (with `spreadLevel = "rack"`) to `partition` (no `spreadLevel` set). After AWS creates the new partition placement group, CCAPI returns `SpreadLevel` populated as a default — the harness flags it because the fixture doesn't expect it and the field doesn't carry the hint.

- Field stays `createOnly`; its mutability semantics are independent of provider-default handling.