### PR TITLE
fix(schema): annotate cloud-defaulted Lambda::LayerVersion fields

### DIFF
--- a/schema/pkl/lambda/layerversion.pkl
+++ b/schema/pkl/lambda/layerversion.pkl
@@ -25,10 +25,10 @@ open class Content extends formae.SubResource {
 }
 open class LayerVersion extends formae.Resource {
 
-    @aws.FieldHint{createOnly = true}
+    @aws.FieldHint{createOnly = true; hasProviderDefault = true}
     compatibleArchitectures: Listing<String>?
 
-    @aws.FieldHint{createOnly = true}
+    @aws.FieldHint{createOnly = true; hasProviderDefault = true}
     compatibleRuntimes: Listing<String>?
 
     @aws.FieldHint{
@@ -38,7 +38,7 @@ open class LayerVersion extends formae.Resource {
     }
     content: Content?
 
-    @aws.FieldHint{createOnly = true}
+    @aws.FieldHint{createOnly = true; hasProviderDefault = true}
     description: String?
 
     @aws.FieldHint{createOnly = true}


### PR DESCRIPTION
## Summary

- Annotates 3 fields on `AWS::Lambda::LayerVersion` as `hasProviderDefault = true`: `compatibleArchitectures`, `compatibleRuntimes`, `description`. AWS injects empty values for these on Read when the user omits them; without the annotation a no-op reapply would see PKL-absent vs cloud-empty as drift, and since every LayerVersion field is `createOnly`, schedule a destroy+create on every reapply.
- Follow-up to PR #60 (squash f8bcba4) which established the `hasProviderDefault` rubric. Same shape as the cycling-parent / Resolvable-consumer pattern (`ECS::TaskDefinition` ↔ `Service.taskDefinition`); here it's `Lambda::LayerVersion` ↔ `Function.layers[]`.

## Empirical verification

Created a minimal LayerVersion via `aws lambda publish-layer-version` (only `LayerName`, `CompatibleRuntimes`, `Content` set) and queried via `aws cloudcontrol get-resource`:

```json
{
  "LayerName": "formae-empirical-test",
  "LayerVersionArn": "arn:aws:lambda:us-east-1:...",
  "CompatibleRuntimes": ["python3.12"],
  "CompatibleArchitectures": [],
  "Description": ""
}
```

Decision per rubric:

| Field | Cloud Read returns | hasProviderDefault? |
|---|---|---|
| `compatibleArchitectures` | `[]` when unset | **add** |
| `compatibleRuntimes` | `[]` when unset (defensive — verified with user-set value, applied for symmetry with sibling list field) | **add** |
| `content` | not returned (writeOnly) | no change — already correct |
| `description` | `""` when unset | **add** |
| `layerName` | identity field | no change |
| `licenseInfo` | not returned when unset | no change — annotation unnecessary |

## Conformance test deferred

A paired `LayerVersion + Function` conformance test (mirroring the TaskDef + Service test from PR #60) requires an S3 object pre-staged for the LayerVersion's `Content` field — `Content` only accepts S3 references, not inline ZipFile. The AWS plugin doesn't yet model `AWS::S3::Object`, so there's no clean way to construct the test in pure PKL. Track as follow-up alongside any future `AWS::S3::Object` work.

The schema change here is small, defensive, and risk-bounded: adding `hasProviderDefault` only changes behavior for fields where AWS injects a default value — it's a strictly more permissive comparison. Verified by `make verify-schema`.