### PR TITLE
fix(schema): correct FileSystemId casing in MountTargetResolvable

### DIFF
--- a/schema/pkl/efs/mounttarget.pkl
+++ b/schema/pkl/efs/mounttarget.pkl
@@ -23,7 +23,7 @@ open class MountTargetResolvable extends formae.Resolvable {
     }
 
     hidden fileSystemId: MountTargetResolvable = (this) {
-        property = "fileSystemId"
+        property = "FileSystemId"
     }
 }
 


### PR DESCRIPTION
## Summary

`MountTargetResolvable.fileSystemId` declared `property = "fileSystemId"` (lowercase initial), but CloudControl returns `FileSystemId` in PascalCase — same convention used by the sibling `FileSystemResolvable` and `AccessPointResolvable`. As a result, `mt.res.fileSystemId` resolved to empty/null at apply time. PKL eval and DAG wiring both accepted the resolvable, so neither structural audits nor `pkl eval` caught it.

This unblocks threading `EFSVolumeConfiguration.filesystemId` through a Mount Target (rather than directly through the EFS) to eliminate one of the parallel mount-target races in ECS service startup.

## Audit

`grep -rn 'property = "[a-z]' schema/pkl/` returns only this one occurrence — no other sibling bugs of the same shape.

## Test plan

- [x] `make verify-schema` passes (225 modules)
- [ ] Author a tiny PKL forma with an EFS, a Mount Target, and a TaskDefinition whose `EFSVolumeConfiguration.filesystemId = mt.res.fileSystemId`; verify on `formae apply --simulate` that the resolved Properties JSON carries the actual `fs-...` id