### PR TITLE
fix: classify CCAPI sync errors; route SES EventDestination via SDK

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,8 +21,8 @@ require (
 	github.com/aws/smithy-go v1.25.1
 	github.com/google/uuid v1.6.0
 	github.com/platform-engineering-labs/formae/pkg/model v0.1.24
-	github.com/platform-engineering-labs/formae/pkg/plugin v0.2.3-0.20260516003828-54274057c9f0
-	github.com/platform-engineering-labs/formae/pkg/plugin-conformance-tests v0.2.5-0.20260516003828-54274057c9f0
+	github.com/platform-engineering-labs/formae/pkg/plugin v0.2.3-0.20260516041807-7c30834d7277
+	github.com/platform-engineering-labs/formae/pkg/plugin-conformance-tests v0.2.5-0.20260516041807-7c30834d7277
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/go.mod
+++ b/go.mod
@@ -21,8 +21,8 @@ require (
 	github.com/aws/smithy-go v1.25.1
 	github.com/google/uuid v1.6.0
 	github.com/platform-engineering-labs/formae/pkg/model v0.1.24
-	github.com/platform-engineering-labs/formae/pkg/plugin v0.2.2
-	github.com/platform-engineering-labs/formae/pkg/plugin-conformance-tests v0.2.4
+	github.com/platform-engineering-labs/formae/pkg/plugin v0.2.3-0.20260516003828-54274057c9f0
+	github.com/platform-engineering-labs/formae/pkg/plugin-conformance-tests v0.2.5-0.20260516003828-54274057c9f0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -126,10 +126,10 @@ github.com/platform-engineering-labs/formae/pkg/api/model v0.1.1 h1:ZMTgKwSomy2c
 github.com/platform-engineering-labs/formae/pkg/api/model v0.1.1/go.mod h1:0ncHFCsGA6b0w1kBm6m+QwJ823qAY2vL47GvoR0BTyU=
 github.com/platform-engineering-labs/formae/pkg/model v0.1.24 h1:FZH3m0zlkXSJMYRy23jZrJPdYv1+6yOxCS5NDHAjNQU=
 github.com/platform-engineering-labs/formae/pkg/model v0.1.24/go.mod h1:1dmsFwoaJZkHevBsAIZr068CWzG7de1VNz7PFWvM3Z8=
-github.com/platform-engineering-labs/formae/pkg/plugin v0.2.3-0.20260516003828-54274057c9f0 h1:a1qlv3d808MLsvL1cxF4NbPTx/ErouH9bGgCkjSkDio=
-github.com/platform-engineering-labs/formae/pkg/plugin v0.2.3-0.20260516003828-54274057c9f0/go.mod h1:rQwaELhpPX042nqpB0n9XcTnyRMnWWp+CJWlOSX5eVA=
-github.com/platform-engineering-labs/formae/pkg/plugin-conformance-tests v0.2.5-0.20260516003828-54274057c9f0 h1:lgNkiSo/0gspUZuNTt9Id3l6X/nz0s/kIrGXOSDzY4Q=
-github.com/platform-engineering-labs/formae/pkg/plugin-conformance-tests v0.2.5-0.20260516003828-54274057c9f0/go.mod h1:gq591ZeRZ4jAHpdSvCyrOvi8qyALxcXQQhd0B6GRMAo=
+github.com/platform-engineering-labs/formae/pkg/plugin v0.2.3-0.20260516041807-7c30834d7277 h1:GZoF5msnE+iWWsmlf+7oxSJvFZ7yTz+F2Zsguz8uqe0=
+github.com/platform-engineering-labs/formae/pkg/plugin v0.2.3-0.20260516041807-7c30834d7277/go.mod h1:rQwaELhpPX042nqpB0n9XcTnyRMnWWp+CJWlOSX5eVA=
+github.com/platform-engineering-labs/formae/pkg/plugin-conformance-tests v0.2.5-0.20260516041807-7c30834d7277 h1:zJL6o4wJxfloRLNflqGQ/tmKea4cmragUZzdLI+gqyc=
+github.com/platform-engineering-labs/formae/pkg/plugin-conformance-tests v0.2.5-0.20260516041807-7c30834d7277/go.mod h1:gq591ZeRZ4jAHpdSvCyrOvi8qyALxcXQQhd0B6GRMAo=
 github.com/platform-engineering-labs/orbital v0.1.36 h1:nPMLxDbwDrjlhJoMQXAE86HtVhQHC2A6BJlWYmNM75c=
 github.com/platform-engineering-labs/orbital v0.1.36/go.mod h1:wwVPqOmW5RO78dDzL/G5CN1Ioao0P/aUsOZVrPVx64s=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=

--- a/go.sum
+++ b/go.sum
@@ -126,10 +126,10 @@ github.com/platform-engineering-labs/formae/pkg/api/model v0.1.1 h1:ZMTgKwSomy2c
 github.com/platform-engineering-labs/formae/pkg/api/model v0.1.1/go.mod h1:0ncHFCsGA6b0w1kBm6m+QwJ823qAY2vL47GvoR0BTyU=
 github.com/platform-engineering-labs/formae/pkg/model v0.1.24 h1:FZH3m0zlkXSJMYRy23jZrJPdYv1+6yOxCS5NDHAjNQU=
 github.com/platform-engineering-labs/formae/pkg/model v0.1.24/go.mod h1:1dmsFwoaJZkHevBsAIZr068CWzG7de1VNz7PFWvM3Z8=
-github.com/platform-engineering-labs/formae/pkg/plugin v0.2.2 h1:woOwbsEk9y9LL2xyPurtkUAB/1gB9nCekLBvgc8E9P8=
-github.com/platform-engineering-labs/formae/pkg/plugin v0.2.2/go.mod h1:rQwaELhpPX042nqpB0n9XcTnyRMnWWp+CJWlOSX5eVA=
-github.com/platform-engineering-labs/formae/pkg/plugin-conformance-tests v0.2.4 h1:7Ww45TQ3sNNQVwMiEMPKles+HCXZLJRSVjgMJZMj0sQ=
-github.com/platform-engineering-labs/formae/pkg/plugin-conformance-tests v0.2.4/go.mod h1:gq591ZeRZ4jAHpdSvCyrOvi8qyALxcXQQhd0B6GRMAo=
+github.com/platform-engineering-labs/formae/pkg/plugin v0.2.3-0.20260516003828-54274057c9f0 h1:a1qlv3d808MLsvL1cxF4NbPTx/ErouH9bGgCkjSkDio=
+github.com/platform-engineering-labs/formae/pkg/plugin v0.2.3-0.20260516003828-54274057c9f0/go.mod h1:rQwaELhpPX042nqpB0n9XcTnyRMnWWp+CJWlOSX5eVA=
+github.com/platform-engineering-labs/formae/pkg/plugin-conformance-tests v0.2.5-0.20260516003828-54274057c9f0 h1:lgNkiSo/0gspUZuNTt9Id3l6X/nz0s/kIrGXOSDzY4Q=
+github.com/platform-engineering-labs/formae/pkg/plugin-conformance-tests v0.2.5-0.20260516003828-54274057c9f0/go.mod h1:gq591ZeRZ4jAHpdSvCyrOvi8qyALxcXQQhd0B6GRMAo=
 github.com/platform-engineering-labs/orbital v0.1.36 h1:nPMLxDbwDrjlhJoMQXAE86HtVhQHC2A6BJlWYmNM75c=
 github.com/platform-engineering-labs/orbital v0.1.36/go.mod h1:wwVPqOmW5RO78dDzL/G5CN1Ioao0P/aUsOZVrPVx64s=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=

--- a/pkg/ccx/client.go
+++ b/pkg/ccx/client.go
@@ -134,6 +134,9 @@ func (c *Client) CreateResource(ctx context.Context, request *resource.CreateReq
 		TypeName:     &request.ResourceType,
 	})
 	if err != nil {
+		if pr, ok := classifyCloudControlError(err, resource.OperationCreate); ok {
+			return &resource.CreateResult{ProgressResult: pr}, nil
+		}
 		return nil, err
 	}
 
@@ -170,6 +173,9 @@ func (c *Client) UpdateResource(ctx context.Context, request *resource.UpdateReq
 		TypeName:   &request.ResourceType,
 	})
 	if err != nil {
+		if pr, ok := classifyCloudControlError(err, resource.OperationUpdate); ok {
+			return &resource.UpdateResult{ProgressResult: pr}, nil
+		}
 		return nil, err
 	}
 
@@ -213,6 +219,9 @@ func (c *Client) UpdateResource(ctx context.Context, request *resource.UpdateReq
 		TypeName:      ptr.Of(request.ResourceType),
 	})
 	if err != nil {
+		if pr, ok := classifyCloudControlError(err, resource.OperationUpdate); ok {
+			return &resource.UpdateResult{ProgressResult: pr}, nil
+		}
 		return nil, err
 	}
 
@@ -246,6 +255,9 @@ func (c *Client) DeleteResource(ctx context.Context, request *resource.DeleteReq
 		TypeName:   ptr.Of(request.ResourceType),
 	})
 	if err != nil {
+		if pr, ok := classifyCloudControlError(err, resource.OperationDelete); ok {
+			return &resource.DeleteResult{ProgressResult: pr}, nil
+		}
 		return nil, err
 	}
 

--- a/pkg/ccx/client_test.go
+++ b/pkg/ccx/client_test.go
@@ -9,8 +9,10 @@ package ccx
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
 	cctypes "github.com/aws/aws-sdk-go-v2/service/cloudcontrol/types"
 	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
@@ -375,6 +377,143 @@ func TestUpdateResource_InProgress_DoesNotRead(t *testing.T) {
 	require.Nil(t, result.ProgressResult.ResourceProperties)
 	// GetResource should only be called once (existence check), not twice (no post-update Read)
 	mockAPI.AssertNumberOfCalls(t, "GetResource", 1)
+}
+
+func TestCreateResource_SyncCloudControlError_ReturnsFailureProgress(t *testing.T) {
+	mockAPI := new(mockCloudControlAPI)
+	client := &Client{api: mockAPI}
+
+	awsErr := ccOpError(&cctypes.InvalidRequestException{
+		Message: aws.String("DesiredState contains an unknown property 'Foo'"),
+	})
+	mockAPI.On("CreateResource", mock.Anything, mock.Anything).Return(
+		(*cloudcontrol.CreateResourceOutput)(nil), awsErr,
+	)
+
+	result, err := client.CreateResource(context.Background(), &resource.CreateRequest{
+		ResourceType: "AWS::EC2::FlowLog",
+		Properties:   json.RawMessage(`{}`),
+	})
+
+	require.NoError(t, err, "classified CC errors must surface via ProgressResult, not as a raw Go error")
+	require.NotNil(t, result)
+	require.NotNil(t, result.ProgressResult)
+	require.Equal(t, resource.OperationStatusFailure, result.ProgressResult.OperationStatus)
+	require.Equal(t, resource.OperationErrorCodeInvalidRequest, result.ProgressResult.ErrorCode)
+	require.Equal(t, resource.OperationCreate, result.ProgressResult.Operation)
+}
+
+func TestCreateResource_RDSSubnetEventualConsistency_RemapsToResourceConflict(t *testing.T) {
+	mockAPI := new(mockCloudControlAPI)
+	client := &Client{api: mockAPI}
+
+	awsErr := ccOpError(&cctypes.InvalidRequestException{
+		Message: aws.String("Some input subnets in :[subnet-0f7a9adc9560fae45, subnet-07544dcf861d1f761] are invalid."),
+	})
+	mockAPI.On("CreateResource", mock.Anything, mock.Anything).Return(
+		(*cloudcontrol.CreateResourceOutput)(nil), awsErr,
+	)
+
+	result, err := client.CreateResource(context.Background(), &resource.CreateRequest{
+		ResourceType: "AWS::RDS::DBSubnetGroup",
+		Properties:   json.RawMessage(`{"DBSubnetGroupName":"test","SubnetIds":["subnet-x","subnet-y"]}`),
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result.ProgressResult)
+	require.Equal(t, resource.OperationStatusFailure, result.ProgressResult.OperationStatus)
+	require.Equal(t, resource.OperationErrorCodeResourceConflict, result.ProgressResult.ErrorCode,
+		"AWS subnet-invalid-after-create is eventual consistency; must remap to ResourceConflict so PluginOperator retries")
+}
+
+func TestCreateResource_NonCloudControlError_BubblesAsRawError(t *testing.T) {
+	mockAPI := new(mockCloudControlAPI)
+	client := &Client{api: mockAPI}
+
+	mockAPI.On("CreateResource", mock.Anything, mock.Anything).Return(
+		(*cloudcontrol.CreateResourceOutput)(nil), errors.New("transport: connection reset"),
+	)
+
+	result, err := client.CreateResource(context.Background(), &resource.CreateRequest{
+		ResourceType: "AWS::EC2::FlowLog",
+		Properties:   json.RawMessage(`{}`),
+	})
+
+	require.Error(t, err, "unclassified errors must bubble as raw Go errors so the agent tags them UnforeseenError")
+	require.Nil(t, result)
+}
+
+func TestUpdateResource_SyncCloudControlError_ReturnsFailureProgress(t *testing.T) {
+	mockAPI := new(mockCloudControlAPI)
+	client := &Client{api: mockAPI}
+
+	// Existence pre-check succeeds.
+	mockAPI.On("GetResource", mock.Anything, mock.Anything).Return(
+		&cloudcontrol.GetResourceOutput{
+			ResourceDescription: &cctypes.ResourceDescription{Properties: ptr.Of(`{}`)},
+		}, nil,
+	)
+	// Actual update fails with a recoverable Throttling exception.
+	mockAPI.On("UpdateResource", mock.Anything, mock.Anything).Return(
+		(*cloudcontrol.UpdateResourceOutput)(nil),
+		ccOpError(&cctypes.ThrottlingException{Message: aws.String("Rate exceeded")}),
+	)
+
+	result, err := client.UpdateResource(context.Background(), &resource.UpdateRequest{
+		ResourceType:  "AWS::EC2::FlowLog",
+		NativeID:      "fl-test",
+		PatchDocument: ptr.Of(`[]`),
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result.ProgressResult)
+	require.Equal(t, resource.OperationStatusFailure, result.ProgressResult.OperationStatus)
+	require.Equal(t, resource.OperationErrorCodeThrottling, result.ProgressResult.ErrorCode)
+	require.True(t, resource.IsRecoverable(result.ProgressResult.ErrorCode))
+}
+
+func TestUpdateResource_GetResourcePrecheckCloudControlError_ReturnsFailureProgress(t *testing.T) {
+	mockAPI := new(mockCloudControlAPI)
+	client := &Client{api: mockAPI}
+
+	mockAPI.On("GetResource", mock.Anything, mock.Anything).Return(
+		(*cloudcontrol.GetResourceOutput)(nil),
+		ccOpError(&cctypes.ResourceNotFoundException{Message: aws.String("not found")}),
+	)
+
+	result, err := client.UpdateResource(context.Background(), &resource.UpdateRequest{
+		ResourceType:  "AWS::EC2::FlowLog",
+		NativeID:      "fl-missing",
+		PatchDocument: ptr.Of(`[]`),
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result.ProgressResult)
+	require.Equal(t, resource.OperationStatusFailure, result.ProgressResult.OperationStatus)
+	require.Equal(t, resource.OperationErrorCodeNotFound, result.ProgressResult.ErrorCode)
+	require.Equal(t, resource.OperationUpdate, result.ProgressResult.Operation)
+	mockAPI.AssertNotCalled(t, "UpdateResource", mock.Anything, mock.Anything)
+}
+
+func TestDeleteResource_SyncCloudControlError_ReturnsFailureProgress(t *testing.T) {
+	mockAPI := new(mockCloudControlAPI)
+	client := &Client{api: mockAPI}
+
+	mockAPI.On("DeleteResource", mock.Anything, mock.Anything).Return(
+		(*cloudcontrol.DeleteResourceOutput)(nil),
+		ccOpError(&cctypes.ThrottlingException{Message: aws.String("Rate exceeded")}),
+	)
+
+	result, err := client.DeleteResource(context.Background(), &resource.DeleteRequest{
+		ResourceType: "AWS::EC2::FlowLog",
+		NativeID:     "fl-test",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result.ProgressResult)
+	require.Equal(t, resource.OperationStatusFailure, result.ProgressResult.OperationStatus)
+	require.Equal(t, resource.OperationErrorCodeThrottling, result.ProgressResult.ErrorCode)
+	require.Equal(t, resource.OperationDelete, result.ProgressResult.Operation)
 }
 
 func TestCreateResource_Success_NilIdentifier_ReturnsError(t *testing.T) {

--- a/pkg/ccx/errors.go
+++ b/pkg/ccx/errors.go
@@ -1,0 +1,74 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package ccx
+
+import (
+	"regexp"
+
+	cctypes "github.com/aws/aws-sdk-go-v2/service/cloudcontrol/types"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/helper"
+)
+
+// awsEventualConsistencyPatterns describes AWS errors that surface as
+// HandlerErrorCodeInvalidRequest on synchronous Create/Update/Delete but are
+// actually transient cross-service state-propagation issues. The plugin SDK's
+// recoverableErrorCodes set excludes InvalidRequest (correctly — most
+// InvalidRequest errors really are bad request payloads), so these specific
+// patterns get re-classified to ResourceConflict (which IS recoverable) so the
+// PluginOperator's retry pipeline absorbs the race.
+//
+// Pairing each pattern with the InvalidRequest code means a wording change
+// degrades gracefully (no remap, the original failure surfaces) while a code
+// change is caught loudly by the dedicated unit tests.
+var awsEventualConsistencyPatterns = []*regexp.Regexp{
+	// RDS rejects DBSubnetGroup creates when EC2-created subnets aren't yet
+	// visible to RDS's internal subnet cache.
+	regexp.MustCompile(`(?i)some input subnets .* are invalid`),
+}
+
+// classifyCloudControlError converts a synchronous CloudControl SDK error into
+// a ProgressResult with the appropriate OperationErrorCode. Returns
+// (nil, false) when the error is not a recognised CloudControl exception, in
+// which case the caller should return the raw Go error (the agent will then
+// tag it OperationErrorCodeUnforeseenError and surface it as terminal).
+//
+// This classification is the foundation of the agent's recoverability
+// machinery: without it every sync error from CCAPI becomes terminal,
+// regardless of whether it's actually transient. See
+// formae/pkg/plugin/plugin_operator.go for the agent-side retry logic and
+// formae/pkg/plugin/resource/resource.go for recoverableErrorCodes.
+func classifyCloudControlError(err error, op resource.Operation) (*resource.ProgressResult, bool) {
+	code, ok := helper.HandleCloudControlError(err)
+	if !ok {
+		return nil, false
+	}
+	msg := err.Error()
+	opCode := resource.OperationErrorCode(code)
+	if code == cctypes.HandlerErrorCodeInvalidRequest && matchesEventualConsistency(msg) {
+		// Re-classify as a recoverable code so PluginOperator retries.
+		// ResourceConflict isn't a perfect semantic fit (there's no
+		// conflict, just stale state); a dedicated
+		// OperationErrorCodeEventualConsistency is tracked as a follow-up
+		// in the engineering notes.
+		opCode = resource.OperationErrorCodeResourceConflict
+	}
+	return &resource.ProgressResult{
+		Operation:       op,
+		OperationStatus: resource.OperationStatusFailure,
+		ErrorCode:       opCode,
+		StatusMessage:   msg,
+	}, true
+}
+
+func matchesEventualConsistency(msg string) bool {
+	for _, re := range awsEventualConsistencyPatterns {
+		if re.MatchString(msg) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/ccx/errors_test.go
+++ b/pkg/ccx/errors_test.go
@@ -1,0 +1,118 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package ccx
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	cctypes "github.com/aws/aws-sdk-go-v2/service/cloudcontrol/types"
+	"github.com/aws/smithy-go"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+	"github.com/stretchr/testify/require"
+)
+
+// ccOpError wraps an underlying CloudControl exception in the same shape the
+// AWS SDK produces, so HandleCloudControlError's errors.As checks succeed.
+func ccOpError(underlying error) error {
+	return &smithy.OperationError{
+		ServiceID:     "CloudControl",
+		OperationName: "CreateResource",
+		Err:           underlying,
+	}
+}
+
+func TestClassifyCloudControlError_InvalidRequest_PassesThrough(t *testing.T) {
+	err := ccOpError(&cctypes.InvalidRequestException{Message: aws.String("DesiredState contains an unknown property")})
+
+	pr, ok := classifyCloudControlError(err, resource.OperationCreate)
+	require.True(t, ok, "InvalidRequestException must be classified")
+	require.NotNil(t, pr)
+	require.Equal(t, resource.OperationStatusFailure, pr.OperationStatus)
+	require.Equal(t, resource.OperationErrorCodeInvalidRequest, pr.ErrorCode,
+		"non-eventual-consistency InvalidRequest must remain InvalidRequest (non-recoverable, terminal)")
+	require.Equal(t, resource.OperationCreate, pr.Operation)
+	require.Contains(t, pr.StatusMessage, "DesiredState")
+}
+
+func TestClassifyCloudControlError_RDSSubnetEventualConsistency_RemapsToResourceConflict(t *testing.T) {
+	// AWS RDS error surfaced when EC2-created subnets aren't yet visible to RDS.
+	err := ccOpError(&cctypes.InvalidRequestException{
+		Message: aws.String("Some input subnets in :[subnet-0f7a9adc9560fae45, subnet-07544dcf861d1f761] are invalid."),
+	})
+
+	pr, ok := classifyCloudControlError(err, resource.OperationCreate)
+	require.True(t, ok)
+	require.NotNil(t, pr)
+	require.Equal(t, resource.OperationStatusFailure, pr.OperationStatus)
+	require.Equal(t, resource.OperationErrorCodeResourceConflict, pr.ErrorCode,
+		"subnet-invalid-after-create is AWS eventual consistency; must remap to ResourceConflict (recoverable) so PluginOperator retries")
+	require.True(t, resource.IsRecoverable(pr.ErrorCode), "remapped code must be in recoverableErrorCodes")
+}
+
+func TestClassifyCloudControlError_SubnetMessage_NotRemappedOnDifferentCode(t *testing.T) {
+	// Same message text but a different exception type — message is a hint, code is the safety rail.
+	err := ccOpError(&cctypes.ResourceNotFoundException{
+		Message: aws.String("Some input subnets in :[subnet-abc] are invalid."),
+	})
+
+	pr, ok := classifyCloudControlError(err, resource.OperationCreate)
+	require.True(t, ok)
+	require.NotNil(t, pr)
+	require.Equal(t, resource.OperationErrorCodeNotFound, pr.ErrorCode,
+		"message match alone (without InvalidRequest code) must not remap — code is the safety rail")
+}
+
+func TestClassifyCloudControlError_InvalidRequest_UnrelatedMessage_NotRemapped(t *testing.T) {
+	err := ccOpError(&cctypes.InvalidRequestException{
+		Message: aws.String("PatchDocument operation 'replace' at /Tags is not supported."),
+	})
+
+	pr, ok := classifyCloudControlError(err, resource.OperationUpdate)
+	require.True(t, ok)
+	require.NotNil(t, pr)
+	require.Equal(t, resource.OperationErrorCodeInvalidRequest, pr.ErrorCode,
+		"InvalidRequest with non-eventual-consistency message must stay InvalidRequest (terminal)")
+}
+
+func TestClassifyCloudControlError_Throttling_PassesThrough(t *testing.T) {
+	err := ccOpError(&cctypes.ThrottlingException{Message: aws.String("Rate exceeded")})
+
+	pr, ok := classifyCloudControlError(err, resource.OperationCreate)
+	require.True(t, ok)
+	require.NotNil(t, pr)
+	require.Equal(t, resource.OperationErrorCodeThrottling, pr.ErrorCode)
+	require.True(t, resource.IsRecoverable(pr.ErrorCode))
+}
+
+func TestClassifyCloudControlError_UnknownError_NotClassified(t *testing.T) {
+	// Plain Go error, not a smithy OperationError — caller must bubble it up
+	// as raw so the agent tags it OperationErrorCodeUnforeseenError.
+	pr, ok := classifyCloudControlError(errors.New("boom"), resource.OperationCreate)
+	require.False(t, ok)
+	require.Nil(t, pr)
+}
+
+func TestMatchesEventualConsistency(t *testing.T) {
+	cases := []struct {
+		name string
+		msg  string
+		want bool
+	}{
+		{"RDS lowercase", "some input subnets in :[subnet-abc] are invalid.", true},
+		{"RDS mixed case", "Some input Subnets in :[subnet-abc] Are Invalid.", true},
+		{"RDS with prefix", "InvalidRequestException: Some input subnets in :[subnet-abc] are invalid.", true},
+		{"unrelated invalid message", "the patch document is invalid", false},
+		{"empty", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, matchesEventualConsistency(tc.msg))
+		})
+	}
+}

--- a/pkg/cfres/ses/emailidentity_mock_test.go
+++ b/pkg/cfres/ses/emailidentity_mock_test.go
@@ -32,3 +32,11 @@ func (m *mockSesV2Client) GetConfigurationSetEventDestinations(ctx context.Conte
 	}
 	return args.Get(0).(*sesv2.GetConfigurationSetEventDestinationsOutput), args.Error(1)
 }
+
+func (m *mockSesV2Client) UpdateConfigurationSetEventDestination(ctx context.Context, input *sesv2.UpdateConfigurationSetEventDestinationInput, optFns ...func(*sesv2.Options)) (*sesv2.UpdateConfigurationSetEventDestinationOutput, error) {
+	args := m.Called(ctx, input)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*sesv2.UpdateConfigurationSetEventDestinationOutput), args.Error(1)
+}

--- a/pkg/cfres/ses/emailidentity_mock_test.go
+++ b/pkg/cfres/ses/emailidentity_mock_test.go
@@ -40,3 +40,11 @@ func (m *mockSesV2Client) UpdateConfigurationSetEventDestination(ctx context.Con
 	}
 	return args.Get(0).(*sesv2.UpdateConfigurationSetEventDestinationOutput), args.Error(1)
 }
+
+func (m *mockSesV2Client) DeleteConfigurationSetEventDestination(ctx context.Context, input *sesv2.DeleteConfigurationSetEventDestinationInput, optFns ...func(*sesv2.Options)) (*sesv2.DeleteConfigurationSetEventDestinationOutput, error) {
+	args := m.Called(ctx, input)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*sesv2.DeleteConfigurationSetEventDestinationOutput), args.Error(1)
+}

--- a/pkg/cfres/ses/emailidentity_mock_test.go
+++ b/pkg/cfres/ses/emailidentity_mock_test.go
@@ -48,3 +48,11 @@ func (m *mockSesV2Client) DeleteConfigurationSetEventDestination(ctx context.Con
 	}
 	return args.Get(0).(*sesv2.DeleteConfigurationSetEventDestinationOutput), args.Error(1)
 }
+
+func (m *mockSesV2Client) ListConfigurationSets(ctx context.Context, input *sesv2.ListConfigurationSetsInput, optFns ...func(*sesv2.Options)) (*sesv2.ListConfigurationSetsOutput, error) {
+	args := m.Called(ctx, input)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*sesv2.ListConfigurationSetsOutput), args.Error(1)
+}

--- a/pkg/cfres/ses/eventdestination.go
+++ b/pkg/cfres/ses/eventdestination.go
@@ -7,6 +7,7 @@ package ses
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -175,12 +176,53 @@ func (e *EventDestination) Update(ctx context.Context, request *resource.UpdateR
 	return updateResult, nil
 }
 
+// Delete uses the SESv2 SDK directly. Same root cause as the custom Read
+// and Update: CCAPI's DeleteResource rejects the composite identifier with
+// a ValidationException for this resource type. SESv2's
+// DeleteConfigurationSetEventDestination accepts csName and edName
+// separately and applies the delete synchronously.
+//
+// AWS treats deleting a non-existent destination as a NotFound error; we
+// translate that to a success ProgressResult so the agent's destroy flow
+// is idempotent (matches the ccx.DeleteResource behavior for the same
+// case at pkg/ccx/client.go).
 func (e *EventDestination) Delete(ctx context.Context, request *resource.DeleteRequest) (*resource.DeleteResult, error) {
-	ccxClient, err := ccx.NewClient(e.cfg)
-	if err != nil {
-		return nil, err
+	csName, edName, ok := splitComposite(request.NativeID)
+	if !ok || csName == "" || edName == "" {
+		return nil, fmt.Errorf("ses eventdestination Delete: NativeID %q is not a composite <csName>|<edName>", request.NativeID)
 	}
-	return ccxClient.DeleteResource(ctx, request)
+
+	sesClient, err := e.sesClientFactory(e.cfg)
+	if err != nil {
+		return nil, fmt.Errorf("ses eventdestination Delete: build SES client: %w", err)
+	}
+
+	_, err = sesClient.DeleteConfigurationSetEventDestination(ctx, &sesv2.DeleteConfigurationSetEventDestinationInput{
+		ConfigurationSetName: &csName,
+		EventDestinationName: &edName,
+	})
+	if err != nil {
+		var notFound *sesv2types.NotFoundException
+		if errors.As(err, &notFound) {
+			return &resource.DeleteResult{
+				ProgressResult: &resource.ProgressResult{
+					Operation:       resource.OperationDelete,
+					OperationStatus: resource.OperationStatusSuccess,
+					NativeID:        request.NativeID,
+					ErrorCode:       resource.OperationErrorCodeNotFound,
+				},
+			}, nil
+		}
+		return nil, fmt.Errorf("ses eventdestination Delete: DeleteConfigurationSetEventDestination(%q, %q): %w", csName, edName, err)
+	}
+
+	return &resource.DeleteResult{
+		ProgressResult: &resource.ProgressResult{
+			Operation:       resource.OperationDelete,
+			OperationStatus: resource.OperationStatusSuccess,
+			NativeID:        request.NativeID,
+		},
+	}, nil
 }
 
 // Read uses the SESv2 SDK directly instead of CloudControl. CCAPI's

--- a/pkg/cfres/ses/eventdestination.go
+++ b/pkg/cfres/ses/eventdestination.go
@@ -66,6 +66,7 @@ func init() {
 			resource.OperationUpdate,
 			resource.OperationCheckStatus,
 			resource.OperationDelete,
+			resource.OperationList,
 		},
 		func(cfg *config.Config) prov.Provisioner {
 			return &EventDestination{
@@ -507,8 +508,57 @@ func (e *EventDestination) Status(ctx context.Context, request *resource.StatusR
 	return result, nil
 }
 
+// List enumerates every event destination across every configuration set in
+// the account/region and returns composite "<csName>|<edName>" identifiers.
+// CCAPI's ListResources for this resource type returns bare
+// EventDestinationNames ("bounces"), which discovery can't subsequently
+// Read because every other path (Read/Update/Delete) requires the parent
+// ConfigurationSetName too. Walking the SES SDK directly is the only way
+// to emit usable identifiers — SES has no top-level "list all event
+// destinations" API.
+//
+// Pagination: ListConfigurationSets returns up to 100 CSes per page;
+// follow NextToken until exhausted. GetConfigurationSetEventDestinations
+// returns all destinations for a single CS in one call (per the SES API
+// docs, no pagination on that endpoint).
 func (e *EventDestination) List(ctx context.Context, request *resource.ListRequest) (*resource.ListResult, error) {
-	return nil, fmt.Errorf("list not implemented for EventDestination provisioner - cloudcontrol natively supports this operation")
+	sesClient, err := e.sesClientFactory(e.cfg)
+	if err != nil {
+		return nil, fmt.Errorf("ses eventdestination List: build SES client: %w", err)
+	}
+
+	var composites []string
+	var nextToken *string
+	for {
+		csOut, err := sesClient.ListConfigurationSets(ctx, &sesv2.ListConfigurationSetsInput{
+			NextToken: nextToken,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("ses eventdestination List: ListConfigurationSets: %w", err)
+		}
+		for _, csName := range csOut.ConfigurationSets {
+			cs := csName
+			edOut, err := sesClient.GetConfigurationSetEventDestinations(ctx, &sesv2.GetConfigurationSetEventDestinationsInput{
+				ConfigurationSetName: &cs,
+			})
+			if err != nil {
+				// Skip CSes we can't read (e.g. just deleted, transient
+				// AccessDenied) rather than fail the whole discovery scan.
+				continue
+			}
+			for _, ed := range edOut.EventDestinations {
+				if ed.Name == nil || *ed.Name == "" {
+					continue
+				}
+				composites = append(composites, cs+"|"+*ed.Name)
+			}
+		}
+		if csOut.NextToken == nil || *csOut.NextToken == "" {
+			break
+		}
+		nextToken = csOut.NextToken
+	}
+	return &resource.ListResult{NativeIDs: composites}, nil
 }
 
 // rewriteToComposite mutates pr in place: if NativeID is a bare

--- a/pkg/cfres/ses/eventdestination.go
+++ b/pkg/cfres/ses/eventdestination.go
@@ -119,12 +119,60 @@ func (e *EventDestination) Create(ctx context.Context, request *resource.CreateR
 	return result, nil
 }
 
+// Update uses the SESv2 SDK directly instead of CloudControl. The plugin's
+// formae-core handoff (2026-05-15) confirmed that CCAPI's UpdateResource
+// returns a synchronous Failure within ~4 ms for this resource type —
+// consistent with CCAPI rejecting the composite "<csName>|<edName>"
+// identifier the same way it does on GetResource (ValidationException:
+// "not valid for identifier [/properties/Id]"). SESv2's
+// UpdateConfigurationSetEventDestination accepts the parts separately and
+// applies the update synchronously, so we issue the SDK call and then
+// re-Read to populate ResourceProperties for the agent.
 func (e *EventDestination) Update(ctx context.Context, request *resource.UpdateRequest) (*resource.UpdateResult, error) {
-	ccxClient, err := ccx.NewClient(e.cfg)
-	if err != nil {
-		return nil, err
+	csName, edName, ok := splitComposite(request.NativeID)
+	if !ok || csName == "" || edName == "" {
+		return nil, fmt.Errorf("ses eventdestination Update: NativeID %q is not a composite <csName>|<edName>", request.NativeID)
 	}
-	return ccxClient.UpdateResource(ctx, request)
+
+	desired, err := parseEventDestinationFromDesired(request.DesiredProperties)
+	if err != nil {
+		return nil, fmt.Errorf("ses eventdestination Update: %w", err)
+	}
+
+	sesClient, err := e.sesClientFactory(e.cfg)
+	if err != nil {
+		return nil, fmt.Errorf("ses eventdestination Update: build SES client: %w", err)
+	}
+
+	_, err = sesClient.UpdateConfigurationSetEventDestination(ctx, &sesv2.UpdateConfigurationSetEventDestinationInput{
+		ConfigurationSetName: &csName,
+		EventDestinationName: &edName,
+		EventDestination:     desired,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("ses eventdestination Update: UpdateConfigurationSetEventDestination(%q, %q): %w", csName, edName, err)
+	}
+
+	// SES doesn't return the updated state — re-Read via our own Read so
+	// the agent gets ResourceProperties populated and any drift detected
+	// post-update is based on the actual AWS-side response, not on what
+	// we sent.
+	readResult, err := e.Read(ctx, &resource.ReadRequest{
+		NativeID:     request.NativeID,
+		ResourceType: request.ResourceType,
+		TargetConfig: request.TargetConfig,
+	})
+	updateResult := &resource.UpdateResult{
+		ProgressResult: &resource.ProgressResult{
+			Operation:       resource.OperationUpdate,
+			OperationStatus: resource.OperationStatusSuccess,
+			NativeID:        request.NativeID,
+		},
+	}
+	if err == nil && readResult != nil && readResult.ErrorCode == "" && readResult.Properties != "" {
+		updateResult.ProgressResult.ResourceProperties = json.RawMessage(readResult.Properties)
+	}
+	return updateResult, nil
 }
 
 func (e *EventDestination) Delete(ctx context.Context, request *resource.DeleteRequest) (*resource.DeleteResult, error) {
@@ -196,6 +244,113 @@ func (e *EventDestination) Read(ctx context.Context, request *resource.ReadReque
 		ResourceType: request.ResourceType,
 		ErrorCode:    "NotFound",
 	}, nil
+}
+
+// parseEventDestinationFromDesired extracts the EventDestination sub-object
+// from the CFN-shape DesiredProperties JSON and converts it into the SESv2
+// SDK's EventDestinationDefinition. The inverse of marshalEventDestinationToCFN —
+// keep the two in sync. CFN renders some ARN fields with uppercase suffixes
+// (TopicARN vs SDK TopicArn) so we cannot just rely on Go struct-tag JSON
+// unmarshaling against the SDK types directly.
+func parseEventDestinationFromDesired(desired json.RawMessage) (*sesv2types.EventDestinationDefinition, error) {
+	if len(desired) == 0 {
+		return nil, fmt.Errorf("DesiredProperties is empty")
+	}
+
+	var wrapper struct {
+		EventDestination *cfnEventDestination `json:"EventDestination"`
+	}
+	if err := json.Unmarshal(desired, &wrapper); err != nil {
+		return nil, fmt.Errorf("parse DesiredProperties: %w", err)
+	}
+	if wrapper.EventDestination == nil {
+		return nil, fmt.Errorf("DesiredProperties has no EventDestination object")
+	}
+	return wrapper.EventDestination.toSDK(), nil
+}
+
+type cfnEventDestination struct {
+	Enabled                    bool                          `json:"Enabled"`
+	MatchingEventTypes         []string                      `json:"MatchingEventTypes,omitempty"`
+	CloudWatchDestination      *cfnCloudWatchDestination     `json:"CloudWatchDestination,omitempty"`
+	SnsDestination             *cfnSnsDestination            `json:"SnsDestination,omitempty"`
+	KinesisFirehoseDestination *cfnKinesisFirehoseDestination `json:"KinesisFirehoseDestination,omitempty"`
+	EventBridgeDestination     *cfnEventBridgeDestination    `json:"EventBridgeDestination,omitempty"`
+	PinpointDestination        *cfnPinpointDestination       `json:"PinpointDestination,omitempty"`
+}
+
+type cfnCloudWatchDestination struct {
+	DimensionConfigurations []cfnDimensionConfig `json:"DimensionConfigurations,omitempty"`
+}
+
+type cfnDimensionConfig struct {
+	DimensionName         string `json:"DimensionName"`
+	DefaultDimensionValue string `json:"DefaultDimensionValue"`
+	DimensionValueSource  string `json:"DimensionValueSource"`
+}
+
+type cfnSnsDestination struct {
+	TopicARN string `json:"TopicARN"`
+}
+
+type cfnKinesisFirehoseDestination struct {
+	IAMRoleARN        string `json:"IAMRoleARN"`
+	DeliveryStreamARN string `json:"DeliveryStreamARN"`
+}
+
+type cfnEventBridgeDestination struct {
+	EventBusArn string `json:"EventBusArn"`
+}
+
+type cfnPinpointDestination struct {
+	ApplicationArn string `json:"ApplicationArn"`
+}
+
+func (c *cfnEventDestination) toSDK() *sesv2types.EventDestinationDefinition {
+	out := &sesv2types.EventDestinationDefinition{
+		Enabled: c.Enabled,
+	}
+	if len(c.MatchingEventTypes) > 0 {
+		types := make([]sesv2types.EventType, len(c.MatchingEventTypes))
+		for i, t := range c.MatchingEventTypes {
+			types[i] = sesv2types.EventType(t)
+		}
+		out.MatchingEventTypes = types
+	}
+	if c.CloudWatchDestination != nil {
+		dims := make([]sesv2types.CloudWatchDimensionConfiguration, len(c.CloudWatchDestination.DimensionConfigurations))
+		for i, dc := range c.CloudWatchDestination.DimensionConfigurations {
+			name := dc.DimensionName
+			def := dc.DefaultDimensionValue
+			dims[i] = sesv2types.CloudWatchDimensionConfiguration{
+				DimensionName:         &name,
+				DefaultDimensionValue: &def,
+				DimensionValueSource:  sesv2types.DimensionValueSource(dc.DimensionValueSource),
+			}
+		}
+		out.CloudWatchDestination = &sesv2types.CloudWatchDestination{DimensionConfigurations: dims}
+	}
+	if c.SnsDestination != nil {
+		arn := c.SnsDestination.TopicARN
+		out.SnsDestination = &sesv2types.SnsDestination{TopicArn: &arn}
+	}
+	if c.KinesisFirehoseDestination != nil {
+		role := c.KinesisFirehoseDestination.IAMRoleARN
+		stream := c.KinesisFirehoseDestination.DeliveryStreamARN
+		out.KinesisFirehoseDestination = &sesv2types.KinesisFirehoseDestination{
+			IamRoleArn:        &role,
+			DeliveryStreamArn: &stream,
+		}
+	}
+	if c.EventBridgeDestination != nil {
+		bus := c.EventBridgeDestination.EventBusArn
+		out.EventBridgeDestination = &sesv2types.EventBridgeDestination{EventBusArn: &bus}
+	}
+	if c.PinpointDestination != nil {
+		app := c.PinpointDestination.ApplicationArn
+		out.PinpointDestination = &sesv2types.PinpointDestination{ApplicationArn: &app}
+	}
+	return out
 }
 
 // splitComposite splits "<csName>|<edName>" into its parts. ok is false if

--- a/pkg/cfres/ses/eventdestination_test.go
+++ b/pkg/cfres/ses/eventdestination_test.go
@@ -1,0 +1,216 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package ses
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/sesv2"
+	sesv2types "github.com/aws/aws-sdk-go-v2/service/sesv2/types"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/config"
+)
+
+func newEventDestinationTestProvisioner(client SesV2ClientInterface) *EventDestination {
+	return &EventDestination{
+		cfg:              &config.Config{},
+		sesClientFactory: func(_ *config.Config) (SesV2ClientInterface, error) { return client, nil },
+	}
+}
+
+func TestEventDestination_Update_SDKCall_ConvertsCFNShapeToSDKInput(t *testing.T) {
+	client := &mockSesV2Client{}
+	prov := newEventDestinationTestProvisioner(client)
+
+	desired := []byte(`{
+		"ConfigurationSetName": "my-cs",
+		"EventDestination": {
+			"Name": "bounces",
+			"Enabled": false,
+			"MatchingEventTypes": ["BOUNCE", "COMPLAINT"],
+			"CloudWatchDestination": {
+				"DimensionConfigurations": [
+					{"DimensionName": "ses:caller-identity", "DefaultDimensionValue": "default", "DimensionValueSource": "MESSAGE_TAG"}
+				]
+			}
+		}
+	}`)
+
+	client.On("UpdateConfigurationSetEventDestination", mock.Anything, mock.MatchedBy(func(input *sesv2.UpdateConfigurationSetEventDestinationInput) bool {
+		if input.ConfigurationSetName == nil || *input.ConfigurationSetName != "my-cs" {
+			return false
+		}
+		if input.EventDestinationName == nil || *input.EventDestinationName != "bounces" {
+			return false
+		}
+		ed := input.EventDestination
+		if ed == nil || ed.Enabled != false {
+			return false
+		}
+		if len(ed.MatchingEventTypes) != 2 || ed.MatchingEventTypes[0] != sesv2types.EventType("BOUNCE") {
+			return false
+		}
+		if ed.CloudWatchDestination == nil || len(ed.CloudWatchDestination.DimensionConfigurations) != 1 {
+			return false
+		}
+		dc := ed.CloudWatchDestination.DimensionConfigurations[0]
+		if dc.DimensionName == nil || *dc.DimensionName != "ses:caller-identity" {
+			return false
+		}
+		if dc.DimensionValueSource != sesv2types.DimensionValueSource("MESSAGE_TAG") {
+			return false
+		}
+		return true
+	})).Return(&sesv2.UpdateConfigurationSetEventDestinationOutput{}, nil)
+
+	// Mock the post-update Read.
+	client.On("GetConfigurationSetEventDestinations", mock.Anything, mock.Anything).Return(
+		&sesv2.GetConfigurationSetEventDestinationsOutput{
+			EventDestinations: []sesv2types.EventDestination{
+				{
+					Name:               stringPtr("bounces"),
+					Enabled:            false,
+					MatchingEventTypes: []sesv2types.EventType{"BOUNCE", "COMPLAINT"},
+				},
+			},
+		}, nil,
+	)
+
+	result, err := prov.Update(context.Background(), &resource.UpdateRequest{
+		ResourceType:      "AWS::SES::ConfigurationSetEventDestination",
+		NativeID:          "my-cs|bounces",
+		DesiredProperties: json.RawMessage(desired),
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result.ProgressResult)
+	require.Equal(t, resource.OperationStatusSuccess, result.ProgressResult.OperationStatus)
+	require.Equal(t, "my-cs|bounces", result.ProgressResult.NativeID)
+	require.NotEmpty(t, result.ProgressResult.ResourceProperties, "post-Update Read must populate ResourceProperties")
+	client.AssertExpectations(t)
+}
+
+func TestEventDestination_Update_BareNativeID_ReturnsError(t *testing.T) {
+	prov := newEventDestinationTestProvisioner(&mockSesV2Client{})
+
+	_, err := prov.Update(context.Background(), &resource.UpdateRequest{
+		ResourceType:      "AWS::SES::ConfigurationSetEventDestination",
+		NativeID:          "bounces",
+		DesiredProperties: json.RawMessage(`{"EventDestination": {"Enabled": false}}`),
+	})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "composite")
+}
+
+func TestEventDestination_Update_PlaceholderNativeID_ReturnsError(t *testing.T) {
+	// "csName|" placeholder is set by Create when CCAPI returns no ID yet —
+	// it should never reach Update (Update operates on an existing resource).
+	prov := newEventDestinationTestProvisioner(&mockSesV2Client{})
+
+	_, err := prov.Update(context.Background(), &resource.UpdateRequest{
+		ResourceType:      "AWS::SES::ConfigurationSetEventDestination",
+		NativeID:          "my-cs|",
+		DesiredProperties: json.RawMessage(`{"EventDestination": {"Enabled": false}}`),
+	})
+
+	require.Error(t, err)
+}
+
+func TestEventDestination_Update_DesiredMissingEventDestination_ReturnsError(t *testing.T) {
+	prov := newEventDestinationTestProvisioner(&mockSesV2Client{})
+
+	_, err := prov.Update(context.Background(), &resource.UpdateRequest{
+		ResourceType:      "AWS::SES::ConfigurationSetEventDestination",
+		NativeID:          "my-cs|bounces",
+		DesiredProperties: json.RawMessage(`{"ConfigurationSetName": "my-cs"}`),
+	})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "EventDestination")
+}
+
+func TestEventDestination_Update_SDKError_Propagates(t *testing.T) {
+	client := &mockSesV2Client{}
+	prov := newEventDestinationTestProvisioner(client)
+
+	client.On("UpdateConfigurationSetEventDestination", mock.Anything, mock.Anything).Return(
+		(*sesv2.UpdateConfigurationSetEventDestinationOutput)(nil), errors.New("AccessDenied"),
+	)
+
+	_, err := prov.Update(context.Background(), &resource.UpdateRequest{
+		ResourceType:      "AWS::SES::ConfigurationSetEventDestination",
+		NativeID:          "my-cs|bounces",
+		DesiredProperties: json.RawMessage(`{"EventDestination": {"Enabled": false}}`),
+	})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "UpdateConfigurationSetEventDestination")
+}
+
+func TestEventDestination_Update_SuccessButReadFails_StillReturnsSuccess(t *testing.T) {
+	// If the SDK Update succeeded, the operation is done from the AWS
+	// perspective — a failing post-update Read shouldn't flip Update to
+	// Failure. The agent will pick up the new state on its next sync.
+	client := &mockSesV2Client{}
+	prov := newEventDestinationTestProvisioner(client)
+
+	client.On("UpdateConfigurationSetEventDestination", mock.Anything, mock.Anything).Return(
+		&sesv2.UpdateConfigurationSetEventDestinationOutput{}, nil,
+	)
+	client.On("GetConfigurationSetEventDestinations", mock.Anything, mock.Anything).Return(
+		(*sesv2.GetConfigurationSetEventDestinationsOutput)(nil), errors.New("transient"),
+	)
+
+	result, err := prov.Update(context.Background(), &resource.UpdateRequest{
+		ResourceType:      "AWS::SES::ConfigurationSetEventDestination",
+		NativeID:          "my-cs|bounces",
+		DesiredProperties: json.RawMessage(`{"EventDestination": {"Enabled": false}}`),
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result.ProgressResult)
+	require.Equal(t, resource.OperationStatusSuccess, result.ProgressResult.OperationStatus)
+	require.Empty(t, result.ProgressResult.ResourceProperties)
+}
+
+func TestParseEventDestinationFromDesired_AllDestinationTypes(t *testing.T) {
+	// Exercise every destination shape so refactors to the CFN→SDK mapping
+	// don't silently drop a destination type.
+	desired := []byte(`{
+		"EventDestination": {
+			"Enabled": true,
+			"MatchingEventTypes": ["SEND"],
+			"SnsDestination": {"TopicARN": "arn:aws:sns:us-east-1:1:t"},
+			"KinesisFirehoseDestination": {"IAMRoleARN": "arn:aws:iam::1:role/r", "DeliveryStreamARN": "arn:aws:firehose:us-east-1:1:deliverystream/s"},
+			"EventBridgeDestination": {"EventBusArn": "arn:aws:events:us-east-1:1:event-bus/default"},
+			"PinpointDestination": {"ApplicationArn": "arn:aws:mobiletargeting:us-east-1:1:apps/x"}
+		}
+	}`)
+
+	sdkED, err := parseEventDestinationFromDesired(desired)
+	require.NoError(t, err)
+	require.NotNil(t, sdkED)
+	require.True(t, sdkED.Enabled)
+	require.NotNil(t, sdkED.SnsDestination)
+	require.Equal(t, "arn:aws:sns:us-east-1:1:t", *sdkED.SnsDestination.TopicArn)
+	require.NotNil(t, sdkED.KinesisFirehoseDestination)
+	require.Equal(t, "arn:aws:iam::1:role/r", *sdkED.KinesisFirehoseDestination.IamRoleArn)
+	require.Equal(t, "arn:aws:firehose:us-east-1:1:deliverystream/s", *sdkED.KinesisFirehoseDestination.DeliveryStreamArn)
+	require.NotNil(t, sdkED.EventBridgeDestination)
+	require.Equal(t, "arn:aws:events:us-east-1:1:event-bus/default", *sdkED.EventBridgeDestination.EventBusArn)
+	require.NotNil(t, sdkED.PinpointDestination)
+	require.Equal(t, "arn:aws:mobiletargeting:us-east-1:1:apps/x", *sdkED.PinpointDestination.ApplicationArn)
+}
+
+func stringPtr(s string) *string { return &s }

--- a/pkg/cfres/ses/eventdestination_test.go
+++ b/pkg/cfres/ses/eventdestination_test.go
@@ -213,4 +213,88 @@ func TestParseEventDestinationFromDesired_AllDestinationTypes(t *testing.T) {
 	require.Equal(t, "arn:aws:mobiletargeting:us-east-1:1:apps/x", *sdkED.PinpointDestination.ApplicationArn)
 }
 
+func TestEventDestination_Delete_SDKCall_SplitsCompositeIdentifier(t *testing.T) {
+	client := &mockSesV2Client{}
+	prov := newEventDestinationTestProvisioner(client)
+
+	client.On("DeleteConfigurationSetEventDestination", mock.Anything, mock.MatchedBy(func(input *sesv2.DeleteConfigurationSetEventDestinationInput) bool {
+		return input.ConfigurationSetName != nil && *input.ConfigurationSetName == "my-cs" &&
+			input.EventDestinationName != nil && *input.EventDestinationName == "bounces"
+	})).Return(&sesv2.DeleteConfigurationSetEventDestinationOutput{}, nil)
+
+	result, err := prov.Delete(context.Background(), &resource.DeleteRequest{
+		ResourceType: "AWS::SES::ConfigurationSetEventDestination",
+		NativeID:     "my-cs|bounces",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result.ProgressResult)
+	require.Equal(t, resource.OperationStatusSuccess, result.ProgressResult.OperationStatus)
+	require.Equal(t, "my-cs|bounces", result.ProgressResult.NativeID)
+	client.AssertExpectations(t)
+}
+
+func TestEventDestination_Delete_BareNativeID_ReturnsError(t *testing.T) {
+	prov := newEventDestinationTestProvisioner(&mockSesV2Client{})
+
+	_, err := prov.Delete(context.Background(), &resource.DeleteRequest{
+		ResourceType: "AWS::SES::ConfigurationSetEventDestination",
+		NativeID:     "bounces",
+	})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "composite")
+}
+
+func TestEventDestination_Delete_PlaceholderNativeID_ReturnsError(t *testing.T) {
+	prov := newEventDestinationTestProvisioner(&mockSesV2Client{})
+
+	_, err := prov.Delete(context.Background(), &resource.DeleteRequest{
+		ResourceType: "AWS::SES::ConfigurationSetEventDestination",
+		NativeID:     "my-cs|",
+	})
+
+	require.Error(t, err)
+}
+
+func TestEventDestination_Delete_NotFoundException_ReturnsSuccess(t *testing.T) {
+	// Idempotent delete: AWS NotFound becomes a successful no-op so a
+	// destroy that runs twice (e.g., a retried changeset step) doesn't
+	// fail the second time.
+	client := &mockSesV2Client{}
+	prov := newEventDestinationTestProvisioner(client)
+
+	client.On("DeleteConfigurationSetEventDestination", mock.Anything, mock.Anything).Return(
+		(*sesv2.DeleteConfigurationSetEventDestinationOutput)(nil),
+		&sesv2types.NotFoundException{Message: stringPtr("Event destination not found")},
+	)
+
+	result, err := prov.Delete(context.Background(), &resource.DeleteRequest{
+		ResourceType: "AWS::SES::ConfigurationSetEventDestination",
+		NativeID:     "my-cs|bounces",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result.ProgressResult)
+	require.Equal(t, resource.OperationStatusSuccess, result.ProgressResult.OperationStatus)
+	require.Equal(t, resource.OperationErrorCodeNotFound, result.ProgressResult.ErrorCode)
+}
+
+func TestEventDestination_Delete_OtherSDKError_Propagates(t *testing.T) {
+	client := &mockSesV2Client{}
+	prov := newEventDestinationTestProvisioner(client)
+
+	client.On("DeleteConfigurationSetEventDestination", mock.Anything, mock.Anything).Return(
+		(*sesv2.DeleteConfigurationSetEventDestinationOutput)(nil), errors.New("AccessDenied"),
+	)
+
+	_, err := prov.Delete(context.Background(), &resource.DeleteRequest{
+		ResourceType: "AWS::SES::ConfigurationSetEventDestination",
+		NativeID:     "my-cs|bounces",
+	})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "DeleteConfigurationSetEventDestination")
+}
+
 func stringPtr(s string) *string { return &s }

--- a/pkg/cfres/ses/eventdestination_test.go
+++ b/pkg/cfres/ses/eventdestination_test.go
@@ -297,4 +297,94 @@ func TestEventDestination_Delete_OtherSDKError_Propagates(t *testing.T) {
 	require.Contains(t, err.Error(), "DeleteConfigurationSetEventDestination")
 }
 
+func TestEventDestination_List_WalksAllConfigurationSets_EmitsComposites(t *testing.T) {
+	client := &mockSesV2Client{}
+	prov := newEventDestinationTestProvisioner(client)
+
+	// Page 1: two CSes
+	client.On("ListConfigurationSets", mock.Anything, mock.MatchedBy(func(in *sesv2.ListConfigurationSetsInput) bool {
+		return in.NextToken == nil
+	})).Return(&sesv2.ListConfigurationSetsOutput{
+		ConfigurationSets: []string{"cs-a", "cs-b"},
+		NextToken:         stringPtr("page2"),
+	}, nil)
+
+	// Page 2: one CS, no further pages
+	client.On("ListConfigurationSets", mock.Anything, mock.MatchedBy(func(in *sesv2.ListConfigurationSetsInput) bool {
+		return in.NextToken != nil && *in.NextToken == "page2"
+	})).Return(&sesv2.ListConfigurationSetsOutput{
+		ConfigurationSets: []string{"cs-c"},
+		NextToken:         nil,
+	}, nil)
+
+	client.On("GetConfigurationSetEventDestinations", mock.Anything, mock.MatchedBy(func(in *sesv2.GetConfigurationSetEventDestinationsInput) bool {
+		return in.ConfigurationSetName != nil && *in.ConfigurationSetName == "cs-a"
+	})).Return(&sesv2.GetConfigurationSetEventDestinationsOutput{
+		EventDestinations: []sesv2types.EventDestination{{Name: stringPtr("bounces")}, {Name: stringPtr("complaints")}},
+	}, nil)
+	client.On("GetConfigurationSetEventDestinations", mock.Anything, mock.MatchedBy(func(in *sesv2.GetConfigurationSetEventDestinationsInput) bool {
+		return in.ConfigurationSetName != nil && *in.ConfigurationSetName == "cs-b"
+	})).Return(&sesv2.GetConfigurationSetEventDestinationsOutput{
+		EventDestinations: []sesv2types.EventDestination{}, // no destinations
+	}, nil)
+	client.On("GetConfigurationSetEventDestinations", mock.Anything, mock.MatchedBy(func(in *sesv2.GetConfigurationSetEventDestinationsInput) bool {
+		return in.ConfigurationSetName != nil && *in.ConfigurationSetName == "cs-c"
+	})).Return(&sesv2.GetConfigurationSetEventDestinationsOutput{
+		EventDestinations: []sesv2types.EventDestination{{Name: stringPtr("deliveries")}},
+	}, nil)
+
+	result, err := prov.List(context.Background(), &resource.ListRequest{
+		ResourceType: "AWS::SES::ConfigurationSetEventDestination",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.ElementsMatch(t, []string{"cs-a|bounces", "cs-a|complaints", "cs-c|deliveries"}, result.NativeIDs,
+		"List must emit composite IDs so subsequent Read/Update/Delete have the parent CS context")
+}
+
+func TestEventDestination_List_SkipsCSWhereGetFails(t *testing.T) {
+	// A CS that we can't read shouldn't fail the entire discovery scan —
+	// just skip it. AWS commonly returns AccessDenied for CSes we don't own.
+	client := &mockSesV2Client{}
+	prov := newEventDestinationTestProvisioner(client)
+
+	client.On("ListConfigurationSets", mock.Anything, mock.Anything).Return(&sesv2.ListConfigurationSetsOutput{
+		ConfigurationSets: []string{"cs-good", "cs-broken"},
+	}, nil)
+	client.On("GetConfigurationSetEventDestinations", mock.Anything, mock.MatchedBy(func(in *sesv2.GetConfigurationSetEventDestinationsInput) bool {
+		return in.ConfigurationSetName != nil && *in.ConfigurationSetName == "cs-good"
+	})).Return(&sesv2.GetConfigurationSetEventDestinationsOutput{
+		EventDestinations: []sesv2types.EventDestination{{Name: stringPtr("bounces")}},
+	}, nil)
+	client.On("GetConfigurationSetEventDestinations", mock.Anything, mock.MatchedBy(func(in *sesv2.GetConfigurationSetEventDestinationsInput) bool {
+		return in.ConfigurationSetName != nil && *in.ConfigurationSetName == "cs-broken"
+	})).Return((*sesv2.GetConfigurationSetEventDestinationsOutput)(nil), errors.New("AccessDenied"))
+
+	result, err := prov.List(context.Background(), &resource.ListRequest{
+		ResourceType: "AWS::SES::ConfigurationSetEventDestination",
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"cs-good|bounces"}, result.NativeIDs)
+}
+
+func TestEventDestination_List_ListConfigurationSetsError_Propagates(t *testing.T) {
+	// If we can't even start listing CSes, fail loudly — that's not a
+	// recoverable per-CS hiccup.
+	client := &mockSesV2Client{}
+	prov := newEventDestinationTestProvisioner(client)
+
+	client.On("ListConfigurationSets", mock.Anything, mock.Anything).Return(
+		(*sesv2.ListConfigurationSetsOutput)(nil), errors.New("throttled"),
+	)
+
+	_, err := prov.List(context.Background(), &resource.ListRequest{
+		ResourceType: "AWS::SES::ConfigurationSetEventDestination",
+	})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "ListConfigurationSets")
+}
+
 func stringPtr(s string) *string { return &s }

--- a/pkg/cfres/ses/sesclient.go
+++ b/pkg/cfres/ses/sesclient.go
@@ -18,4 +18,5 @@ type SesV2ClientInterface interface {
 	GetConfigurationSetEventDestinations(ctx context.Context, params *sesv2.GetConfigurationSetEventDestinationsInput, optFns ...func(*sesv2.Options)) (*sesv2.GetConfigurationSetEventDestinationsOutput, error)
 	UpdateConfigurationSetEventDestination(ctx context.Context, params *sesv2.UpdateConfigurationSetEventDestinationInput, optFns ...func(*sesv2.Options)) (*sesv2.UpdateConfigurationSetEventDestinationOutput, error)
 	DeleteConfigurationSetEventDestination(ctx context.Context, params *sesv2.DeleteConfigurationSetEventDestinationInput, optFns ...func(*sesv2.Options)) (*sesv2.DeleteConfigurationSetEventDestinationOutput, error)
+	ListConfigurationSets(ctx context.Context, params *sesv2.ListConfigurationSetsInput, optFns ...func(*sesv2.Options)) (*sesv2.ListConfigurationSetsOutput, error)
 }

--- a/pkg/cfres/ses/sesclient.go
+++ b/pkg/cfres/ses/sesclient.go
@@ -16,4 +16,5 @@ import (
 type SesV2ClientInterface interface {
 	GetEmailIdentity(ctx context.Context, params *sesv2.GetEmailIdentityInput, optFns ...func(*sesv2.Options)) (*sesv2.GetEmailIdentityOutput, error)
 	GetConfigurationSetEventDestinations(ctx context.Context, params *sesv2.GetConfigurationSetEventDestinationsInput, optFns ...func(*sesv2.Options)) (*sesv2.GetConfigurationSetEventDestinationsOutput, error)
+	UpdateConfigurationSetEventDestination(ctx context.Context, params *sesv2.UpdateConfigurationSetEventDestinationInput, optFns ...func(*sesv2.Options)) (*sesv2.UpdateConfigurationSetEventDestinationOutput, error)
 }

--- a/pkg/cfres/ses/sesclient.go
+++ b/pkg/cfres/ses/sesclient.go
@@ -17,4 +17,5 @@ type SesV2ClientInterface interface {
 	GetEmailIdentity(ctx context.Context, params *sesv2.GetEmailIdentityInput, optFns ...func(*sesv2.Options)) (*sesv2.GetEmailIdentityOutput, error)
 	GetConfigurationSetEventDestinations(ctx context.Context, params *sesv2.GetConfigurationSetEventDestinationsInput, optFns ...func(*sesv2.Options)) (*sesv2.GetConfigurationSetEventDestinationsOutput, error)
 	UpdateConfigurationSetEventDestination(ctx context.Context, params *sesv2.UpdateConfigurationSetEventDestinationInput, optFns ...func(*sesv2.Options)) (*sesv2.UpdateConfigurationSetEventDestinationOutput, error)
+	DeleteConfigurationSetEventDestination(ctx context.Context, params *sesv2.DeleteConfigurationSetEventDestinationInput, optFns ...func(*sesv2.Options)) (*sesv2.DeleteConfigurationSetEventDestinationOutput, error)
 }


### PR DESCRIPTION
## Summary
- Translate sync CloudControl errors from Create/Update/Delete into `ProgressResult{Failure, ErrorCode}` so formae's PluginOperator can retry recoverable codes (Throttling, NotStabilized, ResourceConflict, etc.) instead of tagging everything as terminal UnforeseenError. Includes an eventual-consistency override that remaps the RDS "Some input subnets … are invalid" error to a recoverable code, unblocking the rds-dbinstance Discovery [CreateOOB] test.
- Route AWS::SES::ConfigurationSetEventDestination Update, Delete, and List through the sesv2 SDK directly. CCAPI rejects the composite `<csName>|<edName>` identifier on all non-Read paths and returns bare edNames from List; mirrors the existing custom Read fix for the same root cause. Unblocks Update, Replace, and Discovery for ses-eventdestination.
- Verified end-to-end on the debug conformance workflow: both rds-dbinstance (CRUD + Discovery) and ses-eventdestination (CRUD + Discovery) now pass cleanly against the latest released formae.