### PR TITLE
feat(ecs): re-add attachesTo on Service backend-attachment fields + create-race retry

### DIFF
--- a/formae-plugin.pkl
+++ b/formae-plugin.pkl
@@ -5,7 +5,7 @@
  */
 
 name = "aws"
-version = "0.1.7"
+version = "0.1.8-dev.0"
 namespace = "AWS"
 summary = "AWS resource plugin (CloudControl-based)"
 description = "AWS CloudControl resource plugin for Formae"

--- a/go.mod
+++ b/go.mod
@@ -16,14 +16,13 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3control v1.68.1
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.36.1
 	github.com/aws/aws-sdk-go-v2/service/sesv2 v1.60.4
-	github.com/aws/aws-sdk-go-v2/service/sns v1.39.17
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.23
 	github.com/aws/aws-sdk-go-v2/service/sts v1.42.0
 	github.com/aws/smithy-go v1.25.1
 	github.com/google/uuid v1.6.0
-	github.com/platform-engineering-labs/formae/pkg/model v0.1.23
-	github.com/platform-engineering-labs/formae/pkg/plugin v0.2.2-0.20260425033718-2ccb40eaf779
-	github.com/platform-engineering-labs/formae/pkg/plugin-conformance-tests v0.2.3-0.20260424201437-d7edc93ccc9f
+	github.com/platform-engineering-labs/formae/pkg/model v0.1.24
+	github.com/platform-engineering-labs/formae/pkg/plugin v0.2.2
+	github.com/platform-engineering-labs/formae/pkg/plugin-conformance-tests v0.2.4
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,6 @@ github.com/aws/aws-sdk-go-v2/service/sesv2 v1.60.4 h1:X/PtmuX/EwPivJ9lHCf3Auo8Ak
 github.com/aws/aws-sdk-go-v2/service/sesv2 v1.60.4/go.mod h1:l5cTwZSX9kzxDHz9IpgZC0XIJ/cc43JL6hZzCd0iTwI=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.10 h1:a1Fq/KXn75wSzoJaPQTgZO0wHGqE9mjFnylnqEPTchA=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.10/go.mod h1:p6+MXNxW7IA6dMgHfTAzljuwSKD0NCm/4lbS4t6+7vI=
-github.com/aws/aws-sdk-go-v2/service/sns v1.39.17 h1:synXIPC/L4Cc489P0XDcrVJzHSLj7krKRpFLalbGM2k=
-github.com/aws/aws-sdk-go-v2/service/sns v1.39.17/go.mod h1:4ABZnI23uNK37waIjGwkubnCwGhepIt9x1GvASfljJA=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.42.23 h1:Rw3+8VaLH0jozccNR52bSvCPYtkiQeNn576l7HCHvL0=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.42.23/go.mod h1:MdjRkQEd2EUOiifYnkg/6f1NGtZSN3dFOLNByzufXok=
 github.com/aws/aws-sdk-go-v2/service/sso v1.30.16 h1:x6bKbmDhsgSZwv6q19wY/u3rLk/3FGjJWyqKcIRufpE=
@@ -126,12 +124,12 @@ github.com/naegelejd/go-acl v0.0.0-20260323030528-42e4d61407df h1:1xWk/De6cs3h2r
 github.com/naegelejd/go-acl v0.0.0-20260323030528-42e4d61407df/go.mod h1:sTJHuiEPB0WNdPYPOP9M6FQU4YTHemXgDLIQqkbBdDI=
 github.com/platform-engineering-labs/formae/pkg/api/model v0.1.1 h1:ZMTgKwSomy2cVcl/+NivSqopbWeHbmYeQ+BxoYq8bVY=
 github.com/platform-engineering-labs/formae/pkg/api/model v0.1.1/go.mod h1:0ncHFCsGA6b0w1kBm6m+QwJ823qAY2vL47GvoR0BTyU=
-github.com/platform-engineering-labs/formae/pkg/model v0.1.23 h1:vn1Zifj9IgPew36LQXxQ0HHxf5iQT4DXulhcwf7Nys4=
-github.com/platform-engineering-labs/formae/pkg/model v0.1.23/go.mod h1:XmGJA7jNPX9cEGc8TxTiEDitBuEVJOddNakdTZ/bH4U=
-github.com/platform-engineering-labs/formae/pkg/plugin v0.2.2-0.20260425033718-2ccb40eaf779 h1:aSrjp0GjbYSgJMEbeVGvPe8OLCtX/JNh/z+EzGek4eM=
-github.com/platform-engineering-labs/formae/pkg/plugin v0.2.2-0.20260425033718-2ccb40eaf779/go.mod h1:78S5dbEGcJnOTifi/2pnHNw0JEGTD9x6eYWsntkWBFo=
-github.com/platform-engineering-labs/formae/pkg/plugin-conformance-tests v0.2.3-0.20260424201437-d7edc93ccc9f h1:2PL9AuAIeAMevJsdRedM2LEIs+SLHrfNxos6qPbR0zk=
-github.com/platform-engineering-labs/formae/pkg/plugin-conformance-tests v0.2.3-0.20260424201437-d7edc93ccc9f/go.mod h1:gq591ZeRZ4jAHpdSvCyrOvi8qyALxcXQQhd0B6GRMAo=
+github.com/platform-engineering-labs/formae/pkg/model v0.1.24 h1:FZH3m0zlkXSJMYRy23jZrJPdYv1+6yOxCS5NDHAjNQU=
+github.com/platform-engineering-labs/formae/pkg/model v0.1.24/go.mod h1:1dmsFwoaJZkHevBsAIZr068CWzG7de1VNz7PFWvM3Z8=
+github.com/platform-engineering-labs/formae/pkg/plugin v0.2.2 h1:woOwbsEk9y9LL2xyPurtkUAB/1gB9nCekLBvgc8E9P8=
+github.com/platform-engineering-labs/formae/pkg/plugin v0.2.2/go.mod h1:rQwaELhpPX042nqpB0n9XcTnyRMnWWp+CJWlOSX5eVA=
+github.com/platform-engineering-labs/formae/pkg/plugin-conformance-tests v0.2.4 h1:7Ww45TQ3sNNQVwMiEMPKles+HCXZLJRSVjgMJZMj0sQ=
+github.com/platform-engineering-labs/formae/pkg/plugin-conformance-tests v0.2.4/go.mod h1:gq591ZeRZ4jAHpdSvCyrOvi8qyALxcXQQhd0B6GRMAo=
 github.com/platform-engineering-labs/orbital v0.1.36 h1:nPMLxDbwDrjlhJoMQXAE86HtVhQHC2A6BJlWYmNM75c=
 github.com/platform-engineering-labs/orbital v0.1.36/go.mod h1:wwVPqOmW5RO78dDzL/G5CN1Ioao0P/aUsOZVrPVx64s=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=

--- a/pkg/ccx/client.go
+++ b/pkg/ccx/client.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"regexp"
 	"strings"
 	"time"
 
@@ -25,6 +26,13 @@ import (
 	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/ptr"
 	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/status"
 )
+
+// tgNotAssociatedPattern matches the AWS error surfaced when an ECS service
+// is created before its target group has been wired to a load balancer
+// (F-11). Combined with HandlerErrorCodeInvalidRequest in StatusResource,
+// this turns the error into a "keep polling" signal so the PluginOperator's
+// existing retry budget can absorb the race.
+var tgNotAssociatedPattern = regexp.MustCompile(`(?i)target group .* does not have an associated load balancer`)
 
 // cloudControlAPI defines the CloudControl operations used by Client.
 type cloudControlAPI interface {
@@ -338,6 +346,18 @@ func (c *Client) StatusResource(ctx context.Context, request *resource.StatusReq
 	// in AWS's control plane. Treat as InProgress to keep polling rather than
 	// retrying the create (which could cause AlreadyExists errors).
 	if result.ProgressEvent.Operation == cctypes.OperationCreate && result.ProgressEvent.ErrorCode == cctypes.HandlerErrorCodeNotFound {
+		operationStatus = resource.OperationStatusInProgress
+	}
+
+	// F-11: TG not associated with LB during ECS Service create. The Listener
+	// that wires the TG↔LB association may still be in flight in the same apply;
+	// keep polling so the next CloudControl retry succeeds once Listener.create
+	// completes. Pairing the error code with a status-message substring means a
+	// wording change alone produces a missed remap (graceful) and a code change
+	// fails loudly (caught by the dedicated unit test).
+	if result.ProgressEvent.Operation == cctypes.OperationCreate &&
+		result.ProgressEvent.ErrorCode == cctypes.HandlerErrorCodeInvalidRequest &&
+		tgNotAssociatedPattern.MatchString(aws.ToString(result.ProgressEvent.StatusMessage)) {
 		operationStatus = resource.OperationStatusInProgress
 	}
 

--- a/pkg/ccx/client.go
+++ b/pkg/ccx/client.go
@@ -28,10 +28,10 @@ import (
 )
 
 // tgNotAssociatedPattern matches the AWS error surfaced when an ECS service
-// is created before its target group has been wired to a load balancer
-// (F-11). Combined with HandlerErrorCodeInvalidRequest in StatusResource,
-// this turns the error into a "keep polling" signal so the PluginOperator's
-// existing retry budget can absorb the race.
+// is created before its target group has been wired to a load balancer.
+// Combined with HandlerErrorCodeInvalidRequest in StatusResource, this turns
+// the error into a "keep polling" signal so the PluginOperator's existing
+// retry budget can absorb the race.
 var tgNotAssociatedPattern = regexp.MustCompile(`(?i)target group .* does not have an associated load balancer`)
 
 // cloudControlAPI defines the CloudControl operations used by Client.
@@ -349,8 +349,8 @@ func (c *Client) StatusResource(ctx context.Context, request *resource.StatusReq
 		operationStatus = resource.OperationStatusInProgress
 	}
 
-	// F-11: TG not associated with LB during ECS Service create. The Listener
-	// that wires the TG↔LB association may still be in flight in the same apply;
+	// TG not associated with LB during ECS Service create. The Listener that
+	// wires the TG↔LB association may still be in flight in the same apply;
 	// keep polling so the next CloudControl retry succeeds once Listener.create
 	// completes. Pairing the error code with a status-message substring means a
 	// wording change alone produces a missed remap (graceful) and a code change

--- a/pkg/ccx/client_test.go
+++ b/pkg/ccx/client_test.go
@@ -171,6 +171,127 @@ func TestCreateResource_InProgress_NilIdentifier(t *testing.T) {
 	require.Equal(t, "", result.ProgressResult.NativeID)
 }
 
+func TestStatusResource_F11_TGNotAssociated_RemapsToInProgress(t *testing.T) {
+	mockAPI := new(mockCloudControlAPI)
+	client := &Client{api: mockAPI}
+
+	mockAPI.On("GetResourceRequestStatus", mock.Anything, mock.Anything).Return(
+		&cloudcontrol.GetResourceRequestStatusOutput{
+			ProgressEvent: &cctypes.ProgressEvent{
+				Operation:       cctypes.OperationCreate,
+				OperationStatus: cctypes.OperationStatusFailed,
+				ErrorCode:       cctypes.HandlerErrorCodeInvalidRequest,
+				StatusMessage:   ptr.Of("The target group with targetGroupArn arn:aws:elasticloadbalancing:us-west-2:123:targetgroup/foo/abc does not have an associated load balancer."),
+				TypeName:        ptr.Of("AWS::ECS::Service"),
+			},
+		}, nil,
+	)
+
+	result, err := client.StatusResource(
+		context.Background(),
+		&resource.StatusRequest{RequestID: "req-token-f11"},
+		func(_ context.Context, _ *resource.ReadRequest) (*resource.ReadResult, error) {
+			t.Fatalf("readFunc should not be called when remapping to InProgress")
+			return nil, nil
+		},
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, resource.OperationStatusInProgress, result.ProgressResult.OperationStatus,
+		"F-11 'TG not associated' on Create must remap to InProgress so PluginOperator keeps polling")
+}
+
+func TestStatusResource_F11_NotRemappedOnUpdate(t *testing.T) {
+	mockAPI := new(mockCloudControlAPI)
+	client := &Client{api: mockAPI}
+
+	mockAPI.On("GetResourceRequestStatus", mock.Anything, mock.Anything).Return(
+		&cloudcontrol.GetResourceRequestStatusOutput{
+			ProgressEvent: &cctypes.ProgressEvent{
+				Operation:       cctypes.OperationUpdate,
+				OperationStatus: cctypes.OperationStatusFailed,
+				ErrorCode:       cctypes.HandlerErrorCodeInvalidRequest,
+				StatusMessage:   ptr.Of("The target group with targetGroupArn arn:aws:elasticloadbalancing:us-west-2:123:targetgroup/foo/abc does not have an associated load balancer."),
+				TypeName:        ptr.Of("AWS::ECS::Service"),
+			},
+		}, nil,
+	)
+
+	result, err := client.StatusResource(
+		context.Background(),
+		&resource.StatusRequest{RequestID: "req-token-f11-update"},
+		func(_ context.Context, _ *resource.ReadRequest) (*resource.ReadResult, error) {
+			return nil, nil
+		},
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotEqual(t, resource.OperationStatusInProgress, result.ProgressResult.OperationStatus,
+		"F-11 pattern on Update is a different state (not the create-vs-listener race) — must not remap")
+}
+
+func TestStatusResource_F11_NotRemappedOnDifferentErrorCode(t *testing.T) {
+	mockAPI := new(mockCloudControlAPI)
+	client := &Client{api: mockAPI}
+
+	mockAPI.On("GetResourceRequestStatus", mock.Anything, mock.Anything).Return(
+		&cloudcontrol.GetResourceRequestStatusOutput{
+			ProgressEvent: &cctypes.ProgressEvent{
+				Operation:       cctypes.OperationCreate,
+				OperationStatus: cctypes.OperationStatusFailed,
+				ErrorCode:       cctypes.HandlerErrorCodeAccessDenied,
+				StatusMessage:   ptr.Of("The target group with targetGroupArn arn:aws:elasticloadbalancing:us-west-2:123:targetgroup/foo/abc does not have an associated load balancer."),
+				TypeName:        ptr.Of("AWS::ECS::Service"),
+			},
+		}, nil,
+	)
+
+	result, err := client.StatusResource(
+		context.Background(),
+		&resource.StatusRequest{RequestID: "req-token-f11-wrong-code"},
+		func(_ context.Context, _ *resource.ReadRequest) (*resource.ReadResult, error) {
+			return nil, nil
+		},
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotEqual(t, resource.OperationStatusInProgress, result.ProgressResult.OperationStatus,
+		"matching message text under a different error code must not remap — code is the safety rail")
+}
+
+func TestStatusResource_F11_NotRemappedOnUnrelatedMessage(t *testing.T) {
+	mockAPI := new(mockCloudControlAPI)
+	client := &Client{api: mockAPI}
+
+	mockAPI.On("GetResourceRequestStatus", mock.Anything, mock.Anything).Return(
+		&cloudcontrol.GetResourceRequestStatusOutput{
+			ProgressEvent: &cctypes.ProgressEvent{
+				Operation:       cctypes.OperationCreate,
+				OperationStatus: cctypes.OperationStatusFailed,
+				ErrorCode:       cctypes.HandlerErrorCodeInvalidRequest,
+				StatusMessage:   ptr.Of("Some other validation error about a different field"),
+				TypeName:        ptr.Of("AWS::ECS::Service"),
+			},
+		}, nil,
+	)
+
+	result, err := client.StatusResource(
+		context.Background(),
+		&resource.StatusRequest{RequestID: "req-token-f11-wrong-msg"},
+		func(_ context.Context, _ *resource.ReadRequest) (*resource.ReadResult, error) {
+			return nil, nil
+		},
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotEqual(t, resource.OperationStatusInProgress, result.ProgressResult.OperationStatus,
+		"InvalidRequest on Create with an unrelated message must not remap — message is the discriminator")
+}
+
 func TestUpdateResource_SynchronousSuccess_PopulatesResourceProperties(t *testing.T) {
 	mockAPI := new(mockCloudControlAPI)
 	client := &Client{api: mockAPI}

--- a/pkg/ccx/client_test.go
+++ b/pkg/ccx/client_test.go
@@ -171,7 +171,7 @@ func TestCreateResource_InProgress_NilIdentifier(t *testing.T) {
 	require.Equal(t, "", result.ProgressResult.NativeID)
 }
 
-func TestStatusResource_F11_TGNotAssociated_RemapsToInProgress(t *testing.T) {
+func TestStatusResource_TGCreateRace_RemapsToInProgress(t *testing.T) {
 	mockAPI := new(mockCloudControlAPI)
 	client := &Client{api: mockAPI}
 
@@ -189,7 +189,7 @@ func TestStatusResource_F11_TGNotAssociated_RemapsToInProgress(t *testing.T) {
 
 	result, err := client.StatusResource(
 		context.Background(),
-		&resource.StatusRequest{RequestID: "req-token-f11"},
+		&resource.StatusRequest{RequestID: "req-token-tg-race"},
 		func(_ context.Context, _ *resource.ReadRequest) (*resource.ReadResult, error) {
 			t.Fatalf("readFunc should not be called when remapping to InProgress")
 			return nil, nil
@@ -199,10 +199,10 @@ func TestStatusResource_F11_TGNotAssociated_RemapsToInProgress(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Equal(t, resource.OperationStatusInProgress, result.ProgressResult.OperationStatus,
-		"F-11 'TG not associated' on Create must remap to InProgress so PluginOperator keeps polling")
+		"'TG not associated' on Create must remap to InProgress so PluginOperator keeps polling")
 }
 
-func TestStatusResource_F11_NotRemappedOnUpdate(t *testing.T) {
+func TestStatusResource_TGCreateRace_NotRemappedOnUpdate(t *testing.T) {
 	mockAPI := new(mockCloudControlAPI)
 	client := &Client{api: mockAPI}
 
@@ -220,7 +220,7 @@ func TestStatusResource_F11_NotRemappedOnUpdate(t *testing.T) {
 
 	result, err := client.StatusResource(
 		context.Background(),
-		&resource.StatusRequest{RequestID: "req-token-f11-update"},
+		&resource.StatusRequest{RequestID: "req-token-tg-race-update"},
 		func(_ context.Context, _ *resource.ReadRequest) (*resource.ReadResult, error) {
 			return nil, nil
 		},
@@ -229,10 +229,10 @@ func TestStatusResource_F11_NotRemappedOnUpdate(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.NotEqual(t, resource.OperationStatusInProgress, result.ProgressResult.OperationStatus,
-		"F-11 pattern on Update is a different state (not the create-vs-listener race) — must not remap")
+		"'TG not associated' on Update is a different state (not the create-vs-listener race) — must not remap")
 }
 
-func TestStatusResource_F11_NotRemappedOnDifferentErrorCode(t *testing.T) {
+func TestStatusResource_TGCreateRace_NotRemappedOnDifferentErrorCode(t *testing.T) {
 	mockAPI := new(mockCloudControlAPI)
 	client := &Client{api: mockAPI}
 
@@ -250,7 +250,7 @@ func TestStatusResource_F11_NotRemappedOnDifferentErrorCode(t *testing.T) {
 
 	result, err := client.StatusResource(
 		context.Background(),
-		&resource.StatusRequest{RequestID: "req-token-f11-wrong-code"},
+		&resource.StatusRequest{RequestID: "req-token-tg-race-wrong-code"},
 		func(_ context.Context, _ *resource.ReadRequest) (*resource.ReadResult, error) {
 			return nil, nil
 		},
@@ -262,7 +262,7 @@ func TestStatusResource_F11_NotRemappedOnDifferentErrorCode(t *testing.T) {
 		"matching message text under a different error code must not remap — code is the safety rail")
 }
 
-func TestStatusResource_F11_NotRemappedOnUnrelatedMessage(t *testing.T) {
+func TestStatusResource_TGCreateRace_NotRemappedOnUnrelatedMessage(t *testing.T) {
 	mockAPI := new(mockCloudControlAPI)
 	client := &Client{api: mockAPI}
 
@@ -280,7 +280,7 @@ func TestStatusResource_F11_NotRemappedOnUnrelatedMessage(t *testing.T) {
 
 	result, err := client.StatusResource(
 		context.Background(),
-		&resource.StatusRequest{RequestID: "req-token-f11-wrong-msg"},
+		&resource.StatusRequest{RequestID: "req-token-tg-race-wrong-msg"},
 		func(_ context.Context, _ *resource.ReadRequest) (*resource.ReadResult, error) {
 			return nil, nil
 		},

--- a/pkg/cfres/ecs/service_schema_test.go
+++ b/pkg/cfres/ecs/service_schema_test.go
@@ -1,0 +1,112 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package ecs
+
+// TestService_Schema_AttachesToAnnotations is a textual smoke test that verifies
+// the two targetGroupArn fields on AWS::ECS::Service carry @aws.FieldHint{attachesTo = true}
+// in the PKL schema source. This guards against a future refactor accidentally
+// removing the annotation and silently breaking the AttachesTo-based destroy
+// ordering that ECS load-balancer and VPC Lattice wiring depends on.
+//
+// This is intentionally a textual test rather than a full schema-emission test:
+// running ExtractSchema in a unit test requires a live pkl CLI subprocess and
+// network access for package resolution, making it unsuitable for make test-unit.
+// A proper emission test should live in a dedicated schema integration test suite.
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func serviceSchemaPath() string {
+	_, filename, _, _ := runtime.Caller(0)
+	// pkg/cfres/ecs/ -> (repo root)/schema/pkl/ecs/service.pkl
+	root := filepath.Join(filepath.Dir(filename), "..", "..", "..", "schema", "pkl", "ecs")
+	return filepath.Join(root, "service.pkl")
+}
+
+// extractClassBody returns the text of the class body from the first occurrence
+// of "open class <className>" up to the closing "}" that ends the class block
+// (we use a simple heuristic: collect lines until we see a line that is just "}").
+func extractClassBody(src, className string) string {
+	marker := "open class " + className + " extends"
+	start := strings.Index(src, marker)
+	if start == -1 {
+		return ""
+	}
+	rest := src[start:]
+	// Collect until we find the closing brace that ends the class (a line
+	// consisting of only "}" with possible surrounding whitespace).
+	lines := strings.Split(rest, "\n")
+	var body strings.Builder
+	for _, line := range lines {
+		body.WriteString(line)
+		body.WriteByte('\n')
+		if strings.TrimSpace(line) == "}" {
+			break
+		}
+	}
+	return body.String()
+}
+
+func TestService_Schema_LoadBalancer_TargetGroupArn_AttachesTo(t *testing.T) {
+	content, err := os.ReadFile(serviceSchemaPath())
+	if err != nil {
+		t.Fatalf("could not read service.pkl: %v", err)
+	}
+
+	body := extractClassBody(string(content), "LoadBalancer")
+	if body == "" {
+		t.Fatal("LoadBalancer class not found in service.pkl")
+	}
+
+	lines := strings.Split(body, "\n")
+	for i, line := range lines {
+		if strings.Contains(line, "targetGroupArn") {
+			// The annotation must appear on the line immediately before.
+			if i == 0 {
+				t.Fatal("targetGroupArn is the first line of LoadBalancer body — no preceding annotation line")
+			}
+			prev := strings.TrimSpace(lines[i-1])
+			if !strings.Contains(prev, "attachesTo") || !strings.Contains(prev, "true") {
+				t.Errorf("LoadBalancer.targetGroupArn: expected @aws.FieldHint{attachesTo = true} on preceding line, got %q", prev)
+			}
+			return
+		}
+	}
+	t.Fatal("targetGroupArn field not found inside LoadBalancer class body in service.pkl")
+}
+
+func TestService_Schema_VpcLatticeConfiguration_TargetGroupArn_AttachesTo(t *testing.T) {
+	content, err := os.ReadFile(serviceSchemaPath())
+	if err != nil {
+		t.Fatalf("could not read service.pkl: %v", err)
+	}
+
+	body := extractClassBody(string(content), "VpcLatticeConfiguration")
+	if body == "" {
+		t.Fatal("VpcLatticeConfiguration class not found in service.pkl")
+	}
+
+	lines := strings.Split(body, "\n")
+	for i, line := range lines {
+		if strings.Contains(line, "targetGroupArn") {
+			if i == 0 {
+				t.Fatal("targetGroupArn is the first line of VpcLatticeConfiguration body — no preceding annotation line")
+			}
+			prev := strings.TrimSpace(lines[i-1])
+			if !strings.Contains(prev, "attachesTo") || !strings.Contains(prev, "true") {
+				t.Errorf("VpcLatticeConfiguration.targetGroupArn: expected @aws.FieldHint{attachesTo = true} on preceding line, got %q", prev)
+			}
+			return
+		}
+	}
+	t.Fatal("targetGroupArn field not found inside VpcLatticeConfiguration class body in service.pkl")
+}

--- a/schema/pkl/PklProject
+++ b/schema/pkl/PklProject
@@ -2,7 +2,7 @@ amends "pkl:Project"
 
 dependencies {
   ["formae"] {
-    uri = "package://hub.platform.engineering/plugins/pkl/schema/pkl/formae/formae@0.84.0"
+    uri = "package://hub.platform.engineering/plugins/pkl/schema/pkl/formae/formae@0.85.0"
   }
 }
 

--- a/schema/pkl/ecs/service.pkl
+++ b/schema/pkl/ecs/service.pkl
@@ -83,6 +83,7 @@ open class LoadBalancer extends formae.SubResource {
     containerName: String?
     containerPort: Int?
     loadBalancerName: (String|formae.Resolvable)?
+    @aws.FieldHint{attachesTo = true}
     targetGroupArn: (String|formae.Resolvable)?
 }
 
@@ -194,6 +195,7 @@ open class TimeoutConfiguration extends formae.SubResource {
 open class VpcLatticeConfiguration extends formae.SubResource {
     portName: String
     roleArn: String|formae.Resolvable
+    @aws.FieldHint{attachesTo = true}
     targetGroupArn: String|formae.Resolvable
 }
 

--- a/testdata/PklProject
+++ b/testdata/PklProject
@@ -6,6 +6,6 @@ dependencies {
 
   // Formae schema - fetched from public registry
   ["formae"] {
-    uri = "package://hub.platform.engineering/plugins/pkl/schema/pkl/formae/formae@0.84.0"
+    uri = "package://hub.platform.engineering/plugins/pkl/schema/pkl/formae/formae@0.85.0"
   }
 }


### PR DESCRIPTION
## Summary

Three coordinated changes for the ECS Service destroy wedge and the create-time race between ECS Service and Listener:

- **Re-add `attachesTo` annotations** on `Service.LoadBalancer.targetGroupArn` and `Service.VpcLatticeConfiguration.targetGroupArn`. Completes the deferred re-add from PR #49 — originally merged 2026-04-25, reverted 7 hours later in `33645e3` because formae stable was on 0.83.0 and didn't yet expose `FieldHint.attachesTo`. The field has shipped in 0.85.0 stable since 2026-05-09; this completes the planned re-add against the stable pin.
- **Create-race retry** in `pkg/ccx/client.go`. New conditional in `StatusResource` detects the AWS CloudControl `"target group does not have an associated load balancer"` error during ECS Service create and remaps the operation status to `InProgress`. PluginOperator's existing retry budget then absorbs the race — by the next status poll the Listener has usually finished wiring the TG to the LB.
- **SDK 0.85.0 alignment**: `go.mod` repinned to the clean tags published 2026-05-13 (`pkg/plugin v0.2.2`, `pkg/plugin-conformance-tests v0.2.4`, `pkg/model v0.1.24`); plugin version bumped to `0.1.8-dev.0`; `schema/pkl/PklProject` + `testdata/PklProject` formae dep bumped to stable `formae@0.85.0`.

## Why

Two distinct bugs addressed:

- **Destroy wedge** (originally surfaced in the LGTM stack): the Grafana plugin's target depends on the ECS Service's listener URL during destroy. Without `attachesTo`, the Service tears down in parallel with the listener chain and any plugin target driving CRUD through the URL wedges mid-tear-down. `attachesTo` inverts the destroy edge so the Service waits for the listener/TG to be deleted first, keeping the URL backed throughout the plugin-target tear-down.
- **Create-time race**: ECS Service create can race the Listener create. AWS rejects `CreateService` if the Listener hasn't yet wired the TG into the LB. Today users re-apply to recover; the documented PKL workaround is to ref the TG through `listener.res.targetGroupArn`. The CCX retry makes this race transparent for PKL using the direct `tg.res.targetGroupArn` form.

## Compatibility

- `attachesTo` defaults to `false` on JSON unmarshal of plugin schemas built before formae 0.85.0. Older agents silently ignore the annotation — no regression.
- `minFormaeVersion` cascade stays at `0.84.0` (no SDK floor change this cycle).
- Direct `tg.res.targetGroupArn` PKL keeps working; the create-race retry catches the race without requiring users to switch to `listener.res.targetGroupArn`.

## Companion PRs

- formae SDK 0.85.0 tags (`pkg/plugin@v0.2.2`, `pkg/plugin-conformance-tests@v0.2.4`, `pkg/model@v0.1.24`) — already pushed.
- formae-docs PR documenting the SDK release + `attachesTo` reference: platform-engineering-labs/formae-docs#95.
- Sibling plugin repins (kubernetes, grafana, compose, azure) — already merged to their respective `main` branches.