### PR TITLE
fix(ci): set up orbital tree skeleton before starting formae agent in nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -145,7 +145,15 @@ jobs:
           LATEST_TAG=$(git tag -l "[0-9]*" --sort=-version:refname | grep -v -- '-' | head -1)
           echo "Building formae with VERSION=${LATEST_TAG}"
           make build VERSION="${LATEST_TAG}"
-          echo "FORMAE_BINARY=/tmp/formae/formae" >> $GITHUB_ENV
+
+          # formae main expects an orbital tree at the path derived from the
+          # binary location (introduced in formae#bfeeb541 — orbital-based
+          # plugin distribution). `make build` only produces the binary; we
+          # have to lay out the tree skeleton ourselves. Mirrors the pattern
+          # used in formae's own e2e-tests workflow.
+          mkdir -p dist/bin dist/.ops
+          cp formae dist/bin/formae
+          echo "FORMAE_BINARY=/tmp/formae/dist/bin/formae" >> $GITHUB_ENV
 
       - name: Track formae clone
         if: env.POSTHOG_API_KEY != ''


### PR DESCRIPTION
## Summary

- Adds the orbital tree skeleton (`dist/bin/`, `dist/.ops/`) after `make build` in the nightly workflow's "Build formae" step. Resolves the wholesale conformance failure (~90 jobs in the matrix) where every entry hit:

  ```
  failed to start agent: timeout waiting for agent to become ready after 30s
  ```

  The actual agent stderr was:

  ```
  ERR Plugin manager initialization failed; refusing to start
  error="orbital tree not initialized at the path derived from the formae
         binary location; install formae via the orbital installer or set
         up an orbital tree manually"
  ```

- Introduced upstream in `formae#bfeeb541` (`feat: orbital-based plugin distribution`, 2026-04-29). The nightly builds formae from source, which produces only the binary — no orbital tree. The agent now refuses to start without one.

- Fix mirrors the pattern used in formae's own `.github/workflows/e2e-tests.yml`: after `make build`, `mkdir -p dist/bin dist/.ops` and `cp formae dist/bin/formae`. The orbital library treats `dist/` as the tree root because the binary lives at `dist/bin/formae`.

- CI is unaffected: it installs formae via `pelmgr install`, which sets up the orbital tree as part of the install. Only the build-from-source nightly path was broken.