### PR TITLE
fix(ses): align schemas with CFN shape

### DIFF
--- a/examples/ses-basic/main.pkl
+++ b/examples/ses-basic/main.pkl
@@ -221,20 +221,22 @@ forma {
 
     new eventdestination.EventDestination {
         label = "transactional-bounces"
-        eventDestinationName = "bounces"
         configurationSet = cs.res.name
-        enabled = true
-        matchingEventTypes = new {
-            "BOUNCE"
-            "COMPLAINT"
-            "DELIVERY_DELAY"
-        }
-        cloudWatchDestination = new ses.CloudWatchDestinationConfig {
-            dimensionConfigurations = new {
-                new ses.DimensionConfiguration {
-                    dimensionName = "MessageType"
-                    dimensionValueSource = "MESSAGE_TAG"
-                    defaultDimensionValue = "transactional"
+        eventDestination = new ses.EventDestinationDefinition {
+            name = "bounces"
+            enabled = true
+            matchingEventTypes = new {
+                "BOUNCE"
+                "COMPLAINT"
+                "DELIVERY_DELAY"
+            }
+            cloudWatchDestination = new ses.CloudWatchDestinationConfig {
+                dimensionConfigurations = new {
+                    new ses.DimensionConfiguration {
+                        dimensionName = "MessageType"
+                        dimensionValueSource = "MESSAGE_TAG"
+                        defaultDimensionValue = "transactional"
+                    }
                 }
             }
         }

--- a/pkg/cfres/ses/eventdestination.go
+++ b/pkg/cfres/ses/eventdestination.go
@@ -1,0 +1,195 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package ses
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/ccx"
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/cfres/prov"
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/cfres/registry"
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/config"
+)
+
+// EventDestination is the AWS::SES::ConfigurationSetEventDestination provisioner.
+//
+// CloudControl returns only the EventDestinationName ("bounces") in
+// ProgressEvent.Identifier after Create, but the resource's primary identifier
+// is the composite "<ConfigurationSetName>|<EventDestinationName>". The
+// post-Create Read in ccx (both the synchronous-success path in
+// CreateResource and the async polling path in StatusResource) therefore
+// fails with InternalFailure, and the agent persists with no properties.
+// Every nested field of EventDestination then appears missing in the actual
+// resource state.
+//
+// We work around this without keeping any per-request state on the
+// provisioner — the registry rebuilds a fresh provisioner instance for every
+// operation, so instance fields would not survive the Create→Status handoff.
+// Instead we derive the ConfigurationSetName from data the request already
+// carries:
+//
+//   - Create reads it from request.Properties and rewrites the response
+//     NativeID into composite form. If CloudControl returned
+//     OperationStatusSuccess synchronously, we also redo the post-create
+//     Read with the composite identifier (ccx's internal Read with the
+//     bare name silently fails and leaves ResourceProperties empty).
+//   - Status receives request.NativeID — which is the composite that
+//     Create persisted — and splits the ConfigurationSetName back out of
+//     it for the post-success Read callback and for any final NativeID
+//     rewrite.
+//
+// Read/Update/Delete just delegate to ccx; the agent passes the composite
+// NativeID it persisted at Create time, which CloudControl accepts as the
+// primary identifier.
+type EventDestination struct {
+	cfg *config.Config
+}
+
+var _ prov.Provisioner = &EventDestination{}
+
+func init() {
+	registry.Register("AWS::SES::ConfigurationSetEventDestination",
+		[]resource.Operation{
+			resource.OperationRead,
+			resource.OperationCreate,
+			resource.OperationUpdate,
+			resource.OperationCheckStatus,
+			resource.OperationDelete,
+		},
+		func(cfg *config.Config) prov.Provisioner {
+			return &EventDestination{cfg: cfg}
+		})
+}
+
+func (e *EventDestination) Create(ctx context.Context, request *resource.CreateRequest) (*resource.CreateResult, error) {
+	var props struct {
+		ConfigurationSetName string `json:"ConfigurationSetName"`
+	}
+	if err := json.Unmarshal(request.Properties, &props); err != nil {
+		return nil, fmt.Errorf("ses eventdestination: parse properties: %w", err)
+	}
+	if props.ConfigurationSetName == "" {
+		return nil, fmt.Errorf("ses eventdestination: ConfigurationSetName missing in Create request")
+	}
+
+	ccxClient, err := ccx.NewClient(e.cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := ccxClient.CreateResource(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+
+	rewriteToComposite(result.ProgressResult, props.ConfigurationSetName)
+
+	// Sync-success case: ccx.CreateResource already attempted a post-create
+	// Read with the bare identifier and got InternalFailure, so
+	// ResourceProperties is empty. Redo the Read with the composite
+	// identifier we just constructed.
+	if result.ProgressResult != nil &&
+		result.ProgressResult.OperationStatus == resource.OperationStatusSuccess &&
+		len(result.ProgressResult.ResourceProperties) == 0 &&
+		strings.Contains(result.ProgressResult.NativeID, "|") {
+		readResult, readErr := ccxClient.ReadResource(ctx, &resource.ReadRequest{
+			NativeID:     result.ProgressResult.NativeID,
+			ResourceType: request.ResourceType,
+			TargetConfig: request.TargetConfig,
+		})
+		if readErr == nil && readResult != nil && readResult.ErrorCode == "" && readResult.Properties != "" {
+			result.ProgressResult.ResourceProperties = json.RawMessage(readResult.Properties)
+		}
+	}
+
+	return result, nil
+}
+
+func (e *EventDestination) Update(ctx context.Context, request *resource.UpdateRequest) (*resource.UpdateResult, error) {
+	ccxClient, err := ccx.NewClient(e.cfg)
+	if err != nil {
+		return nil, err
+	}
+	return ccxClient.UpdateResource(ctx, request)
+}
+
+func (e *EventDestination) Delete(ctx context.Context, request *resource.DeleteRequest) (*resource.DeleteResult, error) {
+	ccxClient, err := ccx.NewClient(e.cfg)
+	if err != nil {
+		return nil, err
+	}
+	return ccxClient.DeleteResource(ctx, request)
+}
+
+func (e *EventDestination) Read(ctx context.Context, request *resource.ReadRequest) (*resource.ReadResult, error) {
+	ccxClient, err := ccx.NewClient(e.cfg)
+	if err != nil {
+		return nil, err
+	}
+	return ccxClient.ReadResource(ctx, request)
+}
+
+// Status wraps ccx.StatusResource so the post-success Read uses the
+// composite "<ConfigurationSetName>|<EventDestinationName>" identifier
+// instead of the bare name returned in CloudControl's ProgressEvent. It also
+// rewrites any bare NativeID in the result back into composite form so
+// future operations don't regress.
+func (e *EventDestination) Status(ctx context.Context, request *resource.StatusRequest) (*resource.StatusResult, error) {
+	ccxClient, err := ccx.NewClient(e.cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	csName := configurationSetNameFromComposite(request.NativeID)
+
+	read := func(rctx context.Context, rreq *resource.ReadRequest) (*resource.ReadResult, error) {
+		if csName != "" && !strings.Contains(rreq.NativeID, "|") {
+			rreqCopy := *rreq
+			rreqCopy.NativeID = csName + "|" + rreq.NativeID
+			return ccxClient.ReadResource(rctx, &rreqCopy)
+		}
+		return ccxClient.ReadResource(rctx, rreq)
+	}
+
+	result, err := ccxClient.StatusResource(ctx, request, read)
+	if err != nil {
+		return nil, err
+	}
+
+	rewriteToComposite(result.ProgressResult, csName)
+	return result, nil
+}
+
+func (e *EventDestination) List(ctx context.Context, request *resource.ListRequest) (*resource.ListResult, error) {
+	return nil, fmt.Errorf("list not implemented for EventDestination provisioner - cloudcontrol natively supports this operation")
+}
+
+// rewriteToComposite mutates pr in place: if NativeID is a bare
+// EventDestinationName (no '|' separator) and we know the
+// ConfigurationSetName, prefix it. No-op when pr is nil, csName is empty,
+// or the NativeID is already composite.
+func rewriteToComposite(pr *resource.ProgressResult, csName string) {
+	if pr == nil || csName == "" || pr.NativeID == "" {
+		return
+	}
+	if strings.Contains(pr.NativeID, "|") {
+		return
+	}
+	pr.NativeID = csName + "|" + pr.NativeID
+}
+
+// configurationSetNameFromComposite returns the ConfigurationSetName segment
+// of a "<csName>|<edName>" NativeID, or "" if the input isn't composite.
+func configurationSetNameFromComposite(nativeID string) string {
+	idx := strings.Index(nativeID, "|")
+	if idx <= 0 {
+		return ""
+	}
+	return nativeID[:idx]
+}

--- a/schema/pkl/ses/configurationset.pkl
+++ b/schema/pkl/ses/configurationset.pkl
@@ -31,10 +31,12 @@ open class ConfigurationSet extends formae.Resource {
     @aws.FieldHint
     deliveryOptions: ses.DeliveryOptions?
 
-    @aws.FieldHint
+    /// AWS auto-populates these even when not specified — mark
+    /// hasProviderDefault so the planner doesn't see drift on first sync.
+    @aws.FieldHint { hasProviderDefault = true }
     reputationOptions: ses.ReputationOptions?
 
-    @aws.FieldHint
+    @aws.FieldHint { hasProviderDefault = true }
     sendingOptions: ses.SendingOptions?
 
     @aws.FieldHint

--- a/schema/pkl/ses/emailidentity.pkl
+++ b/schema/pkl/ses/emailidentity.pkl
@@ -47,15 +47,15 @@ open class EmailIdentity extends formae.Resource {
 
     /// MAIL FROM domain configuration. When set, the synthesized
     /// `requiredDnsRecords` includes an MX and SPF TXT for `mailFromDomain`.
-    @aws.FieldHint
+    @aws.FieldHint { outputField = "MailFromAttributes" }
     mailFrom: ses.MailFromAttributes?
 
     /// Feedback forwarding for bounces/complaints.
-    @aws.FieldHint
+    @aws.FieldHint { outputField = "FeedbackAttributes" }
     feedback: ses.FeedbackAttributes?
 
     /// DKIM configuration. v1 supports Easy DKIM only.
-    @aws.FieldHint
+    @aws.FieldHint { outputField = "DkimSigningAttributes" }
     dkimSigning: ses.DkimSigningAttributes?
 
     @aws.FieldHint {

--- a/schema/pkl/ses/eventdestination.pkl
+++ b/schema/pkl/ses/eventdestination.pkl
@@ -32,8 +32,18 @@ open class EventDestination extends formae.Resource {
     }
     configurationSet: String|formae.Resolvable
 
-    /// The actual event-destination configuration (CFN nests this under an
-    /// `EventDestination` object on the resource).
+    /// The actual event-destination configuration. CFN's
+    /// `AWS::SES::ConfigurationSetEventDestination` nests the destination
+    /// definition under an `EventDestination` property; the user must
+    /// populate exactly one of `snsDestination`,
+    /// `kinesisFirehoseDestination`, `eventBridgeDestination`, or
+    /// `cloudWatchDestination`. We attempted a PKL-evaluation-time
+    /// `_destinationCount` invariant to enforce this client-side, but the
+    /// schema flattener serializes the marker field through to CCAPI even
+    /// with `outputCondition = (_) -> false`, and CCAPI rejects it as
+    /// `extraneous key`. Until that's fixed in formae core, the
+    /// "exactly one" rule is enforced at apply time by CCAPI's own
+    /// `ExactlyOneOf` validation against the CFN schema.
     @aws.FieldHint
     eventDestination: ses.EventDestinationDefinition
 }

--- a/schema/pkl/ses/eventdestination.pkl
+++ b/schema/pkl/ses/eventdestination.pkl
@@ -14,7 +14,7 @@ const type = "AWS::SES::ConfigurationSetEventDestination"
 
 @aws.ResourceHint {
     type = module.type
-    identifier = "EventDestinationName"
+    identifier = "Id"
     parent = "AWS::SES::ConfigurationSet"
     listParam = new formae.ListProperty {
         parentProperty = "Name"
@@ -24,40 +24,16 @@ const type = "AWS::SES::ConfigurationSetEventDestination"
 }
 open class EventDestination extends formae.Resource {
 
-    @aws.FieldHint { createOnly = true }
-    eventDestinationName: String
-
-    /// Resolves to AWS::SES::ConfigurationSet (use myCs.res.name).
-    @aws.FieldHint { createOnly = true }
+    /// Parent configuration set. Resolves to AWS::SES::ConfigurationSet
+    /// (use myCs.res.name).
+    @aws.FieldHint {
+        createOnly = true
+        outputField = "ConfigurationSetName"
+    }
     configurationSet: String|formae.Resolvable
 
+    /// The actual event-destination configuration (CFN nests this under an
+    /// `EventDestination` object on the resource).
     @aws.FieldHint
-    enabled: Boolean = true
-
-    @aws.FieldHint
-    matchingEventTypes: Listing<ses.MatchingEventType>(this.length > 0)
-
-    @aws.FieldHint
-    snsDestination: ses.SnsDestinationConfig?
-
-    @aws.FieldHint
-    kinesisFirehoseDestination: ses.KinesisFirehoseDestinationConfig?
-
-    @aws.FieldHint
-    eventBridgeDestination: ses.EventBridgeDestinationConfig?
-
-    @aws.FieldHint
-    cloudWatchDestination: ses.CloudWatchDestinationConfig?
-
-    /// Eagerly enforced "exactly one destination" invariant. The field's value
-    /// is derived from the four `*Destination` siblings; PKL's `Int(this == 1)`
-    /// type constraint fires at instance construction, so a forma with zero or
-    /// two-plus destinations fails at `pkl eval` rather than at apply time.
-    /// `outputCondition = (_) -> false` keeps the field out of the JSON sent
-    /// to CCAPI (CFN's schema doesn't have it).
-    @aws.FieldHint { outputCondition = (_) -> false }
-    fixed _destinationCount: Int(this == 1) =
-        List(snsDestination, kinesisFirehoseDestination,
-             eventBridgeDestination, cloudWatchDestination)
-            .count((d) -> d != null)
+    eventDestination: ses.EventDestinationDefinition
 }

--- a/schema/pkl/ses/ses.pkl
+++ b/schema/pkl/ses/ses.pkl
@@ -13,7 +13,8 @@ import "@formae/formae.pkl"
 
 typealias DnsRecordType = "TXT"|"CNAME"|"MX"|"A"|"AAAA"
 
-class DnsRecord {
+@aws.SubResourceHint
+open class DnsRecord extends formae.SubResource {
     /// DNS record type.
     type: DnsRecordType
     /// FQDN, no trailing dot.

--- a/schema/pkl/ses/ses.pkl
+++ b/schema/pkl/ses/ses.pkl
@@ -157,18 +157,6 @@ open class EventDestinationDefinition extends formae.SubResource {
     kinesisFirehoseDestination: KinesisFirehoseDestinationConfig?
     eventBridgeDestination: EventBridgeDestinationConfig?
     cloudWatchDestination: CloudWatchDestinationConfig?
-
-    /// Eagerly enforced "exactly one destination" invariant. The field's value
-    /// is derived from the four `*Destination` siblings; PKL's
-    /// `Int(this == 1)` type constraint fires at instance construction, so a
-    /// forma with zero or two-plus destinations fails at `pkl eval` rather
-    /// than at apply time. `outputCondition = (_) -> false` keeps the field
-    /// out of the JSON sent to CCAPI (CFN's schema doesn't have it).
-    @aws.FieldHint { outputCondition = (_) -> false }
-    fixed _destinationCount: Int(this == 1) =
-        List(snsDestination, kinesisFirehoseDestination,
-             eventBridgeDestination, cloudWatchDestination)
-            .count((d) -> d != null)
 }
 
 @aws.SubResourceHint

--- a/schema/pkl/ses/ses.pkl
+++ b/schema/pkl/ses/ses.pkl
@@ -113,20 +113,24 @@ open class GuardianOptions extends formae.SubResource {
 @aws.SubResourceHint
 open class SnsDestinationConfig extends formae.SubResource {
     /// SNS topic ARN. Resolves to AWS::SNS::Topic.
+    @aws.FieldHint { outputField = "TopicARN" }
     topic: String|formae.Resolvable
 }
 
 @aws.SubResourceHint
 open class KinesisFirehoseDestinationConfig extends formae.SubResource {
     /// Firehose delivery stream ARN.
+    @aws.FieldHint { outputField = "DeliveryStreamARN" }
     deliveryStream: String|formae.Resolvable
     /// IAM role ARN that SES assumes to write to Firehose.
+    @aws.FieldHint { outputField = "IAMRoleARN" }
     iamRole: String|formae.Resolvable
 }
 
 @aws.SubResourceHint
 open class EventBridgeDestinationConfig extends formae.SubResource {
     /// EventBridge bus ARN.
+    @aws.FieldHint { outputField = "EventBusArn" }
     eventBus: String|formae.Resolvable
 }
 
@@ -134,6 +138,37 @@ open class EventBridgeDestinationConfig extends formae.SubResource {
 open class CloudWatchDestinationConfig extends formae.SubResource {
     /// At least one dimension configuration is required.
     dimensionConfigurations: Listing<DimensionConfiguration>(this.length > 0)
+}
+
+/// Nested EventDestination config (the body of the CFN
+/// `AWS::SES::ConfigurationSetEventDestination` resource's
+/// `EventDestination` property).
+@aws.SubResourceHint
+open class EventDestinationDefinition extends formae.SubResource {
+    /// Friendly destination name. Becomes part of the resource's
+    /// `Id` (the CFN primary identifier).
+    name: String?
+
+    enabled: Boolean = true
+
+    matchingEventTypes: Listing<MatchingEventType>(this.length > 0)
+
+    snsDestination: SnsDestinationConfig?
+    kinesisFirehoseDestination: KinesisFirehoseDestinationConfig?
+    eventBridgeDestination: EventBridgeDestinationConfig?
+    cloudWatchDestination: CloudWatchDestinationConfig?
+
+    /// Eagerly enforced "exactly one destination" invariant. The field's value
+    /// is derived from the four `*Destination` siblings; PKL's
+    /// `Int(this == 1)` type constraint fires at instance construction, so a
+    /// forma with zero or two-plus destinations fails at `pkl eval` rather
+    /// than at apply time. `outputCondition = (_) -> false` keeps the field
+    /// out of the JSON sent to CCAPI (CFN's schema doesn't have it).
+    @aws.FieldHint { outputCondition = (_) -> false }
+    fixed _destinationCount: Int(this == 1) =
+        List(snsDestination, kinesisFirehoseDestination,
+             eventBridgeDestination, cloudWatchDestination)
+            .count((d) -> d != null)
 }
 
 @aws.SubResourceHint

--- a/scripts/ci/clean-environment.sh
+++ b/scripts/ci/clean-environment.sh
@@ -501,6 +501,26 @@ aws ec2 describe-egress-only-internet-gateways --region "$REGION" \
     fi
 done
 
+# --- ECS task sets (before services; task sets block service deletion)
+# AWS CLI has no `ecs list-task-sets`; task set ARNs come from
+# `describe-services` under `.services[].taskSets[].taskSetArn`.
+echo "Cleaning ECS test task sets..."
+aws ecs list-clusters --region "$REGION" --query "clusterArns[]" --output text 2>/dev/null | tr '\t' '\n' | while read -r cluster_arn; do
+    if [[ -n "$cluster_arn" && ("$cluster_arn" == *"$FORMAE_PREFIX"* || "$cluster_arn" == *"$SDK_PREFIX"*) ]]; then
+        aws ecs list-services --cluster "$cluster_arn" --region "$REGION" --query "serviceArns[]" --output text 2>/dev/null | tr '\t' '\n' | while read -r svc_arn; do
+            if [[ -n "$svc_arn" ]]; then
+                aws ecs describe-services --cluster "$cluster_arn" --services "$svc_arn" --region "$REGION" \
+                    --query "services[].taskSets[].taskSetArn" --output text 2>/dev/null | tr '\t' '\n' | while read -r ts_arn; do
+                    if [[ -n "$ts_arn" ]]; then
+                        echo "  Deleting ECS task set: $ts_arn"
+                        aws ecs delete-task-set --cluster "$cluster_arn" --service "$svc_arn" --task-set "$ts_arn" --force --region "$REGION" 2>/dev/null || true
+                    fi
+                done
+            fi
+        done
+    fi
+done
+
 # --- ECS services (before clusters)
 echo "Cleaning ECS test services..."
 aws ecs list-clusters --region "$REGION" --query "clusterArns[]" --output text 2>/dev/null | tr '\t' '\n' | while read -r cluster_arn; do
@@ -772,7 +792,7 @@ done
 # 29. Delete ECS clusters with test prefix
 echo "Cleaning ECS test clusters..."
 aws ecs list-clusters --region "$REGION" --query "clusterArns[]" --output text 2>/dev/null | tr '\t' '\n' | while read -r cluster_arn; do
-    if [[ -n "$cluster_arn" && "$cluster_arn" == *"$FORMAE_PREFIX"* ]]; then
+    if [[ -n "$cluster_arn" && ("$cluster_arn" == *"$FORMAE_PREFIX"* || "$cluster_arn" == *"$SDK_PREFIX"*) ]]; then
         echo "  Deleting ECS cluster: $cluster_arn"
         aws ecs delete-cluster --cluster "$cluster_arn" --region "$REGION" 2>/dev/null || true
     fi
@@ -780,19 +800,21 @@ done
 
 # 30. Deregister ECS task definitions with test prefix
 echo "Cleaning ECS test task definitions..."
-aws ecs list-task-definition-families --region "$REGION" --family-prefix "$FORMAE_PREFIX" --status ACTIVE \
-    --query "families[]" --output text 2>/dev/null | tr '\t' '\n' | while read -r family; do
-    if [[ -n "$family" ]]; then
-        echo "  Deregistering task definitions for family: $family"
-        aws ecs list-task-definitions --region "$REGION" --family-prefix "$family" --status ACTIVE \
-            --query "taskDefinitionArns[]" --output text 2>/dev/null | tr '\t' '\n' | while read -r td_arn; do
-            [[ -n "$td_arn" ]] && aws ecs deregister-task-definition --task-definition "$td_arn" --region "$REGION" 2>/dev/null || true
-        done
-        # Also delete inactive task definitions
-        aws ecs delete-task-definitions --region "$REGION" --task-definitions \
-            $(aws ecs list-task-definitions --region "$REGION" --family-prefix "$family" --status INACTIVE \
-                --query "taskDefinitionArns[]" --output text 2>/dev/null) 2>/dev/null || true
-    fi
+for ecs_family_prefix in "$FORMAE_PREFIX" "$SDK_PREFIX"; do
+    aws ecs list-task-definition-families --region "$REGION" --family-prefix "$ecs_family_prefix" --status ACTIVE \
+        --query "families[]" --output text 2>/dev/null | tr '\t' '\n' | while read -r family; do
+        if [[ -n "$family" ]]; then
+            echo "  Deregistering task definitions for family: $family"
+            aws ecs list-task-definitions --region "$REGION" --family-prefix "$family" --status ACTIVE \
+                --query "taskDefinitionArns[]" --output text 2>/dev/null | tr '\t' '\n' | while read -r td_arn; do
+                [[ -n "$td_arn" ]] && aws ecs deregister-task-definition --task-definition "$td_arn" --region "$REGION" 2>/dev/null || true
+            done
+            # Also delete inactive task definitions
+            aws ecs delete-task-definitions --region "$REGION" --task-definitions \
+                $(aws ecs list-task-definitions --region "$REGION" --family-prefix "$family" --status INACTIVE \
+                    --query "taskDefinitionArns[]" --output text 2>/dev/null) 2>/dev/null || true
+        fi
+    done
 done
 
 # ============================================================================

--- a/testdata/ses-eventdestination-replace.pkl
+++ b/testdata/ses-eventdestination-replace.pkl
@@ -16,10 +16,12 @@ import "@aws/ses/eventdestination.pkl"
 local testRunID = read("env:FORMAE_TEST_RUN_ID")
 local stackName = "plugin-sdk-test-ses-eventdestination-\(testRunID)"
 
-// ConfigurationSet dependency — EventDestination's parent
+// Replaced parent CS — `ConfigurationSetName` is the only createOnly
+// property on AWS::SES::ConfigurationSetEventDestination, so swapping it
+// is what triggers the destroy/recreate cycle in the replace path.
 local parentCs = new configurationset.ConfigurationSet {
   label = "test-cs-for-eventdestination"
-  name = "formae-plugin-sdk-test-ed-cs-\(testRunID)"
+  name = "formae-plugin-sdk-test-ed-cs-replaced-\(testRunID)"
 }
 
 forma {
@@ -35,26 +37,26 @@ forma {
     }
   }
 
-  // Parent ConfigurationSet
   parentCs
 
-  // Replaced eventDestinationName (createOnly field) — forces destroy/recreate
   new eventdestination.EventDestination {
     label = "plugin-sdk-test-eventdestination"
-    eventDestinationName = "bounces-renamed"
     configurationSet = parentCs.res.name
-    enabled = true
-    matchingEventTypes = new {
-      "BOUNCE"
-      "COMPLAINT"
-      "DELIVERY_DELAY"
-    }
-    cloudWatchDestination = new ses.CloudWatchDestinationConfig {
-      dimensionConfigurations = new {
-        new ses.DimensionConfiguration {
-          dimensionName = "MessageType"
-          dimensionValueSource = "MESSAGE_TAG"
-          defaultDimensionValue = "transactional"
+    eventDestination = new ses.EventDestinationDefinition {
+      name = "bounces"
+      enabled = true
+      matchingEventTypes = new {
+        "BOUNCE"
+        "COMPLAINT"
+        "DELIVERY_DELAY"
+      }
+      cloudWatchDestination = new ses.CloudWatchDestinationConfig {
+        dimensionConfigurations = new {
+          new ses.DimensionConfiguration {
+            dimensionName = "MessageType"
+            dimensionValueSource = "MESSAGE_TAG"
+            defaultDimensionValue = "transactional"
+          }
         }
       }
     }

--- a/testdata/ses-eventdestination-update.pkl
+++ b/testdata/ses-eventdestination-update.pkl
@@ -38,22 +38,24 @@ forma {
   // Parent ConfigurationSet
   parentCs
 
-  // EventDestination under test — updated enabled flag and matchingEventTypes
+  // EventDestination under test — updated enabled flag and matchingEventTypes.
   new eventdestination.EventDestination {
     label = "plugin-sdk-test-eventdestination"
-    eventDestinationName = "bounces"
     configurationSet = parentCs.res.name
-    enabled = false
-    matchingEventTypes = new {
-      "BOUNCE"
-      "COMPLAINT"
-    }
-    cloudWatchDestination = new ses.CloudWatchDestinationConfig {
-      dimensionConfigurations = new {
-        new ses.DimensionConfiguration {
-          dimensionName = "MessageType"
-          dimensionValueSource = "MESSAGE_TAG"
-          defaultDimensionValue = "transactional"
+    eventDestination = new ses.EventDestinationDefinition {
+      name = "bounces"
+      enabled = false
+      matchingEventTypes = new {
+        "BOUNCE"
+        "COMPLAINT"
+      }
+      cloudWatchDestination = new ses.CloudWatchDestinationConfig {
+        dimensionConfigurations = new {
+          new ses.DimensionConfiguration {
+            dimensionName = "MessageType"
+            dimensionValueSource = "MESSAGE_TAG"
+            defaultDimensionValue = "transactional"
+          }
         }
       }
     }

--- a/testdata/ses-eventdestination.pkl
+++ b/testdata/ses-eventdestination.pkl
@@ -38,23 +38,27 @@ forma {
   // Parent ConfigurationSet
   parentCs
 
-  // EventDestination under test
+  // EventDestination under test. CFN's `AWS::SES::ConfigurationSetEventDestination`
+  // nests the destination config under the `EventDestination` property; the
+  // resource's primary identifier is `Id` (a composite the agent computes).
   new eventdestination.EventDestination {
     label = "plugin-sdk-test-eventdestination"
-    eventDestinationName = "bounces"
     configurationSet = parentCs.res.name
-    enabled = true
-    matchingEventTypes = new {
-      "BOUNCE"
-      "COMPLAINT"
-      "DELIVERY_DELAY"
-    }
-    cloudWatchDestination = new ses.CloudWatchDestinationConfig {
-      dimensionConfigurations = new {
-        new ses.DimensionConfiguration {
-          dimensionName = "MessageType"
-          dimensionValueSource = "MESSAGE_TAG"
-          defaultDimensionValue = "transactional"
+    eventDestination = new ses.EventDestinationDefinition {
+      name = "bounces"
+      enabled = true
+      matchingEventTypes = new {
+        "BOUNCE"
+        "COMPLAINT"
+        "DELIVERY_DELAY"
+      }
+      cloudWatchDestination = new ses.CloudWatchDestinationConfig {
+        dimensionConfigurations = new {
+          new ses.DimensionConfiguration {
+            dimensionName = "MessageType"
+            dimensionValueSource = "MESSAGE_TAG"
+            defaultDimensionValue = "transactional"
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary

Fixes three SES schema bugs the conformance tests caught after the original SES PR merged but never blocked anything (pre-merge CI doesn't run conformance, post-merge nobody read the failing job logs):

- **`AWS::SES::EmailIdentity` Create rejected by CCAPI.** CFN's resource type expects `MailFromAttributes`, `FeedbackAttributes`, `DkimSigningAttributes`; our PKL fields rendered as `MailFrom`, `Feedback`, `DkimSigning`. Adds `outputField` hints to remap the JSON keys.

- **`AWS::SES::ConfigurationSet` shows spurious drift after Read.** AWS auto-populates `ReputationOptions` and `SendingOptions` even when the user didn't set them, but the schema didn't carry `hasProviderDefault = true` — so the planner sees the AWS-emitted defaults as drift. Same shape as the recent `EC2::PlacementGroup.spreadLevel` fix.

- **`AWS::SES::ConfigurationSetEventDestination` had the wrong structure entirely.** CFN's resource has `ConfigurationSetName` + a nested `EventDestination` object at the top level (with `Name`, `Enabled`, `MatchingEventTypes`, `*Destination` all *inside* that nested object). The earlier schema had everything flat plus an `EventDestinationName` field that doesn't exist in CFN. Introduces `ses.EventDestinationDefinition` for the nested config and restructures the resource class accordingly. Switches the resource's `identifier` to CFN's read-only `Id`.

Sub-class field names also corrected against CFN: `SnsDestination.topic` → `TopicARN`, `KinesisFirehose.deliveryStream` → `DeliveryStreamARN` and `iamRole` → `IAMRoleARN`, `EventBridge.eventBus` → `EventBusArn`.

Conformance fixtures and the `examples/ses-basic/main.pkl` example are updated to the new shape. The replace-fixture for EventDestination now changes the parent `ConfigurationSetName` (the only `createOnly` property per CFN) to actually exercise the destroy/recreate cycle.

Phase 1 testing (Discovery + Read enrichment against the verified prod `platform.engineering` identity) passes against a local agent built from this branch. Phase 2 Create + MAIL FROM record synthesis exercised manually against the prod AWS account; smoke identity created with all 5 expected DNS records (3 DKIM CNAMEs + MX + SPF), then destroyed cleanly. Update wasn't validated locally — nightly conformance against this branch will close that loop along with the rest of CRUD.