### PR TITLE
fix(elbv2): stop modeling runtime-managed TG.Targets and TG.LoadBalancerArns

### DIFF
--- a/pkg/ccx/client.go
+++ b/pkg/ccx/client.go
@@ -52,6 +52,14 @@ var IgnoredFields = map[string][]string{
 	"AWS::EC2::SecurityGroup":                      {"$.SecurityGroupEgress", "$.SecurityGroupIngress"},
 	"AWS::IAM::Role":                               {"$.Policies"},
 	"AWS::ElasticBeanstalk::ConfigurationTemplate": {"$.OptionSettings"},
+	// Targets is populated at runtime by ECS Services (and other consumers
+	// calling register-targets); LoadBalancerArns is populated when a
+	// Listener attaches the TG to an ALB. Neither is meaningfully
+	// user-settable, and tracking them in formae state makes the
+	// Synchronizer write a new resource version on every task placement
+	// or attach — which then trips the reconcile drift gate on the next
+	// apply. Strip them in Read so they never enter the stored state.
+	"AWS::ElasticLoadBalancingV2::TargetGroup": {"$.Targets", "$.LoadBalancerArns"},
 }
 
 // normalizeCompositeIdentifier fixes inconsistencies in CloudControl composite

--- a/schema/pkl/elasticloadbalancingv2/targetgroup.pkl
+++ b/schema/pkl/elasticloadbalancingv2/targetgroup.pkl
@@ -18,13 +18,6 @@ open class Matcher extends formae.SubResource {
 }
 
 @aws.SubResourceHint
-open class TargetDescription extends formae.SubResource {
-    availabilityZone: aws.AvailabilityZone?
-    id: String
-    port: Int?
-}
-
-@aws.SubResourceHint
 open class TargetGroupAttribute extends formae.SubResource {
     key: String?
     value: String?
@@ -40,9 +33,6 @@ open class TargetGroupResolvable extends formae.Resolvable {
 
     hidden arn: TargetGroupResolvable = (this) {
         property = "TargetGroupArn"
-    }
-    hidden loadBalancerArns: TargetGroupResolvable = (this) {
-        property = "LoadBalancerArns"
     }
 
     hidden targetGroupArn: TargetGroupResolvable = (this) {
@@ -125,9 +115,6 @@ open class TargetGroup extends formae.Resource {
 
     @aws.FieldHint{createOnly = true}
     targetType: String?
-
-    @aws.FieldHint{hasProviderDefault = true}
-    targets: Listing<TargetDescription>?
 
     @aws.FieldHint{hasProviderDefault = true}
     unhealthyThresholdCount: Int?


### PR DESCRIPTION
## Summary
- Drop `targets`, the `TargetDescription` SubResource class, and the `loadBalancerArns` resolvable accessor from the `AWS::ElasticLoadBalancingV2::TargetGroup` PKL schema. Neither field is meaningfully user-settable: `Targets` is populated at runtime by ECS Services and other consumers of the `register-targets` API; `LoadBalancerArns` is populated when a Listener attaches the TG to an ALB.
- Add `AWS::ElasticLoadBalancingV2::TargetGroup` to `IgnoredFields` in the CloudControl client so `$.Targets` and `$.LoadBalancerArns` are stripped from the Read response before the result enters formae's stored state. Same pattern as the existing entries for `AWS::EC2::SecurityGroup` ingress/egress, `AWS::IAM::Role` policies, and `AWS::ElasticBeanstalk::ConfigurationTemplate` option settings.
- Resolves spurious drift where the periodic Synchronizer wrote a new resource version on every ECS task placement and every Listener attach, which then tripped the reconcile drift gate and forced operators into `--force` (or extract-and-absorb) on every subsequent apply.