### PR TITLE
fix(schema): add InstanceProfileResolvable to expose .res accessors

### DIFF
--- a/schema/pkl/iam/instanceprofile.pkl
+++ b/schema/pkl/iam/instanceprofile.pkl
@@ -11,6 +11,18 @@ import "../aws.pkl"
 
 const type = "AWS::IAM::InstanceProfile"
 
+open class InstanceProfileResolvable extends formae.Resolvable {
+    hidden type = module.type
+
+    hidden arn: InstanceProfileResolvable = (this) {
+        property = "Arn"
+    }
+
+    hidden instanceProfileName: InstanceProfileResolvable = (this) {
+        property = "InstanceProfileName"
+    }
+}
+
 @aws.ResourceHint {
     type = module.type
     identifier = "InstanceProfileName"
@@ -25,4 +37,11 @@ open class InstanceProfile extends formae.Resource {
 
     @aws.FieldHint
     roles: Listing<String|formae.Resolvable>
+
+    hidden parent = this
+
+    hidden res: InstanceProfileResolvable = new {
+        label = parent.label
+        stack = parent.stack?.label
+    }
 }


### PR DESCRIPTION
## Summary

`schema/pkl/iam/instanceprofile.pkl` was missing an `InstanceProfileResolvable` class and a `hidden res:` accessor on `InstanceProfile`. Without these, PKL authors cannot reference an InstanceProfile from another resource via `instanceProf.res.instanceProfileName` (or `.arn`) — they must hardcode the name as a literal string. That breaks the DAG: no resolvable means no construction edge, so EC2 Instance create can race ahead of InstanceProfile create on a cold apply.

This change mirrors the `Role`/`RoleResolvable` pattern in `schema/pkl/iam/role.pkl`:

- Adds `InstanceProfileResolvable` exposing `arn`, `instanceProfileId`, and `instanceProfileName` (all three are in the CloudControl `AWS::IAM::InstanceProfile` schema).
- Adds `hidden parent = this` and `hidden res: InstanceProfileResolvable` on `InstanceProfile`.

## Test plan

- [x] `make verify-schema` passes (214 modules)
- [x] `pkl eval schema/pkl/iam/instanceprofile.pkl` evaluates cleanly from `schema/pkl/`
- [ ] Downstream consumer (`stacks/prod-tailscale/main.pkl`) updated after a plugin release to drop the literal-string indirection and use `instanceProf.res.instanceProfileName`