### PR TITLE
feat(ecs): track ECS Service deployment stability via Phase A/B Status polling

### DIFF
--- a/.github/workflows/debug-conformance.yml
+++ b/.github/workflows/debug-conformance.yml
@@ -157,7 +157,10 @@ jobs:
           AWS_REGION: us-east-1
           FORMAE_TEST_RUN_ID: debug-${{ github.run_id }}-${{ github.run_attempt }}
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
-        run: make conformance-test-crud-run conformance-test-discovery-run TEST=${{ matrix.test-case }} PARALLEL=1 TIMEOUT=60
+        # 90-minute timeout accommodates LB-attached fixtures (ALB provisioning
+        # + ECS stabilization + destroy + reapply takes 65-80m). Smaller fixtures
+        # are unaffected — they finish well under the bound.
+        run: make conformance-test-crud-run conformance-test-discovery-run TEST=${{ matrix.test-case }} PARALLEL=1 TIMEOUT=90
 
       - name: Dump formae client log on failure
         if: failure()

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.299.0
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.77.0
 	github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk v1.33.20
+	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.54.12
 	github.com/aws/aws-sdk-go-v2/service/iam v1.53.8
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.90.0
 	github.com/aws/aws-sdk-go-v2/service/route53 v1.62.6

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/aws/aws-sdk-go-v2/service/ecs v1.77.0 h1:g3RYQmK6uRU5kOuwDthemuiiTbmw
 github.com/aws/aws-sdk-go-v2/service/ecs v1.77.0/go.mod h1:QkWmubOYmjj3cHn7A4CoUU7BKJhVeo39Gp6NH7IyhZw=
 github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk v1.33.20 h1:0jvM1QtdJPeox3KX7zLV0XWb1rJpvHmVkoAPY3P3hz0=
 github.com/aws/aws-sdk-go-v2/service/elasticbeanstalk v1.33.20/go.mod h1:73bxyBZbIDX0ulG9AgJsGgodZSiqwMoWDyiDY8Rj6Zk=
+github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.54.12 h1:TJXv7kZjdXA2maPDaJFFEQPBrPmvPtMybN3qYDOpJ4Y=
+github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.54.12/go.mod h1:lwjtb9DHOAmNt7EUW68Zd1Qd+cPyFxacXHN5c9JZ2VY=
 github.com/aws/aws-sdk-go-v2/service/iam v1.53.8 h1:p0oB4eZfBfBAOasnKvHJOlNcuHVE/ieuWs7uIZgQlyQ=
 github.com/aws/aws-sdk-go-v2/service/iam v1.53.8/go.mod h1:epCaPnGVdiX5ra1lHPfRkVuiQGxrdY8bRI2FBJU+6ok=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.8 h1:HtOTYcbVcGABLOVuPYaIihj6IlkqubBwFj10K5fxRek=

--- a/pkg/cfres/ecs/classify.go
+++ b/pkg/cfres/ecs/classify.go
@@ -1,0 +1,91 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package ecs
+
+import (
+	"errors"
+	"net"
+
+	"github.com/aws/smithy-go"
+
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+)
+
+// classifyAWSError maps an error from an AWS SDK call (or our own ccx layer) to
+// a (errorCode, retryable) verdict. See design Q5 for the full mapping.
+//
+// Discipline: unknown errors default to TERMINAL (GeneralServiceException) — fail
+// loudly rather than poll forever on something we don't recognize. The 20-minute
+// operation timeout (via inProgressOrTimeout) means even retryable verdicts can
+// escalate to terminal Failure if they persist.
+func classifyAWSError(err error) (resource.OperationErrorCode, bool) {
+	if err == nil {
+		return "", false
+	}
+	var ae smithy.APIError
+	if errors.As(err, &ae) {
+		switch ae.ErrorCode() {
+		// Retryable
+		case "Throttling", "ThrottlingException", "RequestLimitExceeded",
+			"TooManyRequestsException":
+			return resource.OperationErrorCodeThrottling, true
+		case "ServiceUnavailable", "ServiceUnavailableException":
+			return resource.OperationErrorCodeServiceInternalError, true
+		case "InternalFailure", "InternalServerError":
+			return resource.OperationErrorCodeServiceInternalError, true
+		// Terminal — auth/permissions
+		case "AccessDenied", "AccessDeniedException", "UnauthorizedOperation":
+			return resource.OperationErrorCodeAccessDenied, false
+		case "ExpiredToken", "InvalidClientTokenId",
+			"InvalidSignatureException", "SignatureDoesNotMatch":
+			return resource.OperationErrorCodeInvalidCredentials, false
+		// Terminal — validation
+		case "ValidationException", "InvalidParameterException",
+			"InvalidParameterValueException", "InvalidInputException":
+			return resource.OperationErrorCodeInvalidRequest, false
+		}
+	}
+	// Network errors with .Timeout() == true → retryable
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return resource.OperationErrorCodeNetworkFailure, true
+	}
+	return resource.OperationErrorCodeGeneralServiceException, false
+}
+
+// classifyForEntry is used by Create/Update entry. Retryable AWS errors return
+// a recoverable ErrorCode so the operator's handlePluginResult schedules a CRUD
+// retry of the entire operation. Terminal errors get a non-recoverable code so
+// the operator surfaces the failure immediately.
+func classifyForEntry(err error, op resource.Operation, nativeID, contextMsg string) *resource.ProgressResult {
+	code, retryable := classifyAWSError(err)
+	if retryable {
+		// Map our verdict to a recoverable code the SDK's recoverableErrorCodes
+		// table actually recognises. (Throttling, NetworkFailure, ServiceInternalError
+		// are all in the table — see pkg/plugin/resource/resource.go:172-181.)
+		switch code {
+		case resource.OperationErrorCodeThrottling,
+			resource.OperationErrorCodeNetworkFailure,
+			resource.OperationErrorCodeServiceInternalError:
+			// already recoverable
+		default:
+			code = resource.OperationErrorCodeThrottling
+		}
+	}
+	return terminalFailurePR(op, nativeID, "", code, contextMsg+": "+err.Error())
+}
+
+// terminalFailurePR builds a populated Failure ProgressResult.
+func terminalFailurePR(op resource.Operation, nativeID, requestID string,
+	code resource.OperationErrorCode, msg string) *resource.ProgressResult {
+	return &resource.ProgressResult{
+		Operation:       op,
+		OperationStatus: resource.OperationStatusFailure,
+		NativeID:        nativeID,
+		RequestID:       requestID,
+		ErrorCode:       code,
+		StatusMessage:   msg,
+	}
+}

--- a/pkg/cfres/ecs/classify.go
+++ b/pkg/cfres/ecs/classify.go
@@ -89,3 +89,41 @@ func terminalFailurePR(op resource.Operation, nativeID, requestID string,
 		StatusMessage:   msg,
 	}
 }
+
+// classifyReadResultForFinal classifies a post-stability Read outcome. Handles
+// both Go errors and ReadResult.ErrorCode (ccx.ReadResource maps CCAPI errors
+// into ErrorCode without returning a Go error — see pkg/ccx/client.go:294-303).
+//
+// Returns:
+//   - ok=true:                 Read returned non-empty Properties → caller emits Success
+//   - ok=false, retryable=true: route through inProgressOrFinalReadTimeout (grace-bounded)
+//   - ok=false, retryable=false: terminal Failure with `code`
+func classifyReadResultForFinal(rr *resource.ReadResult, readErr error) (resource.OperationErrorCode, bool, bool) {
+	if readErr != nil {
+		code, retryable := classifyAWSError(readErr)
+		return code, retryable, false
+	}
+	if rr == nil {
+		return resource.OperationErrorCodeGeneralServiceException, false, false
+	}
+	switch rr.ErrorCode {
+	case "":
+		if rr.Properties == "" {
+			return "", true, false // retryable: empty body without error
+		}
+		return "", false, true // success
+	case resource.OperationErrorCodeNotFound,
+		resource.OperationErrorCodeThrottling,
+		resource.OperationErrorCodeServiceInternalError,
+		resource.OperationErrorCodeServiceTimeout,
+		resource.OperationErrorCodeNetworkFailure,
+		resource.OperationErrorCodeInternalFailure:
+		return rr.ErrorCode, true, false
+	case resource.OperationErrorCodeAccessDenied,
+		resource.OperationErrorCodeInvalidCredentials,
+		resource.OperationErrorCodeInvalidRequest:
+		return rr.ErrorCode, false, false
+	default:
+		return resource.OperationErrorCodeGeneralServiceException, false, false
+	}
+}

--- a/pkg/cfres/ecs/classify_test.go
+++ b/pkg/cfres/ecs/classify_test.go
@@ -1,0 +1,86 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package ecs
+
+import (
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/aws/smithy-go"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+)
+
+type fakeAPIError struct{ code, msg string }
+
+func (e *fakeAPIError) Error() string                 { return e.code + ": " + e.msg }
+func (e *fakeAPIError) ErrorCode() string             { return e.code }
+func (e *fakeAPIError) ErrorMessage() string          { return e.msg }
+func (e *fakeAPIError) ErrorFault() smithy.ErrorFault { return smithy.FaultServer }
+
+func TestClassifyAWSError_Throttling(t *testing.T) {
+	code, retryable := classifyAWSError(&fakeAPIError{code: "Throttling", msg: "Rate exceeded"})
+	assert.True(t, retryable)
+	assert.Equal(t, resource.OperationErrorCodeThrottling, code)
+}
+
+func TestClassifyAWSError_AccessDenied(t *testing.T) {
+	code, retryable := classifyAWSError(&fakeAPIError{code: "AccessDenied", msg: "denied"})
+	assert.False(t, retryable)
+	assert.Equal(t, resource.OperationErrorCodeAccessDenied, code)
+}
+
+func TestClassifyAWSError_ExpiredToken(t *testing.T) {
+	code, retryable := classifyAWSError(&fakeAPIError{code: "ExpiredToken", msg: "expired"})
+	assert.False(t, retryable)
+	assert.Equal(t, resource.OperationErrorCodeInvalidCredentials, code)
+}
+
+func TestClassifyAWSError_ValidationException(t *testing.T) {
+	code, retryable := classifyAWSError(&fakeAPIError{code: "ValidationException", msg: "bad input"})
+	assert.False(t, retryable)
+	assert.Equal(t, resource.OperationErrorCodeInvalidRequest, code)
+}
+
+func TestClassifyAWSError_UnknownCode_TerminalGeneralServiceException(t *testing.T) {
+	code, retryable := classifyAWSError(&fakeAPIError{code: "SomethingBrandNew", msg: "?"})
+	assert.False(t, retryable)
+	assert.Equal(t, resource.OperationErrorCodeGeneralServiceException, code)
+}
+
+type timeoutErr struct{}
+
+func (timeoutErr) Error() string   { return "i/o timeout" }
+func (timeoutErr) Timeout() bool   { return true }
+func (timeoutErr) Temporary() bool { return true }
+
+var _ net.Error = timeoutErr{}
+
+func TestClassifyAWSError_NetworkTimeout_Retryable(t *testing.T) {
+	code, retryable := classifyAWSError(timeoutErr{})
+	assert.True(t, retryable)
+	assert.Equal(t, resource.OperationErrorCodeNetworkFailure, code)
+}
+
+func TestClassifyAWSError_PlainError_TerminalGeneralServiceException(t *testing.T) {
+	code, retryable := classifyAWSError(errors.New("some random non-AWS error"))
+	assert.False(t, retryable)
+	assert.Equal(t, resource.OperationErrorCodeGeneralServiceException, code)
+}
+
+func TestTerminalFailurePR(t *testing.T) {
+	pr := terminalFailurePR(resource.OperationCreate, "nid", "rid",
+		resource.OperationErrorCodeAccessDenied, "denied here")
+	assert.Equal(t, resource.OperationCreate, pr.Operation)
+	assert.Equal(t, resource.OperationStatusFailure, pr.OperationStatus)
+	assert.Equal(t, "nid", pr.NativeID)
+	assert.Equal(t, "rid", pr.RequestID)
+	assert.Equal(t, resource.OperationErrorCodeAccessDenied, pr.ErrorCode)
+	assert.Contains(t, pr.StatusMessage, "denied here")
+}

--- a/pkg/cfres/ecs/classify_test.go
+++ b/pkg/cfres/ecs/classify_test.go
@@ -84,3 +84,39 @@ func TestTerminalFailurePR(t *testing.T) {
 	assert.Equal(t, resource.OperationErrorCodeAccessDenied, pr.ErrorCode)
 	assert.Contains(t, pr.StatusMessage, "denied here")
 }
+
+func TestClassifyReadResultForFinal_Success(t *testing.T) {
+	rr := &resource.ReadResult{Properties: `{"k":"v"}`}
+	code, retryable, ok := classifyReadResultForFinal(rr, nil)
+	assert.True(t, ok)
+	assert.False(t, retryable)
+	assert.Equal(t, resource.OperationErrorCode(""), code)
+}
+
+func TestClassifyReadResultForFinal_NotFound_Retryable(t *testing.T) {
+	rr := &resource.ReadResult{ErrorCode: resource.OperationErrorCodeNotFound}
+	_, retryable, ok := classifyReadResultForFinal(rr, nil)
+	assert.False(t, ok)
+	assert.True(t, retryable)
+}
+
+func TestClassifyReadResultForFinal_AccessDenied_Terminal(t *testing.T) {
+	rr := &resource.ReadResult{ErrorCode: resource.OperationErrorCodeAccessDenied}
+	code, retryable, ok := classifyReadResultForFinal(rr, nil)
+	assert.False(t, ok)
+	assert.False(t, retryable)
+	assert.Equal(t, resource.OperationErrorCodeAccessDenied, code)
+}
+
+func TestClassifyReadResultForFinal_EmptyProperties_Retryable(t *testing.T) {
+	rr := &resource.ReadResult{ErrorCode: "", Properties: ""}
+	_, retryable, ok := classifyReadResultForFinal(rr, nil)
+	assert.False(t, ok)
+	assert.True(t, retryable)
+}
+
+func TestClassifyReadResultForFinal_GoError_GoesThroughAWSClassifier(t *testing.T) {
+	_, retryable, ok := classifyReadResultForFinal(nil, &fakeAPIError{code: "Throttling"})
+	assert.False(t, ok)
+	assert.True(t, retryable)
+}

--- a/pkg/cfres/ecs/clients.go
+++ b/pkg/cfres/ecs/clients.go
@@ -1,0 +1,56 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package ecs
+
+import (
+	"context"
+	"fmt"
+
+	awsecs "github.com/aws/aws-sdk-go-v2/service/ecs"
+	awselbv2 "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/ccx"
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/config"
+)
+
+// ccxClient is the surface of pkg/ccx the ECS provisioner depends on. Defined
+// here so unit tests can mock just the methods we actually call.
+type ccxClient interface {
+	CreateResource(ctx context.Context, req *resource.CreateRequest) (*resource.CreateResult, error)
+	UpdateResource(ctx context.Context, req *resource.UpdateRequest) (*resource.UpdateResult, error)
+	StatusResource(ctx context.Context, req *resource.StatusRequest, readFunc func(context.Context, *resource.ReadRequest) (*resource.ReadResult, error)) (*resource.StatusResult, error)
+	ReadResource(ctx context.Context, req *resource.ReadRequest) (*resource.ReadResult, error)
+}
+
+// ecsClient is the surface of the AWS ECS SDK used by the Service provisioner for stability polling.
+type ecsClient interface {
+	DescribeServices(ctx context.Context, params *awsecs.DescribeServicesInput, optFns ...func(*awsecs.Options)) (*awsecs.DescribeServicesOutput, error)
+}
+
+// elbv2Client is the surface of the AWS ELBv2 SDK used by the Service provisioner for target-health checks.
+type elbv2Client interface {
+	DescribeTargetHealth(ctx context.Context, params *awselbv2.DescribeTargetHealthInput, optFns ...func(*awselbv2.Options)) (*awselbv2.DescribeTargetHealthOutput, error)
+}
+
+func defaultCCXClientFactory(cfg *config.Config) (ccxClient, error) {
+	return ccx.NewClient(cfg)
+}
+
+func defaultECSClientFactory(cfg *config.Config) (ecsClient, error) {
+	awsCfg, err := cfg.ToAwsConfig(context.Background())
+	if err != nil {
+		return nil, fmt.Errorf("ecs: build AWS config: %w", err)
+	}
+	return awsecs.NewFromConfig(awsCfg), nil
+}
+
+func defaultELBv2ClientFactory(cfg *config.Config) (elbv2Client, error) {
+	awsCfg, err := cfg.ToAwsConfig(context.Background())
+	if err != nil {
+		return nil, fmt.Errorf("elbv2: build AWS config: %w", err)
+	}
+	return awselbv2.NewFromConfig(awsCfg), nil
+}

--- a/pkg/cfres/ecs/parse.go
+++ b/pkg/cfres/ecs/parse.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 
+	awsecs "github.com/aws/aws-sdk-go-v2/service/ecs"
+
 	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
 )
 
@@ -152,4 +154,60 @@ func parseUpdateClusterAndService(nativeID string) (cluster, service string, err
 		return "", "", fmt.Errorf("malformed Update NativeID: %q", nativeID)
 	}
 	return c, s, nil
+}
+
+// wrapForCreate encodes the composite RequestID and (when CCAPI didn't give us a
+// canonical identifier) a synthetic NativeID, so the operator-preserved fields
+// carry enough state for Phase B dispatch without depending on CCAPI returning
+// an Identifier first. If CCAPI returned sync Success, also rewrite to InProgress
+// so the operator transitions into status-polling. No-op for missing RequestID
+// (CCAPI returned an error-shaped result with no token).
+func (s *Service) wrapForCreate(pr *resource.ProgressResult, cluster, service string) {
+	if pr == nil || pr.RequestID == "" {
+		return
+	}
+	if pr.OperationStatus == resource.OperationStatusSuccess {
+		pr.OperationStatus = resource.OperationStatusInProgress
+		pr.ResourceProperties = nil
+		pr.StatusMessage = "ECS registration complete; waiting for service to appear"
+	}
+	pr.RequestID = composeRequestID(opSegCreate, s.now().Unix(), pr.RequestID)
+	if pr.NativeID == "" {
+		pr.NativeID = "pending|" + cluster + "|" + service
+	}
+	pr.Operation = resource.OperationCreate
+}
+
+// wrapForUpdate is the Update analogue. NativeID is always canonical for Update
+// (req.NativeID is populated by definition), but we set it defensively in case
+// ccx returned an empty one.
+func (s *Service) wrapForUpdate(pr *resource.ProgressResult, canonicalNativeID, cluster, service string) {
+	if pr == nil || pr.RequestID == "" {
+		return
+	}
+	if pr.OperationStatus == resource.OperationStatusSuccess {
+		pr.OperationStatus = resource.OperationStatusInProgress
+		pr.ResourceProperties = nil
+		pr.StatusMessage = "ECS update accepted; waiting for deployment to stabilize"
+	}
+	pr.RequestID = composeRequestID(opSegUpdate, s.now().Unix(), pr.RequestID)
+	if pr.NativeID == "" {
+		pr.NativeID = canonicalNativeID
+	}
+	pr.Operation = resource.OperationUpdate
+}
+
+// hasInactiveFailure scans DescribeServices.Failures for any entry whose Reason
+// is "INACTIVE" — the fast path for OOB-delete detection. AWS keeps INACTIVE
+// tombstones for ~1 hour post-delete.
+func hasInactiveFailure(out *awsecs.DescribeServicesOutput) bool {
+	if out == nil {
+		return false
+	}
+	for _, f := range out.Failures {
+		if f.Reason != nil && *f.Reason == "INACTIVE" {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/cfres/ecs/parse.go
+++ b/pkg/cfres/ecs/parse.go
@@ -5,6 +5,7 @@
 package ecs
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -87,4 +88,68 @@ func parseClusterAndServiceFromNativeID(nativeID string) (cluster, service strin
 // form the agent persists. Used by finalSuccess once Phase B stability is observed.
 func buildCanonicalNativeID(serviceArn, clusterShortName string) string {
 	return serviceArn + "|" + clusterShortName
+}
+
+// shapeSupportsPhaseB returns true iff the request properties describe the shape
+// our Phase B tracking handles: deploymentController.type == "ECS" (or absent),
+// AND schedulingStrategy == "REPLICA" (or absent). Anything else (CODE_DEPLOY,
+// EXTERNAL, DAEMON) falls through to generic CCAPI Status. Empty/nil props →
+// false (conservative — let the generic path handle whatever it is).
+func shapeSupportsPhaseB(props json.RawMessage) bool {
+	if len(props) == 0 {
+		return false
+	}
+	var shape struct {
+		DeploymentController *struct {
+			Type string `json:"Type"`
+		} `json:"DeploymentController"`
+		SchedulingStrategy string `json:"SchedulingStrategy"`
+	}
+	if err := json.Unmarshal(props, &shape); err != nil {
+		return false
+	}
+	if shape.DeploymentController != nil && shape.DeploymentController.Type != "" && shape.DeploymentController.Type != "ECS" {
+		return false
+	}
+	if shape.SchedulingStrategy != "" && shape.SchedulingStrategy != "REPLICA" {
+		return false
+	}
+	return true
+}
+
+// parseCreateClusterAndService extracts Cluster (normalized to short name) and
+// ServiceName from a Create request's Properties. Returns a wrapped error
+// pointing at the schema field if ServiceName is missing.
+func parseCreateClusterAndService(props json.RawMessage) (cluster, service string, err error) {
+	var p struct {
+		Cluster     string `json:"Cluster"`
+		ServiceName string `json:"ServiceName"`
+	}
+	if err := json.Unmarshal(props, &p); err != nil {
+		return "", "", fmt.Errorf("parse Create properties: %w", err)
+	}
+	if p.ServiceName == "" {
+		return "", "", fmt.Errorf("AWS::ECS::Service.ServiceName is required for Phase B tracking (REPLICA + ECS controller); auto-generated names are not supported in v1")
+	}
+	cluster = p.Cluster
+	if strings.HasPrefix(cluster, "arn:") {
+		// arn:aws:ecs:region:account:cluster/<name> → last "/" segment
+		if idx := strings.LastIndex(cluster, "/"); idx >= 0 {
+			cluster = cluster[idx+1:]
+		}
+	}
+	if cluster == "" {
+		return "", "", fmt.Errorf("AWS::ECS::Service.Cluster is required")
+	}
+	return cluster, p.ServiceName, nil
+}
+
+// parseUpdateClusterAndService extracts cluster + service from the canonical
+// NativeID an Update request carries ("<serviceArn>|<clusterShortName>").
+func parseUpdateClusterAndService(nativeID string) (cluster, service string, err error) {
+	c, s, ok := parseClusterAndServiceFromNativeID(nativeID)
+	if !ok {
+		return "", "", fmt.Errorf("malformed Update NativeID: %q", nativeID)
+	}
+	return c, s, nil
 }

--- a/pkg/cfres/ecs/parse.go
+++ b/pkg/cfres/ecs/parse.go
@@ -1,0 +1,47 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package ecs
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+)
+
+// parseComposite splits "formae-ecs/<op>/<unixStart>/<ccapiToken>" into its
+// components. Returns ok=false for anything that does not start with the
+// formae-ecs prefix or that has a malformed op/unix segment — the caller is
+// expected to fall through to generic CCAPI Status for ok=false.
+func parseComposite(s string) (op resource.Operation, unixStart int64, ccapiToken string, ok bool) {
+	if !strings.HasPrefix(s, phaseBPrefix) {
+		return "", 0, "", false
+	}
+	rest := s[len(phaseBPrefix):]
+	parts := strings.SplitN(rest, "/", 3)
+	if len(parts) != 3 {
+		return "", 0, "", false
+	}
+	switch parts[0] {
+	case opSegCreate:
+		op = resource.OperationCreate
+	case opSegUpdate:
+		op = resource.OperationUpdate
+	default:
+		return "", 0, "", false
+	}
+	unixStart, err := strconv.ParseInt(parts[1], 10, 64)
+	if err != nil {
+		return "", 0, "", false
+	}
+	ccapiToken = parts[2]
+	return op, unixStart, ccapiToken, true
+}
+
+// composeRequestID builds the composite RequestID set at Create/Update return time.
+func composeRequestID(opSeg string, unixStart int64, ccapiToken string) string {
+	return fmt.Sprintf("%s%s/%d/%s", phaseBPrefix, opSeg, unixStart, ccapiToken)
+}

--- a/pkg/cfres/ecs/parse.go
+++ b/pkg/cfres/ecs/parse.go
@@ -45,3 +45,46 @@ func parseComposite(s string) (op resource.Operation, unixStart int64, ccapiToke
 func composeRequestID(opSeg string, unixStart int64, ccapiToken string) string {
 	return fmt.Sprintf("%s%s/%d/%s", phaseBPrefix, opSeg, unixStart, ccapiToken)
 }
+
+// parseClusterAndServiceFromNativeID accepts either:
+//   - "pending|<cluster>|<service>"  (synthetic, set by Create when CCAPI gave no Identifier)
+//   - "<serviceArn>|<clusterShortName>"  (canonical: Update, or Create with sync Identifier)
+//
+// Returns ok=false for malformed/empty shapes; caller should treat as a terminal
+// programmer error (Failure InvalidRequest).
+func parseClusterAndServiceFromNativeID(nativeID string) (cluster, service string, ok bool) {
+	if nativeID == "" {
+		return "", "", false
+	}
+	if strings.HasPrefix(nativeID, "pending|") {
+		// pending|<cluster>|<service>
+		parts := strings.SplitN(nativeID, "|", 3)
+		if len(parts) != 3 || parts[1] == "" || parts[2] == "" {
+			return "", "", false
+		}
+		return parts[1], parts[2], true
+	}
+	// Canonical: <serviceArn>|<clusterShortName>. Last '|' splits arn from cluster.
+	idx := strings.LastIndex(nativeID, "|")
+	if idx < 0 || idx == len(nativeID)-1 {
+		return "", "", false
+	}
+	serviceArn := nativeID[:idx]
+	cluster = nativeID[idx+1:]
+	// Service short name is the last "/" segment of the ARN.
+	slashIdx := strings.LastIndex(serviceArn, "/")
+	if slashIdx < 0 || slashIdx == len(serviceArn)-1 {
+		return "", "", false
+	}
+	service = serviceArn[slashIdx+1:]
+	if cluster == "" || service == "" {
+		return "", "", false
+	}
+	return cluster, service, true
+}
+
+// buildCanonicalNativeID composes "<serviceArn>|<clusterShortName>" — the canonical
+// form the agent persists. Used by finalSuccess once Phase B stability is observed.
+func buildCanonicalNativeID(serviceArn, clusterShortName string) string {
+	return serviceArn + "|" + clusterShortName
+}

--- a/pkg/cfres/ecs/parse.go
+++ b/pkg/cfres/ecs/parse.go
@@ -122,6 +122,10 @@ func shapeSupportsPhaseB(props json.RawMessage) bool {
 // parseCreateClusterAndService extracts Cluster (normalized to short name) and
 // ServiceName from a Create request's Properties. Returns a wrapped error
 // pointing at the schema field if ServiceName is missing.
+//
+// Cluster is optional in the AWS::ECS::Service schema: when absent, ECS places
+// the service in a cluster literally named "default" (auto-created on first
+// use). We mirror that semantic here so Phase B polls the right cluster.
 func parseCreateClusterAndService(props json.RawMessage) (cluster, service string, err error) {
 	var p struct {
 		Cluster     string `json:"Cluster"`
@@ -141,7 +145,7 @@ func parseCreateClusterAndService(props json.RawMessage) (cluster, service strin
 		}
 	}
 	if cluster == "" {
-		return "", "", fmt.Errorf("AWS::ECS::Service.Cluster is required")
+		cluster = "default"
 	}
 	return cluster, p.ServiceName, nil
 }

--- a/pkg/cfres/ecs/parse_test.go
+++ b/pkg/cfres/ecs/parse_test.go
@@ -70,3 +70,40 @@ func TestComposite_RoundTrip(t *testing.T) {
 	assert.Equal(t, int64(1747526400), unixStart)
 	assert.Equal(t, "tA", token)
 }
+
+func TestParseClusterAndServiceFromNativeID_Synthetic(t *testing.T) {
+	cluster, service, ok := parseClusterAndServiceFromNativeID("pending|my-cluster|my-svc")
+	assert.True(t, ok)
+	assert.Equal(t, "my-cluster", cluster)
+	assert.Equal(t, "my-svc", service)
+}
+
+func TestParseClusterAndServiceFromNativeID_Canonical(t *testing.T) {
+	cluster, service, ok := parseClusterAndServiceFromNativeID(
+		"arn:aws:ecs:us-east-1:123456789012:service/my-cluster/my-svc|my-cluster")
+	assert.True(t, ok)
+	assert.Equal(t, "my-cluster", cluster)
+	assert.Equal(t, "my-svc", service)
+}
+
+func TestParseClusterAndServiceFromNativeID_Empty(t *testing.T) {
+	_, _, ok := parseClusterAndServiceFromNativeID("")
+	assert.False(t, ok)
+}
+
+func TestParseClusterAndServiceFromNativeID_Malformed(t *testing.T) {
+	_, _, ok := parseClusterAndServiceFromNativeID("not-a-real-shape")
+	assert.False(t, ok)
+}
+
+func TestParseClusterAndServiceFromNativeID_SyntheticEmptyCluster(t *testing.T) {
+	_, _, ok := parseClusterAndServiceFromNativeID("pending||my-svc")
+	assert.False(t, ok)
+}
+
+func TestBuildCanonicalNativeID(t *testing.T) {
+	canonical := buildCanonicalNativeID(
+		"arn:aws:ecs:us-east-1:123456789012:service/my-cluster/my-svc",
+		"my-cluster")
+	assert.Equal(t, "arn:aws:ecs:us-east-1:123456789012:service/my-cluster/my-svc|my-cluster", canonical)
+}

--- a/pkg/cfres/ecs/parse_test.go
+++ b/pkg/cfres/ecs/parse_test.go
@@ -1,0 +1,72 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package ecs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+)
+
+func TestParseComposite_ValidCreate(t *testing.T) {
+	op, unixStart, ccapiToken, ok := parseComposite("formae-ecs/create/1747526400/f470d40b-d23c-4d3a")
+	assert.True(t, ok)
+	assert.Equal(t, resource.OperationCreate, op)
+	assert.Equal(t, int64(1747526400), unixStart)
+	assert.Equal(t, "f470d40b-d23c-4d3a", ccapiToken)
+}
+
+func TestParseComposite_ValidUpdate(t *testing.T) {
+	op, unixStart, ccapiToken, ok := parseComposite("formae-ecs/update/1747526400/abc-123")
+	assert.True(t, ok)
+	assert.Equal(t, resource.OperationUpdate, op)
+	assert.Equal(t, int64(1747526400), unixStart)
+	assert.Equal(t, "abc-123", ccapiToken)
+}
+
+func TestParseComposite_BareCCAPIToken(t *testing.T) {
+	// CCAPI-shaped UUID without our prefix — this is the normal path for
+	// CODE_DEPLOY/EXTERNAL/DAEMON shapes that bypass our wrap.
+	_, _, _, ok := parseComposite("f470d40b-d23c-4d3a-9c11-some-uuid")
+	assert.False(t, ok)
+}
+
+func TestParseComposite_EmptyString(t *testing.T) {
+	_, _, _, ok := parseComposite("")
+	assert.False(t, ok)
+}
+
+func TestParseComposite_MalformedUnix(t *testing.T) {
+	_, _, _, ok := parseComposite("formae-ecs/create/not-a-number/abc")
+	assert.False(t, ok)
+}
+
+func TestParseComposite_UnknownOp(t *testing.T) {
+	_, _, _, ok := parseComposite("formae-ecs/delete/1747526400/abc")
+	assert.False(t, ok)
+}
+
+func TestComposeRequestID_Create(t *testing.T) {
+	s := composeRequestID(opSegCreate, 1747526400, "ccapi-token")
+	assert.Equal(t, "formae-ecs/create/1747526400/ccapi-token", s)
+}
+
+func TestComposeRequestID_Update(t *testing.T) {
+	s := composeRequestID(opSegUpdate, 1747526400, "ccapi-token")
+	assert.Equal(t, "formae-ecs/update/1747526400/ccapi-token", s)
+}
+
+func TestComposite_RoundTrip(t *testing.T) {
+	encoded := composeRequestID(opSegCreate, 1747526400, "tA")
+	op, unixStart, token, ok := parseComposite(encoded)
+	assert.True(t, ok)
+	assert.Equal(t, resource.OperationCreate, op)
+	assert.Equal(t, int64(1747526400), unixStart)
+	assert.Equal(t, "tA", token)
+}

--- a/pkg/cfres/ecs/parse_test.go
+++ b/pkg/cfres/ecs/parse_test.go
@@ -107,3 +107,77 @@ func TestBuildCanonicalNativeID(t *testing.T) {
 		"my-cluster")
 	assert.Equal(t, "arn:aws:ecs:us-east-1:123456789012:service/my-cluster/my-svc|my-cluster", canonical)
 }
+
+func TestShapeSupportsPhaseB_DefaultShape(t *testing.T) {
+	// Empty JSON object — all fields absent = all defaults (ECS controller, REPLICA strategy)
+	assert.True(t, shapeSupportsPhaseB([]byte(`{}`)))
+}
+
+func TestShapeSupportsPhaseB_ExplicitREPLICA_ECS(t *testing.T) {
+	props := []byte(`{
+        "Cluster": "c", "ServiceName": "s",
+        "DeploymentController": {"Type": "ECS"},
+        "SchedulingStrategy": "REPLICA"
+    }`)
+	assert.True(t, shapeSupportsPhaseB(props))
+}
+
+func TestShapeSupportsPhaseB_CODE_DEPLOY(t *testing.T) {
+	props := []byte(`{"DeploymentController": {"Type": "CODE_DEPLOY"}}`)
+	assert.False(t, shapeSupportsPhaseB(props))
+}
+
+func TestShapeSupportsPhaseB_EXTERNAL(t *testing.T) {
+	props := []byte(`{"DeploymentController": {"Type": "EXTERNAL"}}`)
+	assert.False(t, shapeSupportsPhaseB(props))
+}
+
+func TestShapeSupportsPhaseB_DAEMON(t *testing.T) {
+	props := []byte(`{"SchedulingStrategy": "DAEMON"}`)
+	assert.False(t, shapeSupportsPhaseB(props))
+}
+
+func TestShapeSupportsPhaseB_EmptyProps(t *testing.T) {
+	// No properties at all → conservatively false; let the generic path handle it.
+	assert.False(t, shapeSupportsPhaseB(nil))
+	assert.False(t, shapeSupportsPhaseB([]byte{}))
+}
+
+func TestParseCreateClusterAndService_FullArn(t *testing.T) {
+	props := []byte(`{
+        "Cluster": "arn:aws:ecs:us-east-1:123456789012:cluster/my-cluster",
+        "ServiceName": "my-svc"
+    }`)
+	cluster, service, err := parseCreateClusterAndService(props)
+	assert.NoError(t, err)
+	assert.Equal(t, "my-cluster", cluster)
+	assert.Equal(t, "my-svc", service)
+}
+
+func TestParseCreateClusterAndService_ShortName(t *testing.T) {
+	props := []byte(`{"Cluster": "my-cluster", "ServiceName": "my-svc"}`)
+	cluster, service, err := parseCreateClusterAndService(props)
+	assert.NoError(t, err)
+	assert.Equal(t, "my-cluster", cluster)
+	assert.Equal(t, "my-svc", service)
+}
+
+func TestParseCreateClusterAndService_MissingServiceName(t *testing.T) {
+	props := []byte(`{"Cluster": "my-cluster"}`)
+	_, _, err := parseCreateClusterAndService(props)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "ServiceName")
+}
+
+func TestParseUpdateClusterAndService_Canonical(t *testing.T) {
+	cluster, service, err := parseUpdateClusterAndService(
+		"arn:aws:ecs:us-east-1:123456789012:service/my-cluster/my-svc|my-cluster")
+	assert.NoError(t, err)
+	assert.Equal(t, "my-cluster", cluster)
+	assert.Equal(t, "my-svc", service)
+}
+
+func TestParseUpdateClusterAndService_Malformed(t *testing.T) {
+	_, _, err := parseUpdateClusterAndService("garbage")
+	assert.Error(t, err)
+}

--- a/pkg/cfres/ecs/parse_test.go
+++ b/pkg/cfres/ecs/parse_test.go
@@ -8,7 +8,10 @@ package ecs
 
 import (
 	"testing"
+	"time"
 
+	awsecs "github.com/aws/aws-sdk-go-v2/service/ecs"
+	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
@@ -181,3 +184,83 @@ func TestParseUpdateClusterAndService_Malformed(t *testing.T) {
 	_, _, err := parseUpdateClusterAndService("garbage")
 	assert.Error(t, err)
 }
+
+func TestWrapForCreate_AsyncInProgress(t *testing.T) {
+	s := &Service{now: func() time.Time { return time.Unix(1747526400, 0) }}
+	pr := &resource.ProgressResult{
+		Operation:       resource.OperationCreate,
+		OperationStatus: resource.OperationStatusInProgress,
+		RequestID:       "ccapi-tA",
+		NativeID:        "",
+	}
+	s.wrapForCreate(pr, "my-cluster", "my-svc")
+	assert.Equal(t, resource.OperationCreate, pr.Operation)
+	assert.Equal(t, resource.OperationStatusInProgress, pr.OperationStatus)
+	assert.Equal(t, "formae-ecs/create/1747526400/ccapi-tA", pr.RequestID)
+	assert.Equal(t, "pending|my-cluster|my-svc", pr.NativeID)
+}
+
+func TestWrapForCreate_SyncSuccess_RewritesToInProgress(t *testing.T) {
+	s := &Service{now: func() time.Time { return time.Unix(1747526400, 0) }}
+	pr := &resource.ProgressResult{
+		Operation:          resource.OperationCreate,
+		OperationStatus:    resource.OperationStatusSuccess,
+		RequestID:          "ccapi-tA",
+		NativeID:           "arn:aws:ecs:us-east-1:123:service/my-cluster/my-svc|my-cluster",
+		ResourceProperties: []byte(`{"some":"props"}`),
+	}
+	s.wrapForCreate(pr, "my-cluster", "my-svc")
+	assert.Equal(t, resource.OperationStatusInProgress, pr.OperationStatus)
+	assert.Nil(t, pr.ResourceProperties)
+	assert.Contains(t, pr.StatusMessage, "waiting")
+	assert.Equal(t, "formae-ecs/create/1747526400/ccapi-tA", pr.RequestID)
+	// NativeID stays canonical when CCAPI gave us one.
+	assert.Equal(t, "arn:aws:ecs:us-east-1:123:service/my-cluster/my-svc|my-cluster", pr.NativeID)
+}
+
+func TestWrapForCreate_EmptyRequestID_NoOp(t *testing.T) {
+	s := &Service{now: func() time.Time { return time.Unix(1747526400, 0) }}
+	pr := &resource.ProgressResult{
+		OperationStatus: resource.OperationStatusFailure,
+		RequestID:       "",
+	}
+	s.wrapForCreate(pr, "c", "s")
+	assert.Equal(t, "", pr.RequestID)
+	assert.Equal(t, "", pr.NativeID)
+}
+
+func TestWrapForUpdate_NativeIDStaysCanonical(t *testing.T) {
+	s := &Service{now: func() time.Time { return time.Unix(1747526400, 0) }}
+	pr := &resource.ProgressResult{
+		Operation:       resource.OperationUpdate,
+		OperationStatus: resource.OperationStatusInProgress,
+		RequestID:       "ccapi-tU",
+		NativeID:        "",
+	}
+	canonical := "arn:aws:ecs:us-east-1:123:service/my-cluster/my-svc|my-cluster"
+	s.wrapForUpdate(pr, canonical, "my-cluster", "my-svc")
+	assert.Equal(t, "formae-ecs/update/1747526400/ccapi-tU", pr.RequestID)
+	assert.Equal(t, canonical, pr.NativeID)
+	assert.Equal(t, resource.OperationUpdate, pr.Operation)
+}
+
+func TestHasInactiveFailure(t *testing.T) {
+	out := &awsecs.DescribeServicesOutput{
+		Failures: []ecstypes.Failure{
+			{Arn: ptrString("arn"), Reason: ptrString("INACTIVE")},
+		},
+	}
+	assert.True(t, hasInactiveFailure(out))
+
+	out2 := &awsecs.DescribeServicesOutput{
+		Failures: []ecstypes.Failure{
+			{Arn: ptrString("arn"), Reason: ptrString("MISSING")},
+		},
+	}
+	assert.False(t, hasInactiveFailure(out2))
+
+	out3 := &awsecs.DescribeServicesOutput{}
+	assert.False(t, hasInactiveFailure(out3))
+}
+
+func ptrString(s string) *string { return &s }

--- a/pkg/cfres/ecs/parse_test.go
+++ b/pkg/cfres/ecs/parse_test.go
@@ -172,6 +172,18 @@ func TestParseCreateClusterAndService_MissingServiceName(t *testing.T) {
 	assert.Contains(t, err.Error(), "ServiceName")
 }
 
+func TestParseCreateClusterAndService_MissingCluster_DefaultsToDefaultCluster(t *testing.T) {
+	// Schema marks Cluster as optional. When absent, ECS places the service in
+	// a cluster literally named "default". Regression coverage for the gap the
+	// adversarial review caught: pre-this-branch the generic CCAPI path handled
+	// this transparently, so Phase B must mirror that semantic.
+	props := []byte(`{"ServiceName": "my-svc"}`)
+	cluster, service, err := parseCreateClusterAndService(props)
+	assert.NoError(t, err)
+	assert.Equal(t, "default", cluster)
+	assert.Equal(t, "my-svc", service)
+}
+
 func TestParseUpdateClusterAndService_Canonical(t *testing.T) {
 	cluster, service, err := parseUpdateClusterAndService(
 		"arn:aws:ecs:us-east-1:123456789012:service/my-cluster/my-svc|my-cluster")

--- a/pkg/cfres/ecs/phase.go
+++ b/pkg/cfres/ecs/phase.go
@@ -221,7 +221,7 @@ func (s *Service) finalSuccess(ctx context.Context, req *resource.StatusRequest,
 		}
 	}
 
-	// Build canonical NativeID + final Read (full classifier in Task 16).
+	// Build canonical NativeID.
 	canonical := buildCanonicalNativeID(aws.ToString(svc.ServiceArn),
 		deriveClusterShortName(req.NativeID, svc))
 	readResult, readErr := s.Read(ctx, &resource.ReadRequest{
@@ -229,19 +229,39 @@ func (s *Service) finalSuccess(ctx context.Context, req *resource.StatusRequest,
 		ResourceType: req.ResourceType,
 		TargetConfig: req.TargetConfig,
 	})
-	if readErr != nil || readResult == nil || readResult.ErrorCode != "" || readResult.Properties == "" {
-		// Task 16 wires this through classifyReadResultForFinal + inProgressOrFinalReadTimeout.
-		return s.inProgressOrTimeout(op, req, unixStart, "post-stability Read returned no properties"), nil
+	code, retryable, ok := classifyReadResultForFinal(readResult, readErr)
+	if ok {
+		return &resource.StatusResult{
+			ProgressResult: &resource.ProgressResult{
+				Operation:          op,
+				OperationStatus:    resource.OperationStatusSuccess,
+				NativeID:           canonical,
+				RequestID:          "",
+				ResourceProperties: []byte(readResult.Properties),
+			},
+		}, nil
+	}
+	if retryable {
+		return s.inProgressOrFinalReadTimeout(op, req, unixStart,
+			"post-stability Read transient: "+formatReadFailure(readResult, readErr)), nil
 	}
 	return &resource.StatusResult{
-		ProgressResult: &resource.ProgressResult{
-			Operation:          op,
-			OperationStatus:    resource.OperationStatusSuccess,
-			NativeID:           canonical,
-			RequestID:          "",
-			ResourceProperties: []byte(readResult.Properties),
-		},
+		ProgressResult: terminalFailurePR(op, req.NativeID, "", code,
+			"post-stability Read failed: "+formatReadFailure(readResult, readErr)),
 	}, nil
+}
+
+func formatReadFailure(rr *resource.ReadResult, readErr error) string {
+	if readErr != nil {
+		return readErr.Error()
+	}
+	if rr == nil {
+		return "nil ReadResult"
+	}
+	if rr.ErrorCode != "" {
+		return string(rr.ErrorCode)
+	}
+	return "empty Properties"
 }
 
 // deriveClusterShortName extracts the cluster short name from whichever NativeID

--- a/pkg/cfres/ecs/phase.go
+++ b/pkg/cfres/ecs/phase.go
@@ -10,9 +10,48 @@ import (
 	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
 )
 
+// checkPhaseA polls CCAPI and returns either (resultToReturn, false) when
+// Phase A is still in flight or failed, or (nil, true) when CCAPI has accepted
+// the operation and Phase B should run.
 func (s *Service) checkPhaseA(ctx context.Context, req *resource.StatusRequest,
 	op resource.Operation, unixStart int64, ccapiToken string) (*resource.StatusResult, bool) {
-	panic("checkPhaseA: implemented in Task 13")
+	cli, err := s.ccxClientFactory(s.cfg)
+	if err != nil {
+		return s.classifyForStatus(err, op, req, unixStart, "build CCAPI client"), false
+	}
+	phaseAReq := *req
+	phaseAReq.RequestID = ccapiToken
+	res, err := cli.StatusResource(ctx, &phaseAReq, s.Read)
+	if err != nil {
+		return s.classifyForStatus(err, op, req, unixStart, "ccx.StatusResource"), false
+	}
+	if res.ProgressResult == nil {
+		return s.inProgressOrTimeout(op, req, unixStart, "CCAPI status returned no progress"), false
+	}
+	switch res.ProgressResult.OperationStatus {
+	case resource.OperationStatusSuccess:
+		return nil, true
+	case resource.OperationStatusInProgress:
+		return s.inProgressOrTimeout(op, req, unixStart, res.ProgressResult.StatusMessage), false
+	case resource.OperationStatusFailure:
+		// Update + NotFound = OOB-delete pre-CCAPI-Success. NotFound is recoverable
+		// per the SDK; surface as terminal GeneralServiceException to avoid retry loops.
+		if op == resource.OperationUpdate && res.ProgressResult.ErrorCode == resource.OperationErrorCodeNotFound {
+			return &resource.StatusResult{
+				ProgressResult: terminalFailurePR(op, req.NativeID, req.RequestID,
+					resource.OperationErrorCodeGeneralServiceException,
+					"ECS service deleted out-of-band during Update (CCAPI reported NotFound): "+
+						res.ProgressResult.StatusMessage),
+			}, false
+		}
+		// Other failures: propagate verbatim with composite identity restored.
+		res.ProgressResult.RequestID = req.RequestID
+		res.ProgressResult.Operation = op
+		return res, false
+	default:
+		return s.inProgressOrTimeout(op, req, unixStart,
+			"unexpected CCAPI status: "+string(res.ProgressResult.OperationStatus)), false
+	}
 }
 
 func (s *Service) statusPhaseB(ctx context.Context, req *resource.StatusRequest,

--- a/pkg/cfres/ecs/phase.go
+++ b/pkg/cfres/ecs/phase.go
@@ -6,6 +6,12 @@ package ecs
 
 import (
 	"context"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsecs "github.com/aws/aws-sdk-go-v2/service/ecs"
+	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 
 	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
 )
@@ -56,5 +62,94 @@ func (s *Service) checkPhaseA(ctx context.Context, req *resource.StatusRequest,
 
 func (s *Service) statusPhaseB(ctx context.Context, req *resource.StatusRequest,
 	op resource.Operation, unixStart int64, cluster, service string) (*resource.StatusResult, error) {
-	panic("statusPhaseB: implemented in Task 14")
+
+	ecsCli, err := s.ecsClientFactory(s.cfg)
+	if err != nil {
+		return s.classifyForStatus(err, op, req, unixStart, "build ECS client"), nil
+	}
+	descOut, err := ecsCli.DescribeServices(ctx, &awsecs.DescribeServicesInput{
+		Cluster:  &cluster,
+		Services: []string{service},
+	})
+	if err != nil {
+		return s.classifyForStatus(err, op, req, unixStart, "DescribeServices"), nil
+	}
+
+	// INACTIVE failure → fast OOB-delete terminal.
+	if hasInactiveFailure(descOut) {
+		return &resource.StatusResult{
+			ProgressResult: terminalFailurePR(op, req.NativeID, "",
+				resource.OperationErrorCodeGeneralServiceException,
+				fmt.Sprintf("ECS service %s in cluster %s reports INACTIVE — deleted out-of-band",
+					service, cluster)),
+		}, nil
+	}
+	if len(descOut.Services) == 0 {
+		return s.inProgressOrTimeout(op, req, unixStart,
+			"service not yet visible in DescribeServices (may be lag or out-of-band deletion)"), nil
+	}
+	svc := descOut.Services[0]
+	if aws.ToString(svc.Status) == "INACTIVE" {
+		return &resource.StatusResult{
+			ProgressResult: terminalFailurePR(op, req.NativeID, "",
+				resource.OperationErrorCodeGeneralServiceException,
+				fmt.Sprintf("ECS service %s is INACTIVE — deleted out-of-band", service)),
+		}, nil
+	}
+
+	primary := findPrimaryDeployment(svc.Deployments)
+	if primary == nil {
+		return s.inProgressOrTimeout(op, req, unixStart, "no PRIMARY deployment yet"), nil
+	}
+
+	// Update no-new-deployment grace window.
+	if op == resource.OperationUpdate {
+		opStart := time.Unix(unixStart, 0)
+		if primary.CreatedAt == nil || primary.CreatedAt.Before(opStart.Add(-primaryCreatedSlack)) {
+			if s.now().Sub(opStart) < updateGraceWindow {
+				return s.inProgressOrTimeout(op, req, unixStart,
+					"waiting for new deployment to start"), nil
+			}
+			// Past grace — treat as no-op Update; check existing primary's stability.
+		}
+	}
+
+	// Explicit FAILED before stability check.
+	if primary.RolloutState == ecstypes.DeploymentRolloutStateFailed {
+		return &resource.StatusResult{
+			ProgressResult: terminalFailurePR(op, req.NativeID, "",
+				resource.OperationErrorCodeGeneralServiceException,
+				"deployment failed: "+aws.ToString(primary.RolloutStateReason)),
+		}, nil
+	}
+
+	if !isPhaseBStable(primary, svc) {
+		return s.inProgressOrTimeout(op, req, unixStart,
+			fmt.Sprintf("rollout %s: %d/%d tasks running",
+				primary.RolloutState, svc.RunningCount, svc.DesiredCount)), nil
+	}
+
+	// TG health + finalSuccess — Task 15/16.
+	return s.finalSuccess(ctx, req, op, unixStart, svc)
+}
+
+func findPrimaryDeployment(deployments []ecstypes.Deployment) *ecstypes.Deployment {
+	for i := range deployments {
+		if aws.ToString(deployments[i].Status) == "PRIMARY" {
+			return &deployments[i]
+		}
+	}
+	return nil
+}
+
+func isPhaseBStable(primary *ecstypes.Deployment, svc ecstypes.Service) bool {
+	return primary.RolloutState == ecstypes.DeploymentRolloutStateCompleted &&
+		svc.RunningCount == svc.DesiredCount
+}
+
+// Placeholder for Task 15/16. finalSuccess takes the unixStart so it can pass
+// it to inProgressOrFinalReadTimeout in Task 16.
+func (s *Service) finalSuccess(ctx context.Context, req *resource.StatusRequest,
+	op resource.Operation, unixStart int64, svc ecstypes.Service) (*resource.StatusResult, error) {
+	panic("finalSuccess: TG health gate + Read in Task 15/16")
 }

--- a/pkg/cfres/ecs/phase.go
+++ b/pkg/cfres/ecs/phase.go
@@ -7,11 +7,14 @@ package ecs
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsecs "github.com/aws/aws-sdk-go-v2/service/ecs"
 	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	awselbv2 "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	elbv2types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
 
 	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
 )
@@ -147,9 +150,112 @@ func isPhaseBStable(primary *ecstypes.Deployment, svc ecstypes.Service) bool {
 		svc.RunningCount == svc.DesiredCount
 }
 
-// Placeholder for Task 15/16. finalSuccess takes the unixStart so it can pass
-// it to inProgressOrFinalReadTimeout in Task 16.
+// needsTargetHealth returns true iff desiredCount > 0 AND at least one LB entry
+// has a non-empty TargetGroupArn. Classic-ELB attachments (loadBalancerName only)
+// are skipped — we have no equivalent health signal and ECS's stability already
+// guards the deploy.
+func needsTargetHealth(svc ecstypes.Service) bool {
+	if svc.DesiredCount <= 0 {
+		return false
+	}
+	for _, lb := range svc.LoadBalancers {
+		if aws.ToString(lb.TargetGroupArn) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// checkAllTGsHealthy walks loadBalancers, skipping classic-ELB entries (empty
+// TargetGroupArn), and calls DescribeTargetHealth on each TG. Returns:
+//   - allHealthy: true if every TG has ≥1 healthy target
+//   - msg:        a descriptive "<tg> <healthy>/<total>" string for status reporting
+//   - err:        any Go error from the SDK call (caller routes through classifier)
+func checkAllTGsHealthy(ctx context.Context, elbCli elbv2Client,
+	loadBalancers []ecstypes.LoadBalancer) (bool, string, error) {
+	var msgs []string
+	allHealthy := true
+	for _, lb := range loadBalancers {
+		arn := aws.ToString(lb.TargetGroupArn)
+		if arn == "" {
+			continue
+		}
+		out, err := elbCli.DescribeTargetHealth(ctx, &awselbv2.DescribeTargetHealthInput{
+			TargetGroupArn: &arn,
+		})
+		if err != nil {
+			return false, "", err
+		}
+		healthy := 0
+		for _, t := range out.TargetHealthDescriptions {
+			if t.TargetHealth != nil && t.TargetHealth.State == elbv2types.TargetHealthStateEnumHealthy {
+				healthy++
+			}
+		}
+		if healthy == 0 {
+			allHealthy = false
+		}
+		msgs = append(msgs, fmt.Sprintf("%s %d/%d", arn, healthy, len(out.TargetHealthDescriptions)))
+	}
+	return allHealthy, strings.Join(msgs, ", "), nil
+}
+
+// finalSuccess builds canonical NativeID, performs a final Read, and returns
+// Success only if the Read returns non-empty Properties. Read failures get a
+// proper classifier in Task 16.
 func (s *Service) finalSuccess(ctx context.Context, req *resource.StatusRequest,
 	op resource.Operation, unixStart int64, svc ecstypes.Service) (*resource.StatusResult, error) {
-	panic("finalSuccess: TG health gate + Read in Task 15/16")
+
+	if needsTargetHealth(svc) {
+		elbCli, err := s.elbv2ClientFactory(s.cfg)
+		if err != nil {
+			return s.classifyForStatus(err, op, req, unixStart, "build ELBv2 client"), nil
+		}
+		healthy, msg, hErr := checkAllTGsHealthy(ctx, elbCli, svc.LoadBalancers)
+		if hErr != nil {
+			return s.classifyForStatus(hErr, op, req, unixStart, "DescribeTargetHealth"), nil
+		}
+		if !healthy {
+			return s.inProgressOrTimeout(op, req, unixStart,
+				"deployment stable; waiting for healthy targets: "+msg), nil
+		}
+	}
+
+	// Build canonical NativeID + final Read (full classifier in Task 16).
+	canonical := buildCanonicalNativeID(aws.ToString(svc.ServiceArn),
+		deriveClusterShortName(req.NativeID, svc))
+	readResult, readErr := s.Read(ctx, &resource.ReadRequest{
+		NativeID:     canonical,
+		ResourceType: req.ResourceType,
+		TargetConfig: req.TargetConfig,
+	})
+	if readErr != nil || readResult == nil || readResult.ErrorCode != "" || readResult.Properties == "" {
+		// Task 16 wires this through classifyReadResultForFinal + inProgressOrFinalReadTimeout.
+		return s.inProgressOrTimeout(op, req, unixStart, "post-stability Read returned no properties"), nil
+	}
+	return &resource.StatusResult{
+		ProgressResult: &resource.ProgressResult{
+			Operation:          op,
+			OperationStatus:    resource.OperationStatusSuccess,
+			NativeID:           canonical,
+			RequestID:          "",
+			ResourceProperties: []byte(readResult.Properties),
+		},
+	}, nil
+}
+
+// deriveClusterShortName extracts the cluster short name from whichever NativeID
+// shape is in flight (synthetic or canonical), or falls back to derivation from
+// the DescribeServices result.
+func deriveClusterShortName(nativeID string, svc ecstypes.Service) string {
+	if cluster, _, ok := parseClusterAndServiceFromNativeID(nativeID); ok {
+		return cluster
+	}
+	// Last-resort: parse from ClusterArn in svc (arn:...:cluster/<name>).
+	if c := aws.ToString(svc.ClusterArn); c != "" {
+		if idx := strings.LastIndex(c, "/"); idx >= 0 {
+			return c[idx+1:]
+		}
+	}
+	return ""
 }

--- a/pkg/cfres/ecs/phase.go
+++ b/pkg/cfres/ecs/phase.go
@@ -1,0 +1,21 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package ecs
+
+import (
+	"context"
+
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+)
+
+func (s *Service) checkPhaseA(ctx context.Context, req *resource.StatusRequest,
+	op resource.Operation, unixStart int64, ccapiToken string) (*resource.StatusResult, bool) {
+	panic("checkPhaseA: implemented in Task 13")
+}
+
+func (s *Service) statusPhaseB(ctx context.Context, req *resource.StatusRequest,
+	op resource.Operation, unixStart int64, cluster, service string) (*resource.StatusResult, error) {
+	panic("statusPhaseB: implemented in Task 14")
+}

--- a/pkg/cfres/ecs/phase_test.go
+++ b/pkg/cfres/ecs/phase_test.go
@@ -1,0 +1,146 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package ecs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsecs "github.com/aws/aws-sdk-go-v2/service/ecs"
+	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	awselbv2 "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	elbv2types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+)
+
+func TestCheckPhaseA_InProgress(t *testing.T) {
+	ccx := &mockCCXClient{}
+	ccx.On("StatusResource", mock.Anything, mock.Anything, mock.Anything).Return(
+		&resource.StatusResult{
+			ProgressResult: &resource.ProgressResult{
+				Operation:       resource.OperationCreate,
+				OperationStatus: resource.OperationStatusInProgress,
+				StatusMessage:   "CCAPI still working",
+			},
+		}, nil)
+
+	s := newServiceWithMocks(ccx, nil, nil)
+	req := &resource.StatusRequest{
+		RequestID: "formae-ecs/create/1747526400/tA",
+		NativeID:  "pending|c|s",
+	}
+	res, ok := s.checkPhaseA(context.Background(), req, resource.OperationCreate, 1747526400, "tA")
+	assert.False(t, ok, "still in Phase A — Phase B not entered")
+	assert.Equal(t, resource.OperationStatusInProgress, res.ProgressResult.OperationStatus)
+	assert.Equal(t, "formae-ecs/create/1747526400/tA", res.ProgressResult.RequestID)
+}
+
+func TestCheckPhaseA_Success_TransitionsToPhaseB(t *testing.T) {
+	ccx := &mockCCXClient{}
+	ccx.On("StatusResource", mock.Anything, mock.Anything, mock.Anything).Return(
+		&resource.StatusResult{
+			ProgressResult: &resource.ProgressResult{
+				Operation:       resource.OperationCreate,
+				OperationStatus: resource.OperationStatusSuccess,
+			},
+		}, nil)
+
+	s := newServiceWithMocks(ccx, nil, nil)
+	req := &resource.StatusRequest{RequestID: "formae-ecs/create/1747526400/tA", NativeID: "pending|c|s"}
+	_, ok := s.checkPhaseA(context.Background(), req, resource.OperationCreate, 1747526400, "tA")
+	assert.True(t, ok, "Phase B should be entered after CCAPI Success")
+}
+
+func TestCheckPhaseA_Failure_Propagates(t *testing.T) {
+	ccx := &mockCCXClient{}
+	ccx.On("StatusResource", mock.Anything, mock.Anything, mock.Anything).Return(
+		&resource.StatusResult{
+			ProgressResult: &resource.ProgressResult{
+				Operation:       resource.OperationCreate,
+				OperationStatus: resource.OperationStatusFailure,
+				ErrorCode:       resource.OperationErrorCodeInvalidRequest,
+				StatusMessage:   "bad CFN payload",
+			},
+		}, nil)
+
+	s := newServiceWithMocks(ccx, nil, nil)
+	req := &resource.StatusRequest{RequestID: "formae-ecs/create/1747526400/tA", NativeID: "pending|c|s"}
+	res, ok := s.checkPhaseA(context.Background(), req, resource.OperationCreate, 1747526400, "tA")
+	assert.False(t, ok)
+	assert.Equal(t, resource.OperationStatusFailure, res.ProgressResult.OperationStatus)
+	assert.Equal(t, resource.OperationErrorCodeInvalidRequest, res.ProgressResult.ErrorCode)
+}
+
+func TestCheckPhaseA_UpdateNotFound_RewritesToGeneralServiceException(t *testing.T) {
+	// Async Phase A intercept: ccx.StatusResource only remaps NotFound→InProgress
+	// for Create. For Update, NotFound (OOB delete pre-CCAPI-Success) propagates,
+	// which is recoverable per SDK. We must rewrite to GeneralServiceException.
+	ccx := &mockCCXClient{}
+	ccx.On("StatusResource", mock.Anything, mock.Anything, mock.Anything).Return(
+		&resource.StatusResult{
+			ProgressResult: &resource.ProgressResult{
+				Operation:       resource.OperationUpdate,
+				OperationStatus: resource.OperationStatusFailure,
+				ErrorCode:       resource.OperationErrorCodeNotFound,
+				StatusMessage:   "NotFound from CCAPI",
+			},
+		}, nil)
+
+	s := newServiceWithMocks(ccx, nil, nil)
+	req := &resource.StatusRequest{
+		RequestID: "formae-ecs/update/1747526400/tU",
+		NativeID:  "arn:aws:ecs:us-east-1:123:service/c/s|c",
+	}
+	res, ok := s.checkPhaseA(context.Background(), req, resource.OperationUpdate, 1747526400, "tU")
+	assert.False(t, ok)
+	assert.Equal(t, resource.OperationErrorCodeGeneralServiceException, res.ProgressResult.ErrorCode)
+	assert.Contains(t, res.ProgressResult.StatusMessage, "deleted out-of-band")
+}
+
+func TestCheckPhaseA_CreateNotFound_NotIntercepted(t *testing.T) {
+	// In normal operation, ccx already turned Create+NotFound into InProgress. If
+	// we ever see Create+NotFound here, propagate (don't apply the Update intercept).
+	ccx := &mockCCXClient{}
+	ccx.On("StatusResource", mock.Anything, mock.Anything, mock.Anything).Return(
+		&resource.StatusResult{
+			ProgressResult: &resource.ProgressResult{
+				Operation:       resource.OperationCreate,
+				OperationStatus: resource.OperationStatusFailure,
+				ErrorCode:       resource.OperationErrorCodeNotFound,
+			},
+		}, nil)
+
+	s := newServiceWithMocks(ccx, nil, nil)
+	req := &resource.StatusRequest{RequestID: "formae-ecs/create/1747526400/tA", NativeID: "pending|c|s"}
+	res, ok := s.checkPhaseA(context.Background(), req, resource.OperationCreate, 1747526400, "tA")
+	assert.False(t, ok)
+	assert.Equal(t, resource.OperationErrorCodeNotFound, res.ProgressResult.ErrorCode,
+		"Create NotFound passes through unchanged; ccx-level remap is the intended handler")
+}
+
+func TestCheckPhaseA_CCAPIError_RetryableInProgress(t *testing.T) {
+	ccx := &mockCCXClient{}
+	ccx.On("StatusResource", mock.Anything, mock.Anything, mock.Anything).Return(
+		(*resource.StatusResult)(nil), &fakeAPIError{code: "Throttling"})
+
+	s := newServiceWithMocks(ccx, nil, nil)
+	req := &resource.StatusRequest{RequestID: "formae-ecs/create/1747526400/tA", NativeID: "pending|c|s"}
+	res, ok := s.checkPhaseA(context.Background(), req, resource.OperationCreate, 1747526400, "tA")
+	assert.False(t, ok)
+	assert.Equal(t, resource.OperationStatusInProgress, res.ProgressResult.OperationStatus)
+}
+
+// Silence unused imports — these types will be used by Tasks 14/15 tests.
+var _ = aws.String
+var _ = awsecs.DescribeServicesInput{}
+var _ ecstypes.LaunchType
+var _ = awselbv2.DescribeTargetHealthInput{}
+var _ elbv2types.TargetHealthStateEnum

--- a/pkg/cfres/ecs/phase_test.go
+++ b/pkg/cfres/ecs/phase_test.go
@@ -9,6 +9,7 @@ package ecs
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsecs "github.com/aws/aws-sdk-go-v2/service/ecs"
@@ -138,9 +139,126 @@ func TestCheckPhaseA_CCAPIError_RetryableInProgress(t *testing.T) {
 	assert.Equal(t, resource.OperationStatusInProgress, res.ProgressResult.OperationStatus)
 }
 
-// Silence unused imports — these types will be used by Tasks 14/15 tests.
-var _ = aws.String
-var _ = awsecs.DescribeServicesInput{}
-var _ ecstypes.LaunchType
+// Silence unused imports — these elbv2 types will be used by Task 15 tests.
 var _ = awselbv2.DescribeTargetHealthInput{}
 var _ elbv2types.TargetHealthStateEnum
+
+func TestStatusPhaseB_INACTIVEFailure_TerminalGeneralServiceException(t *testing.T) {
+	ecsCli := &mockECSClient{}
+	ecsCli.On("DescribeServices", mock.Anything, mock.Anything).Return(
+		&awsecs.DescribeServicesOutput{
+			Failures: []ecstypes.Failure{{Reason: aws.String("INACTIVE")}},
+		}, nil)
+
+	s := newServiceWithMocks(&mockCCXClient{}, ecsCli, nil)
+	req := &resource.StatusRequest{RequestID: "formae-ecs/create/1747526400/tA", NativeID: "pending|c|s"}
+	res, err := s.statusPhaseB(context.Background(), req, resource.OperationCreate, 1747526400, "c", "s")
+	assert.NoError(t, err)
+	assert.Equal(t, resource.OperationStatusFailure, res.ProgressResult.OperationStatus)
+	assert.Equal(t, resource.OperationErrorCodeGeneralServiceException, res.ProgressResult.ErrorCode)
+	assert.Contains(t, res.ProgressResult.StatusMessage, "deleted out-of-band")
+}
+
+func TestStatusPhaseB_INACTIVEServiceStatus_TerminalGeneralServiceException(t *testing.T) {
+	ecsCli := &mockECSClient{}
+	ecsCli.On("DescribeServices", mock.Anything, mock.Anything).Return(
+		&awsecs.DescribeServicesOutput{
+			Services: []ecstypes.Service{{Status: aws.String("INACTIVE")}},
+		}, nil)
+
+	s := newServiceWithMocks(&mockCCXClient{}, ecsCli, nil)
+	req := &resource.StatusRequest{RequestID: "formae-ecs/create/1747526400/tA", NativeID: "pending|c|s"}
+	res, err := s.statusPhaseB(context.Background(), req, resource.OperationCreate, 1747526400, "c", "s")
+	assert.NoError(t, err)
+	assert.Equal(t, resource.OperationErrorCodeGeneralServiceException, res.ProgressResult.ErrorCode)
+}
+
+func TestStatusPhaseB_ServiceMissing_InProgressBounded(t *testing.T) {
+	ecsCli := &mockECSClient{}
+	ecsCli.On("DescribeServices", mock.Anything, mock.Anything).Return(
+		&awsecs.DescribeServicesOutput{}, nil)
+
+	s := newServiceWithMocks(&mockCCXClient{}, ecsCli, nil)
+	req := &resource.StatusRequest{RequestID: "formae-ecs/create/1747526400/tA", NativeID: "pending|c|s"}
+	res, err := s.statusPhaseB(context.Background(), req, resource.OperationCreate, 1747526400, "c", "s")
+	assert.NoError(t, err)
+	assert.Equal(t, resource.OperationStatusInProgress, res.ProgressResult.OperationStatus)
+	assert.Contains(t, res.ProgressResult.StatusMessage, "not yet visible")
+}
+
+func TestStatusPhaseB_RolloutInProgress_InProgress(t *testing.T) {
+	now := time.Unix(1747526400, 0)
+	ecsCli := &mockECSClient{}
+	ecsCli.On("DescribeServices", mock.Anything, mock.Anything).Return(
+		&awsecs.DescribeServicesOutput{
+			Services: []ecstypes.Service{{
+				Status:       aws.String("ACTIVE"),
+				RunningCount: 0,
+				DesiredCount: 1,
+				Deployments: []ecstypes.Deployment{{
+					Status:       aws.String("PRIMARY"),
+					RolloutState: ecstypes.DeploymentRolloutStateInProgress,
+					CreatedAt:    &now,
+				}},
+			}},
+		}, nil)
+
+	s := newServiceWithMocks(&mockCCXClient{}, ecsCli, nil)
+	req := &resource.StatusRequest{RequestID: "formae-ecs/create/1747526400/tA", NativeID: "pending|c|s"}
+	res, err := s.statusPhaseB(context.Background(), req, resource.OperationCreate, 1747526400, "c", "s")
+	assert.NoError(t, err)
+	assert.Equal(t, resource.OperationStatusInProgress, res.ProgressResult.OperationStatus)
+	assert.Contains(t, res.ProgressResult.StatusMessage, "0/1")
+}
+
+func TestStatusPhaseB_RolloutFailed_TerminalGeneralServiceException(t *testing.T) {
+	now := time.Unix(1747526400, 0)
+	ecsCli := &mockECSClient{}
+	ecsCli.On("DescribeServices", mock.Anything, mock.Anything).Return(
+		&awsecs.DescribeServicesOutput{
+			Services: []ecstypes.Service{{
+				Status:       aws.String("ACTIVE"),
+				RunningCount: 0,
+				DesiredCount: 1,
+				Deployments: []ecstypes.Deployment{{
+					Status:             aws.String("PRIMARY"),
+					RolloutState:       ecstypes.DeploymentRolloutStateFailed,
+					RolloutStateReason: aws.String("Circuit breaker tripped"),
+					CreatedAt:          &now,
+				}},
+			}},
+		}, nil)
+
+	s := newServiceWithMocks(&mockCCXClient{}, ecsCli, nil)
+	req := &resource.StatusRequest{RequestID: "formae-ecs/create/1747526400/tA", NativeID: "pending|c|s"}
+	res, err := s.statusPhaseB(context.Background(), req, resource.OperationCreate, 1747526400, "c", "s")
+	assert.NoError(t, err)
+	assert.Equal(t, resource.OperationErrorCodeGeneralServiceException, res.ProgressResult.ErrorCode)
+	assert.Contains(t, res.ProgressResult.StatusMessage, "Circuit breaker")
+}
+
+func TestStatusPhaseB_PastTimeout_NotStable_Terminal(t *testing.T) {
+	primaryStart := time.Unix(1747526400, 0)
+	ecsCli := &mockECSClient{}
+	ecsCli.On("DescribeServices", mock.Anything, mock.Anything).Return(
+		&awsecs.DescribeServicesOutput{
+			Services: []ecstypes.Service{{
+				Status:       aws.String("ACTIVE"),
+				RunningCount: 0,
+				DesiredCount: 1,
+				Deployments: []ecstypes.Deployment{{
+					Status:       aws.String("PRIMARY"),
+					RolloutState: ecstypes.DeploymentRolloutStateInProgress,
+					CreatedAt:    &primaryStart,
+				}},
+			}},
+		}, nil)
+
+	s := newServiceWithMocks(&mockCCXClient{}, ecsCli, nil)
+	s.now = func() time.Time { return primaryStart.Add(25 * time.Minute) }
+	req := &resource.StatusRequest{RequestID: "formae-ecs/create/1747526400/tA", NativeID: "pending|c|s"}
+	res, err := s.statusPhaseB(context.Background(), req, resource.OperationCreate, 1747526400, "c", "s")
+	assert.NoError(t, err)
+	assert.Equal(t, resource.OperationStatusFailure, res.ProgressResult.OperationStatus)
+	assert.Equal(t, resource.OperationErrorCodeGeneralServiceException, res.ProgressResult.ErrorCode)
+}

--- a/pkg/cfres/ecs/phase_test.go
+++ b/pkg/cfres/ecs/phase_test.go
@@ -139,10 +139,6 @@ func TestCheckPhaseA_CCAPIError_RetryableInProgress(t *testing.T) {
 	assert.Equal(t, resource.OperationStatusInProgress, res.ProgressResult.OperationStatus)
 }
 
-// Silence unused imports — these elbv2 types will be used by Task 15 tests.
-var _ = awselbv2.DescribeTargetHealthInput{}
-var _ elbv2types.TargetHealthStateEnum
-
 func TestStatusPhaseB_INACTIVEFailure_TerminalGeneralServiceException(t *testing.T) {
 	ecsCli := &mockECSClient{}
 	ecsCli.On("DescribeServices", mock.Anything, mock.Anything).Return(
@@ -261,4 +257,110 @@ func TestStatusPhaseB_PastTimeout_NotStable_Terminal(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, resource.OperationStatusFailure, res.ProgressResult.OperationStatus)
 	assert.Equal(t, resource.OperationErrorCodeGeneralServiceException, res.ProgressResult.ErrorCode)
+}
+
+func TestStatusPhaseB_DesiredCountZero_NoTGCheck(t *testing.T) {
+	primaryStart := time.Unix(1747526400, 0)
+	ecsCli := &mockECSClient{}
+	ecsCli.On("DescribeServices", mock.Anything, mock.Anything).Return(
+		&awsecs.DescribeServicesOutput{
+			Services: []ecstypes.Service{{
+				Status:       aws.String("ACTIVE"),
+				ServiceArn:   aws.String("arn:aws:ecs:us-east-1:123:service/c/s"),
+				RunningCount: 0,
+				DesiredCount: 0,
+				LoadBalancers: []ecstypes.LoadBalancer{
+					{TargetGroupArn: aws.String("arn:tg:1")}, // attached but desired=0 → skip
+				},
+				Deployments: []ecstypes.Deployment{{
+					Status:       aws.String("PRIMARY"),
+					RolloutState: ecstypes.DeploymentRolloutStateCompleted,
+					CreatedAt:    &primaryStart,
+				}},
+			}},
+		}, nil)
+
+	ccx := &mockCCXClient{}
+	ccx.On("ReadResource", mock.Anything, mock.Anything).Return(
+		&resource.ReadResult{ResourceType: "AWS::ECS::Service", Properties: `{"DesiredCount":0}`}, nil)
+
+	elb := &mockELBv2Client{} // never called — assert via mock expectations
+
+	s := newServiceWithMocks(ccx, ecsCli, elb)
+	req := &resource.StatusRequest{RequestID: "formae-ecs/create/1747526400/tA", NativeID: "pending|c|s"}
+	res, err := s.statusPhaseB(context.Background(), req, resource.OperationCreate, 1747526400, "c", "s")
+	assert.NoError(t, err)
+	assert.Equal(t, resource.OperationStatusSuccess, res.ProgressResult.OperationStatus)
+	elb.AssertNotCalled(t, "DescribeTargetHealth")
+}
+
+func TestStatusPhaseB_ClassicELB_SkipsTGCheck(t *testing.T) {
+	primaryStart := time.Unix(1747526400, 0)
+	ecsCli := &mockECSClient{}
+	ecsCli.On("DescribeServices", mock.Anything, mock.Anything).Return(
+		&awsecs.DescribeServicesOutput{
+			Services: []ecstypes.Service{{
+				Status:       aws.String("ACTIVE"),
+				ServiceArn:   aws.String("arn:aws:ecs:us-east-1:123:service/c/s"),
+				RunningCount: 1,
+				DesiredCount: 1,
+				LoadBalancers: []ecstypes.LoadBalancer{
+					// Classic ELB attachment — no TargetGroupArn, only LoadBalancerName.
+					{LoadBalancerName: aws.String("classic-elb-1")},
+				},
+				Deployments: []ecstypes.Deployment{{
+					Status:       aws.String("PRIMARY"),
+					RolloutState: ecstypes.DeploymentRolloutStateCompleted,
+					CreatedAt:    &primaryStart,
+				}},
+			}},
+		}, nil)
+
+	ccx := &mockCCXClient{}
+	ccx.On("ReadResource", mock.Anything, mock.Anything).Return(
+		&resource.ReadResult{ResourceType: "AWS::ECS::Service", Properties: `{"DesiredCount":1}`}, nil)
+
+	elb := &mockELBv2Client{}
+	s := newServiceWithMocks(ccx, ecsCli, elb)
+	req := &resource.StatusRequest{RequestID: "formae-ecs/create/1747526400/tA", NativeID: "pending|c|s"}
+	res, err := s.statusPhaseB(context.Background(), req, resource.OperationCreate, 1747526400, "c", "s")
+	assert.NoError(t, err)
+	assert.Equal(t, resource.OperationStatusSuccess, res.ProgressResult.OperationStatus)
+	elb.AssertNotCalled(t, "DescribeTargetHealth")
+}
+
+func TestStatusPhaseB_TGUnhealthy_InProgress(t *testing.T) {
+	primaryStart := time.Unix(1747526400, 0)
+	ecsCli := &mockECSClient{}
+	ecsCli.On("DescribeServices", mock.Anything, mock.Anything).Return(
+		&awsecs.DescribeServicesOutput{
+			Services: []ecstypes.Service{{
+				Status:       aws.String("ACTIVE"),
+				RunningCount: 1,
+				DesiredCount: 1,
+				LoadBalancers: []ecstypes.LoadBalancer{
+					{TargetGroupArn: aws.String("arn:tg:1")},
+				},
+				Deployments: []ecstypes.Deployment{{
+					Status:       aws.String("PRIMARY"),
+					RolloutState: ecstypes.DeploymentRolloutStateCompleted,
+					CreatedAt:    &primaryStart,
+				}},
+			}},
+		}, nil)
+
+	elb := &mockELBv2Client{}
+	elb.On("DescribeTargetHealth", mock.Anything, mock.Anything).Return(
+		&awselbv2.DescribeTargetHealthOutput{
+			TargetHealthDescriptions: []elbv2types.TargetHealthDescription{{
+				TargetHealth: &elbv2types.TargetHealth{State: elbv2types.TargetHealthStateEnumUnhealthy},
+			}},
+		}, nil)
+
+	s := newServiceWithMocks(&mockCCXClient{}, ecsCli, elb)
+	req := &resource.StatusRequest{RequestID: "formae-ecs/create/1747526400/tA", NativeID: "pending|c|s"}
+	res, err := s.statusPhaseB(context.Background(), req, resource.OperationCreate, 1747526400, "c", "s")
+	assert.NoError(t, err)
+	assert.Equal(t, resource.OperationStatusInProgress, res.ProgressResult.OperationStatus)
+	assert.Contains(t, res.ProgressResult.StatusMessage, "healthy")
 }

--- a/pkg/cfres/ecs/phase_test.go
+++ b/pkg/cfres/ecs/phase_test.go
@@ -329,6 +329,105 @@ func TestStatusPhaseB_ClassicELB_SkipsTGCheck(t *testing.T) {
 	elb.AssertNotCalled(t, "DescribeTargetHealth")
 }
 
+func TestStatusPhaseB_FinalReadNotFound_WithinGrace_InProgress(t *testing.T) {
+	primaryStart := time.Unix(1747526400, 0)
+	ecsCli := &mockECSClient{}
+	ecsCli.On("DescribeServices", mock.Anything, mock.Anything).Return(
+		&awsecs.DescribeServicesOutput{
+			Services: []ecstypes.Service{{
+				Status:       aws.String("ACTIVE"),
+				ServiceArn:   aws.String("arn:aws:ecs:us-east-1:123:service/c/s"),
+				RunningCount: 1,
+				DesiredCount: 1,
+				Deployments: []ecstypes.Deployment{{
+					Status:       aws.String("PRIMARY"),
+					RolloutState: ecstypes.DeploymentRolloutStateCompleted,
+					CreatedAt:    &primaryStart,
+				}},
+			}},
+		}, nil)
+	ccx := &mockCCXClient{}
+	// Final Read returns NotFound (eventual consistency on a just-stabilized service).
+	ccx.On("ReadResource", mock.Anything, mock.Anything).Return(
+		&resource.ReadResult{
+			ResourceType: "AWS::ECS::Service",
+			ErrorCode:    resource.OperationErrorCodeNotFound,
+		}, nil)
+
+	s := newServiceWithMocks(ccx, ecsCli, nil)
+	// 20m 30s after unixStart — inside operationTimeout + finalReadGrace (22m).
+	s.now = func() time.Time { return time.Unix(1747526400, 0).Add(20*time.Minute + 30*time.Second) }
+
+	req := &resource.StatusRequest{RequestID: "formae-ecs/create/1747526400/tA", NativeID: "pending|c|s"}
+	res, err := s.statusPhaseB(context.Background(), req, resource.OperationCreate, 1747526400, "c", "s")
+	assert.NoError(t, err)
+	assert.Equal(t, resource.OperationStatusInProgress, res.ProgressResult.OperationStatus,
+		"stable service within finalReadGrace should still be InProgress, not terminal")
+}
+
+func TestStatusPhaseB_FinalReadAccessDenied_Terminal(t *testing.T) {
+	primaryStart := time.Unix(1747526400, 0)
+	ecsCli := &mockECSClient{}
+	ecsCli.On("DescribeServices", mock.Anything, mock.Anything).Return(
+		&awsecs.DescribeServicesOutput{
+			Services: []ecstypes.Service{{
+				Status:       aws.String("ACTIVE"),
+				ServiceArn:   aws.String("arn:aws:ecs:us-east-1:123:service/c/s"),
+				RunningCount: 1,
+				DesiredCount: 1,
+				Deployments: []ecstypes.Deployment{{
+					Status:       aws.String("PRIMARY"),
+					RolloutState: ecstypes.DeploymentRolloutStateCompleted,
+					CreatedAt:    &primaryStart,
+				}},
+			}},
+		}, nil)
+	ccx := &mockCCXClient{}
+	ccx.On("ReadResource", mock.Anything, mock.Anything).Return(
+		&resource.ReadResult{ErrorCode: resource.OperationErrorCodeAccessDenied}, nil)
+
+	s := newServiceWithMocks(ccx, ecsCli, nil)
+	req := &resource.StatusRequest{RequestID: "formae-ecs/create/1747526400/tA", NativeID: "pending|c|s"}
+	res, err := s.statusPhaseB(context.Background(), req, resource.OperationCreate, 1747526400, "c", "s")
+	assert.NoError(t, err)
+	assert.Equal(t, resource.OperationStatusFailure, res.ProgressResult.OperationStatus)
+	assert.Equal(t, resource.OperationErrorCodeAccessDenied, res.ProgressResult.ErrorCode)
+}
+
+func TestStatusPhaseB_StableAtBoundary_SucceedsNotTimeoutsOut(t *testing.T) {
+	// Service stabilized just before the 20m boundary. Final Read succeeds.
+	// Verify Success even though `now - unixStart` > operationTimeout would
+	// have escalated via inProgressOrTimeout — but the success path doesn't
+	// route through that helper.
+	primaryStart := time.Unix(1747526400, 0)
+	ecsCli := &mockECSClient{}
+	ecsCli.On("DescribeServices", mock.Anything, mock.Anything).Return(
+		&awsecs.DescribeServicesOutput{
+			Services: []ecstypes.Service{{
+				Status:       aws.String("ACTIVE"),
+				ServiceArn:   aws.String("arn:aws:ecs:us-east-1:123:service/c/s"),
+				RunningCount: 1,
+				DesiredCount: 1,
+				Deployments: []ecstypes.Deployment{{
+					Status:       aws.String("PRIMARY"),
+					RolloutState: ecstypes.DeploymentRolloutStateCompleted,
+					CreatedAt:    &primaryStart,
+				}},
+			}},
+		}, nil)
+	ccx := &mockCCXClient{}
+	ccx.On("ReadResource", mock.Anything, mock.Anything).Return(
+		&resource.ReadResult{ResourceType: "AWS::ECS::Service", Properties: `{"k":"v"}`}, nil)
+
+	s := newServiceWithMocks(ccx, ecsCli, nil)
+	s.now = func() time.Time { return time.Unix(1747526400, 0).Add(20*time.Minute + 1*time.Second) }
+
+	req := &resource.StatusRequest{RequestID: "formae-ecs/create/1747526400/tA", NativeID: "pending|c|s"}
+	res, err := s.statusPhaseB(context.Background(), req, resource.OperationCreate, 1747526400, "c", "s")
+	assert.NoError(t, err)
+	assert.Equal(t, resource.OperationStatusSuccess, res.ProgressResult.OperationStatus)
+}
+
 func TestStatusPhaseB_TGUnhealthy_InProgress(t *testing.T) {
 	primaryStart := time.Unix(1747526400, 0)
 	ecsCli := &mockECSClient{}

--- a/pkg/cfres/ecs/phase_test.go
+++ b/pkg/cfres/ecs/phase_test.go
@@ -463,3 +463,100 @@ func TestStatusPhaseB_TGUnhealthy_InProgress(t *testing.T) {
 	assert.Equal(t, resource.OperationStatusInProgress, res.ProgressResult.OperationStatus)
 	assert.Contains(t, res.ProgressResult.StatusMessage, "healthy")
 }
+
+func TestStatusPhaseB_UpdateWithNewDeployment_NormalFlow(t *testing.T) {
+	// Update where primary.CreatedAt >= unixStart - slack (the new deployment IS ours).
+	// Phase B proceeds normally, returns InProgress for a still-rolling deployment.
+	unixStart := int64(1747526400)
+	primaryStart := time.Unix(unixStart, 0).Add(5 * time.Second) // new deployment just appeared
+	ecsCli := &mockECSClient{}
+	ecsCli.On("DescribeServices", mock.Anything, mock.Anything).Return(
+		&awsecs.DescribeServicesOutput{
+			Services: []ecstypes.Service{{
+				Status:       aws.String("ACTIVE"),
+				RunningCount: 0,
+				DesiredCount: 1,
+				Deployments: []ecstypes.Deployment{{
+					Status:       aws.String("PRIMARY"),
+					RolloutState: ecstypes.DeploymentRolloutStateInProgress,
+					CreatedAt:    &primaryStart,
+				}},
+			}},
+		}, nil)
+
+	s := newServiceWithMocks(&mockCCXClient{}, ecsCli, nil)
+	// Now is shortly after the deployment started
+	s.now = func() time.Time { return primaryStart.Add(10 * time.Second) }
+	req := &resource.StatusRequest{RequestID: "formae-ecs/update/1747526400/tU", NativeID: "pending|c|s"}
+	res, err := s.statusPhaseB(context.Background(), req, resource.OperationUpdate, unixStart, "c", "s")
+	assert.NoError(t, err)
+	assert.Equal(t, resource.OperationStatusInProgress, res.ProgressResult.OperationStatus)
+	assert.Contains(t, res.ProgressResult.StatusMessage, "0/1")
+}
+
+func TestStatusPhaseB_UpdateNoNewDeployment_WithinGrace_InProgress(t *testing.T) {
+	// Update where primary.CreatedAt is well before unixStart-slack AND we are still
+	// inside the updateGraceWindow (60s) since unixStart. Should return InProgress
+	// with "waiting for new deployment to start".
+	unixStart := int64(1747526400)
+	primaryStart := time.Unix(unixStart, 0).Add(-1 * time.Hour) // pre-existing deployment
+	ecsCli := &mockECSClient{}
+	ecsCli.On("DescribeServices", mock.Anything, mock.Anything).Return(
+		&awsecs.DescribeServicesOutput{
+			Services: []ecstypes.Service{{
+				Status:       aws.String("ACTIVE"),
+				RunningCount: 1,
+				DesiredCount: 1,
+				Deployments: []ecstypes.Deployment{{
+					Status:       aws.String("PRIMARY"),
+					RolloutState: ecstypes.DeploymentRolloutStateCompleted,
+					CreatedAt:    &primaryStart,
+				}},
+			}},
+		}, nil)
+
+	s := newServiceWithMocks(&mockCCXClient{}, ecsCli, nil)
+	// 30s after unixStart — inside the 60s grace window
+	s.now = func() time.Time { return time.Unix(unixStart, 0).Add(30 * time.Second) }
+	req := &resource.StatusRequest{RequestID: "formae-ecs/update/1747526400/tU", NativeID: "pending|c|s"}
+	res, err := s.statusPhaseB(context.Background(), req, resource.OperationUpdate, unixStart, "c", "s")
+	assert.NoError(t, err)
+	assert.Equal(t, resource.OperationStatusInProgress, res.ProgressResult.OperationStatus)
+	assert.Contains(t, res.ProgressResult.StatusMessage, "waiting for new deployment to start")
+}
+
+func TestStatusPhaseB_UpdateNoNewDeployment_PastGrace_NoopUpdate_Success(t *testing.T) {
+	// Update where primary.CreatedAt is well before unixStart-slack AND we are PAST
+	// the updateGraceWindow. The implementation falls through to stability check
+	// on the existing primary. Since it's stable + no TGs, it should report Success.
+	unixStart := int64(1747526400)
+	primaryStart := time.Unix(unixStart, 0).Add(-1 * time.Hour) // pre-existing, stable
+	ecsCli := &mockECSClient{}
+	ecsCli.On("DescribeServices", mock.Anything, mock.Anything).Return(
+		&awsecs.DescribeServicesOutput{
+			Services: []ecstypes.Service{{
+				Status:       aws.String("ACTIVE"),
+				ServiceArn:   aws.String("arn:aws:ecs:us-east-1:123:service/c/s"),
+				RunningCount: 1,
+				DesiredCount: 1,
+				Deployments: []ecstypes.Deployment{{
+					Status:       aws.String("PRIMARY"),
+					RolloutState: ecstypes.DeploymentRolloutStateCompleted,
+					CreatedAt:    &primaryStart,
+				}},
+			}},
+		}, nil)
+	ccx := &mockCCXClient{}
+	ccx.On("ReadResource", mock.Anything, mock.Anything).Return(
+		&resource.ReadResult{ResourceType: "AWS::ECS::Service", Properties: `{"k":"v"}`}, nil)
+
+	s := newServiceWithMocks(ccx, ecsCli, nil)
+	// 5 min after unixStart — past 60s grace
+	s.now = func() time.Time { return time.Unix(unixStart, 0).Add(5 * time.Minute) }
+	req := &resource.StatusRequest{RequestID: "formae-ecs/update/1747526400/tU", NativeID: "pending|c|s"}
+	res, err := s.statusPhaseB(context.Background(), req, resource.OperationUpdate, unixStart, "c", "s")
+	assert.NoError(t, err)
+	assert.Equal(t, resource.OperationStatusSuccess, res.ProgressResult.OperationStatus,
+		"no-op Update past grace with stable existing primary should report Success")
+	assert.Equal(t, resource.OperationUpdate, res.ProgressResult.Operation)
+}

--- a/pkg/cfres/ecs/service.go
+++ b/pkg/cfres/ecs/service.go
@@ -184,7 +184,55 @@ func (s *Service) Create(ctx context.Context, req *resource.CreateRequest) (*res
 }
 
 func (s *Service) Update(ctx context.Context, req *resource.UpdateRequest) (*resource.UpdateResult, error) {
-	panic("Service.Update: implemented in Task 11")
+	// Shape gate FIRST. PriorProperties is authoritative — DesiredProperties may
+	// omit createOnly fields (deploymentController, schedulingStrategy) in patch shape.
+	usePhaseB := shapeSupportsPhaseB(req.PriorProperties)
+
+	var cluster, service string
+	if usePhaseB {
+		c, s2, err := parseUpdateClusterAndService(req.NativeID)
+		if err != nil {
+			return &resource.UpdateResult{
+				ProgressResult: terminalFailurePR(resource.OperationUpdate, req.NativeID, "",
+					resource.OperationErrorCodeInvalidRequest, err.Error()),
+			}, nil
+		}
+		cluster, service = c, s2
+	}
+
+	cli, err := s.ccxClientFactory(s.cfg)
+	if err != nil {
+		return &resource.UpdateResult{
+			ProgressResult: classifyForEntry(err, resource.OperationUpdate, req.NativeID, "build CCAPI client"),
+		}, nil
+	}
+	res, err := cli.UpdateResource(ctx, req)
+	if err != nil {
+		return &resource.UpdateResult{
+			ProgressResult: classifyForEntry(err, resource.OperationUpdate, req.NativeID, "ccx.UpdateResource"),
+		}, nil
+	}
+
+	// Sync-preflight OOB-delete intercept: ccx.UpdateResource preflights with
+	// GetResource (pkg/ccx/client.go:171-180); ResourceNotFoundException there
+	// wraps as Failure with ErrorCode=NotFound. NotFound is in the SDK's
+	// recoverableErrorCodes table, so propagating it would loop the operator.
+	// Swap to GeneralServiceException (non-recoverable).
+	if res.ProgressResult != nil &&
+		res.ProgressResult.OperationStatus == resource.OperationStatusFailure &&
+		res.ProgressResult.ErrorCode == resource.OperationErrorCodeNotFound {
+		return &resource.UpdateResult{
+			ProgressResult: terminalFailurePR(resource.OperationUpdate, req.NativeID, "",
+				resource.OperationErrorCodeGeneralServiceException,
+				"ECS service deleted out-of-band before Update could fire (CCAPI preflight NotFound): "+
+					res.ProgressResult.StatusMessage),
+		}, nil
+	}
+
+	if usePhaseB {
+		s.wrapForUpdate(res.ProgressResult, req.NativeID, cluster, service)
+	}
+	return res, nil
 }
 
 func (s *Service) Status(ctx context.Context, req *resource.StatusRequest) (*resource.StatusResult, error) {

--- a/pkg/cfres/ecs/service.go
+++ b/pkg/cfres/ecs/service.go
@@ -10,12 +10,25 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
 	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/ccx"
 	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/cfres/prov"
 	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/cfres/registry"
 	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/config"
+)
+
+// Constants used across Phase A/Phase B. Some are wired in subsequent tasks;
+// staged here so later diffs stay focused on behavior rather than constants.
+const (
+	phaseBPrefix            = "formae-ecs/"
+	opSegCreate             = "create"
+	opSegUpdate             = "update"
+	defaultOperationTimeout = 20 * time.Minute
+	defaultFinalReadGrace   = 2 * time.Minute
+	updateGraceWindow       = 60 * time.Second
+	primaryCreatedSlack     = 10 * time.Second
 )
 
 // Service is a custom provisioner for AWS::ECS::Service. CloudControl accepts
@@ -32,7 +45,13 @@ import (
 //
 // Bug reference: formae@.claude/handover/spurious-replace-ecs/BUG-2-CLUSTER-ARN-DRIFT.md.
 type Service struct {
-	cfg *config.Config
+	cfg                *config.Config
+	ccxClientFactory   func(*config.Config) (ccxClient, error)
+	ecsClientFactory   func(*config.Config) (ecsClient, error)
+	elbv2ClientFactory func(*config.Config) (elbv2Client, error)
+	now                func() time.Time
+	operationTimeout   time.Duration
+	finalReadGrace     time.Duration
 }
 
 type ccxReadClient interface {
@@ -43,9 +62,24 @@ var _ prov.Provisioner = &Service{}
 
 func init() {
 	registry.Register("AWS::ECS::Service",
-		[]resource.Operation{resource.OperationRead},
+		[]resource.Operation{
+			resource.OperationRead,
+			resource.OperationCreate,
+			resource.OperationUpdate,
+			resource.OperationCheckStatus,
+			// Delete intentionally NOT registered — generic CCAPI Delete polls correctly
+			// per the bug report's 6-minute deleting state observation.
+		},
 		func(cfg *config.Config) prov.Provisioner {
-			return &Service{cfg: cfg}
+			return &Service{
+				cfg:                cfg,
+				ccxClientFactory:   defaultCCXClientFactory,
+				ecsClientFactory:   defaultECSClientFactory,
+				elbv2ClientFactory: defaultELBv2ClientFactory,
+				now:                time.Now,
+				operationTimeout:   defaultOperationTimeout,
+				finalReadGrace:     defaultFinalReadGrace,
+			}
 		})
 }
 
@@ -114,22 +148,22 @@ func parseEcsArn(arn string) (partition, region, account string, ok bool) {
 	return parts[1], parts[3], parts[4], true
 }
 
-func (s *Service) Create(_ context.Context, _ *resource.CreateRequest) (*resource.CreateResult, error) {
-	return nil, fmt.Errorf("AWS::ECS::Service custom provisioner only implements Read")
+func (s *Service) Create(ctx context.Context, req *resource.CreateRequest) (*resource.CreateResult, error) {
+	panic("Service.Create: implemented in Task 10")
 }
 
-func (s *Service) Update(_ context.Context, _ *resource.UpdateRequest) (*resource.UpdateResult, error) {
-	return nil, fmt.Errorf("AWS::ECS::Service custom provisioner only implements Read")
+func (s *Service) Update(ctx context.Context, req *resource.UpdateRequest) (*resource.UpdateResult, error) {
+	panic("Service.Update: implemented in Task 11")
+}
+
+func (s *Service) Status(ctx context.Context, req *resource.StatusRequest) (*resource.StatusResult, error) {
+	panic("Service.Status: implemented in Task 12")
 }
 
 func (s *Service) Delete(_ context.Context, _ *resource.DeleteRequest) (*resource.DeleteResult, error) {
-	return nil, fmt.Errorf("AWS::ECS::Service custom provisioner only implements Read")
-}
-
-func (s *Service) Status(_ context.Context, _ *resource.StatusRequest) (*resource.StatusResult, error) {
-	return nil, fmt.Errorf("AWS::ECS::Service custom provisioner only implements Read")
+	return nil, fmt.Errorf("AWS::ECS::Service custom provisioner does not implement Delete")
 }
 
 func (s *Service) List(_ context.Context, _ *resource.ListRequest) (*resource.ListResult, error) {
-	return nil, fmt.Errorf("AWS::ECS::Service custom provisioner only implements Read")
+	return nil, fmt.Errorf("AWS::ECS::Service custom provisioner does not implement List")
 }

--- a/pkg/cfres/ecs/service.go
+++ b/pkg/cfres/ecs/service.go
@@ -236,7 +236,38 @@ func (s *Service) Update(ctx context.Context, req *resource.UpdateRequest) (*res
 }
 
 func (s *Service) Status(ctx context.Context, req *resource.StatusRequest) (*resource.StatusResult, error) {
-	panic("Service.Status: implemented in Task 12")
+	op, unixStart, ccapiToken, ok := parseComposite(req.RequestID)
+	if !ok {
+		return s.delegateRawStatus(ctx, req)
+	}
+	cluster, service, ok := parseClusterAndServiceFromNativeID(req.NativeID)
+	if !ok {
+		return &resource.StatusResult{
+			ProgressResult: terminalFailurePR(op, req.NativeID, req.RequestID,
+				resource.OperationErrorCodeInvalidRequest,
+				"malformed NativeID: "+req.NativeID),
+		}, nil
+	}
+
+	// Always poll CCAPI first; Phase B runs only after CCAPI Success.
+	phaseAResult, ccapiSuccess := s.checkPhaseA(ctx, req, op, unixStart, ccapiToken)
+	if !ccapiSuccess {
+		return phaseAResult, nil
+	}
+
+	// Phase B path.
+	return s.statusPhaseB(ctx, req, op, unixStart, cluster, service)
+}
+
+// delegateRawStatus passes a non-composite request straight through to
+// ccx.StatusResource. Used for CODE_DEPLOY/EXTERNAL/DAEMON services whose
+// Create/Update declined to wrap the RequestID, plus legacy replays.
+func (s *Service) delegateRawStatus(ctx context.Context, req *resource.StatusRequest) (*resource.StatusResult, error) {
+	cli, err := s.ccxClientFactory(s.cfg)
+	if err != nil {
+		return nil, err
+	}
+	return cli.StatusResource(ctx, req, s.Read)
 }
 
 func (s *Service) Delete(_ context.Context, _ *resource.DeleteRequest) (*resource.DeleteResult, error) {

--- a/pkg/cfres/ecs/service.go
+++ b/pkg/cfres/ecs/service.go
@@ -149,7 +149,38 @@ func parseEcsArn(arn string) (partition, region, account string, ok bool) {
 }
 
 func (s *Service) Create(ctx context.Context, req *resource.CreateRequest) (*resource.CreateResult, error) {
-	panic("Service.Create: implemented in Task 10")
+	// Shape gate FIRST. Non-Phase-B shapes (CODE_DEPLOY/EXTERNAL/DAEMON) skip
+	// the wrap entirely and fall through to generic CCAPI Status.
+	usePhaseB := shapeSupportsPhaseB(req.Properties)
+
+	var cluster, service string
+	if usePhaseB {
+		c, s2, err := parseCreateClusterAndService(req.Properties)
+		if err != nil {
+			return &resource.CreateResult{
+				ProgressResult: terminalFailurePR(resource.OperationCreate, "", "",
+					resource.OperationErrorCodeInvalidRequest, err.Error()),
+			}, nil
+		}
+		cluster, service = c, s2
+	}
+
+	cli, err := s.ccxClientFactory(s.cfg)
+	if err != nil {
+		return &resource.CreateResult{
+			ProgressResult: classifyForEntry(err, resource.OperationCreate, "", "build CCAPI client"),
+		}, nil
+	}
+	res, err := cli.CreateResource(ctx, req)
+	if err != nil {
+		return &resource.CreateResult{
+			ProgressResult: classifyForEntry(err, resource.OperationCreate, "", "ccx.CreateResource"),
+		}, nil
+	}
+	if usePhaseB {
+		s.wrapForCreate(res.ProgressResult, cluster, service)
+	}
+	return res, nil
 }
 
 func (s *Service) Update(ctx context.Context, req *resource.UpdateRequest) (*resource.UpdateResult, error) {

--- a/pkg/cfres/ecs/service.go
+++ b/pkg/cfres/ecs/service.go
@@ -30,19 +30,27 @@ const (
 	primaryCreatedSlack     = 10 * time.Second
 )
 
-// Service is a custom provisioner for AWS::ECS::Service. CloudControl accepts
-// either a cluster short name or a full ARN in the Cluster field on Create,
-// but its Read response always returns the bare short name. When the caller
-// set Cluster with an ARN-valued Resolvable (e.g. `cluster = ecsCluster.res.arn`),
-// that mismatch surfaces on every reapply as a phantom createOnly diff on the
-// Cluster field — the planner promotes the Update to a full Replace.
+// Service is a custom provisioner for AWS::ECS::Service that implements:
 //
-// This provisioner intercepts Read and re-inflates the bare cluster name back
-// to a full ARN using the region and account parsed from the always-present
-// ServiceArn, so the comparator sees the same shape the user sent on Create.
-// Create/Update/Delete/Status continue through the generic CloudControl path.
+//  1. Cluster ARN re-inflation on Read (legacy behavior). CloudControl's Read
+//     response always returns the bare cluster short name, which causes phantom
+//     createOnly diffs when the caller used a full ARN. Read re-inflates the
+//     short name back to the ARN using region/account parsed from ServiceArn.
 //
-// Bug reference: formae@.claude/handover/spurious-replace-ecs/BUG-2-CLUSTER-ARN-DRIFT.md.
+//  2. Two-phase stability tracking on Create/Update for REPLICA + ECS-controller
+//     services. Phase A polls CCAPI's request token; once CCAPI accepts the
+//     registration, Phase B polls DescribeServices + DescribeTargetHealth until
+//     the deployment is stable (rolloutState=COMPLETED, runningCount=desiredCount,
+//     ≥1 healthy target per attached ELBv2 target group). State is encoded in
+//     a composite RequestID ("formae-ecs/<op>/<unixStart>/<ccapiToken>") set
+//     once at Create/Update return and preserved across polls by the operator.
+//
+// Non-default shapes (CODE_DEPLOY / EXTERNAL controllers, DAEMON scheduling,
+// classic-ELB attachments) fall through to generic CCAPI Status via the shape
+// gate in Create/Update.
+//
+// Design: ~/dev/personal/engineering-notes/formae-plugin-aws/design/2026-05-18-ecs-service-stability-tracking.md
+// Bug:    ~/dev/personal/engineering-notes/formae-plugin-aws/2026-05-17-ecs-service-create-should-report-inprogress-until-deployment-stable.md
 type Service struct {
 	cfg                *config.Config
 	ccxClientFactory   func(*config.Config) (ccxClient, error)

--- a/pkg/cfres/ecs/service.go
+++ b/pkg/cfres/ecs/service.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
-	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/ccx"
 	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/cfres/prov"
 	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/cfres/registry"
 	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/config"
@@ -84,7 +83,7 @@ func init() {
 }
 
 func (s *Service) Read(ctx context.Context, request *resource.ReadRequest) (*resource.ReadResult, error) {
-	client, err := ccx.NewClient(s.cfg)
+	client, err := s.ccxClientFactory(s.cfg)
 	if err != nil {
 		return nil, fmt.Errorf("loading CloudControl client: %w", err)
 	}

--- a/pkg/cfres/ecs/service_mock_test.go
+++ b/pkg/cfres/ecs/service_mock_test.go
@@ -9,17 +9,66 @@ package ecs
 import (
 	"context"
 
+	awsecs "github.com/aws/aws-sdk-go-v2/service/ecs"
+	awselbv2 "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
 	"github.com/stretchr/testify/mock"
 
 	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
 )
 
-type mockCCXReadClient struct {
+// mockCCXClient implements the full ccxClient interface (Read+Create+Update+Status).
+// We keep the name from the prior mockCCXReadClient since the existing Read tests
+// reference it; we just add the new methods.
+type mockCCXClient struct {
 	mock.Mock
 }
 
-func (m *mockCCXReadClient) ReadResource(ctx context.Context, request *resource.ReadRequest) (*resource.ReadResult, error) {
+func (m *mockCCXClient) ReadResource(ctx context.Context, request *resource.ReadRequest) (*resource.ReadResult, error) {
 	args := m.Called(ctx, request)
 	out, _ := args.Get(0).(*resource.ReadResult)
+	return out, args.Error(1)
+}
+
+func (m *mockCCXClient) CreateResource(ctx context.Context, request *resource.CreateRequest) (*resource.CreateResult, error) {
+	args := m.Called(ctx, request)
+	out, _ := args.Get(0).(*resource.CreateResult)
+	return out, args.Error(1)
+}
+
+func (m *mockCCXClient) UpdateResource(ctx context.Context, request *resource.UpdateRequest) (*resource.UpdateResult, error) {
+	args := m.Called(ctx, request)
+	out, _ := args.Get(0).(*resource.UpdateResult)
+	return out, args.Error(1)
+}
+
+func (m *mockCCXClient) StatusResource(ctx context.Context, request *resource.StatusRequest,
+	readFunc func(context.Context, *resource.ReadRequest) (*resource.ReadResult, error)) (*resource.StatusResult, error) {
+	args := m.Called(ctx, request, readFunc)
+	out, _ := args.Get(0).(*resource.StatusResult)
+	return out, args.Error(1)
+}
+
+// Alias retained for the existing Read tests which reference mockCCXReadClient.
+type mockCCXReadClient = mockCCXClient
+
+type mockECSClient struct {
+	mock.Mock
+}
+
+func (m *mockECSClient) DescribeServices(ctx context.Context, params *awsecs.DescribeServicesInput,
+	optFns ...func(*awsecs.Options)) (*awsecs.DescribeServicesOutput, error) {
+	args := m.Called(ctx, params)
+	out, _ := args.Get(0).(*awsecs.DescribeServicesOutput)
+	return out, args.Error(1)
+}
+
+type mockELBv2Client struct {
+	mock.Mock
+}
+
+func (m *mockELBv2Client) DescribeTargetHealth(ctx context.Context, params *awselbv2.DescribeTargetHealthInput,
+	optFns ...func(*awselbv2.Options)) (*awselbv2.DescribeTargetHealthOutput, error) {
+	args := m.Called(ctx, params)
+	out, _ := args.Get(0).(*awselbv2.DescribeTargetHealthOutput)
 	return out, args.Error(1)
 }

--- a/pkg/cfres/ecs/service_test.go
+++ b/pkg/cfres/ecs/service_test.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -18,6 +19,18 @@ import (
 	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
 	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/config"
 )
+
+func newServiceWithMocks(ccx ccxClient, ecsCli ecsClient, elb elbv2Client) *Service {
+	return &Service{
+		cfg:                &config.Config{},
+		ccxClientFactory:   func(*config.Config) (ccxClient, error) { return ccx, nil },
+		ecsClientFactory:   func(*config.Config) (ecsClient, error) { return ecsCli, nil },
+		elbv2ClientFactory: func(*config.Config) (elbv2Client, error) { return elb, nil },
+		now:                func() time.Time { return time.Unix(1747526400, 0) },
+		operationTimeout:   20 * time.Minute,
+		finalReadGrace:     2 * time.Minute,
+	}
+}
 
 func TestService_Read_ReinflatesBareClusterNameToArn(t *testing.T) {
 	ctx := context.Background()
@@ -129,4 +142,110 @@ func TestService_Read_PropagatesInnerError(t *testing.T) {
 	})
 
 	assert.Error(t, err)
+}
+
+func TestService_Create_REPLICA_ECS_WrapsComposite(t *testing.T) {
+	ccx := &mockCCXClient{}
+	inner := &resource.CreateResult{
+		ProgressResult: &resource.ProgressResult{
+			Operation:       resource.OperationCreate,
+			OperationStatus: resource.OperationStatusInProgress,
+			RequestID:       "ccapi-tA",
+			NativeID:        "",
+		},
+	}
+	ccx.On("CreateResource", mock.Anything, mock.Anything).Return(inner, nil)
+
+	s := newServiceWithMocks(ccx, nil, nil)
+	req := &resource.CreateRequest{
+		ResourceType: "AWS::ECS::Service",
+		Properties:   []byte(`{"Cluster":"my-cluster","ServiceName":"my-svc"}`),
+	}
+	res, err := s.Create(context.Background(), req)
+	assert.NoError(t, err)
+	assert.Equal(t, "formae-ecs/create/1747526400/ccapi-tA", res.ProgressResult.RequestID)
+	assert.Equal(t, "pending|my-cluster|my-svc", res.ProgressResult.NativeID)
+}
+
+func TestService_Create_CODE_DEPLOY_Passthrough(t *testing.T) {
+	ccx := &mockCCXClient{}
+	inner := &resource.CreateResult{
+		ProgressResult: &resource.ProgressResult{
+			Operation:       resource.OperationCreate,
+			OperationStatus: resource.OperationStatusInProgress,
+			RequestID:       "ccapi-tA",
+			NativeID:        "",
+		},
+	}
+	ccx.On("CreateResource", mock.Anything, mock.Anything).Return(inner, nil)
+
+	s := newServiceWithMocks(ccx, nil, nil)
+	req := &resource.CreateRequest{
+		ResourceType: "AWS::ECS::Service",
+		Properties:   []byte(`{"DeploymentController":{"Type":"CODE_DEPLOY"}}`),
+	}
+	res, err := s.Create(context.Background(), req)
+	assert.NoError(t, err)
+	// No composite wrap — bare CCAPI token.
+	assert.Equal(t, "ccapi-tA", res.ProgressResult.RequestID)
+	assert.Equal(t, "", res.ProgressResult.NativeID)
+}
+
+func TestService_Create_DAEMON_Passthrough(t *testing.T) {
+	ccx := &mockCCXClient{}
+	inner := &resource.CreateResult{
+		ProgressResult: &resource.ProgressResult{
+			OperationStatus: resource.OperationStatusInProgress,
+			RequestID:       "ccapi-tA",
+		},
+	}
+	ccx.On("CreateResource", mock.Anything, mock.Anything).Return(inner, nil)
+
+	s := newServiceWithMocks(ccx, nil, nil)
+	req := &resource.CreateRequest{
+		ResourceType: "AWS::ECS::Service",
+		Properties:   []byte(`{"SchedulingStrategy":"DAEMON"}`),
+	}
+	res, err := s.Create(context.Background(), req)
+	assert.NoError(t, err)
+	assert.Equal(t, "ccapi-tA", res.ProgressResult.RequestID, "DAEMON shapes pass through without composite wrap")
+}
+
+func TestService_Create_REPLICA_MissingServiceName_InvalidRequest(t *testing.T) {
+	// shapeSupportsPhaseB(true) AND ServiceName missing → terminal Failure.
+	s := newServiceWithMocks(&mockCCXClient{}, nil, nil)
+	req := &resource.CreateRequest{
+		ResourceType: "AWS::ECS::Service",
+		Properties:   []byte(`{"Cluster":"my-cluster"}`),
+	}
+	res, err := s.Create(context.Background(), req)
+	assert.NoError(t, err)
+	assert.Equal(t, resource.OperationStatusFailure, res.ProgressResult.OperationStatus)
+	assert.Equal(t, resource.OperationErrorCodeInvalidRequest, res.ProgressResult.ErrorCode)
+	assert.Contains(t, res.ProgressResult.StatusMessage, "ServiceName")
+}
+
+func TestService_Create_SyncSuccess_RewritesToInProgress(t *testing.T) {
+	ccx := &mockCCXClient{}
+	inner := &resource.CreateResult{
+		ProgressResult: &resource.ProgressResult{
+			Operation:          resource.OperationCreate,
+			OperationStatus:    resource.OperationStatusSuccess,
+			RequestID:          "ccapi-tA",
+			NativeID:           "arn:aws:ecs:us-east-1:123:service/my-cluster/my-svc|my-cluster",
+			ResourceProperties: []byte(`{"k":"v"}`),
+		},
+	}
+	ccx.On("CreateResource", mock.Anything, mock.Anything).Return(inner, nil)
+
+	s := newServiceWithMocks(ccx, nil, nil)
+	req := &resource.CreateRequest{
+		ResourceType: "AWS::ECS::Service",
+		Properties:   []byte(`{"Cluster":"my-cluster","ServiceName":"my-svc"}`),
+	}
+	res, err := s.Create(context.Background(), req)
+	assert.NoError(t, err)
+	assert.Equal(t, resource.OperationStatusInProgress, res.ProgressResult.OperationStatus)
+	assert.Nil(t, res.ProgressResult.ResourceProperties)
+	assert.Equal(t, "formae-ecs/create/1747526400/ccapi-tA", res.ProgressResult.RequestID)
 }

--- a/pkg/cfres/ecs/service_test.go
+++ b/pkg/cfres/ecs/service_test.go
@@ -323,6 +323,41 @@ func TestService_Update_SyncThrottling_Propagates(t *testing.T) {
 	assert.Equal(t, resource.OperationErrorCodeThrottling, res.ProgressResult.ErrorCode)
 }
 
+func TestService_Status_BareToken_DelegatesToCCXStatus(t *testing.T) {
+	// Non-composite RequestID — defensive fallback for CODE_DEPLOY/EXTERNAL/DAEMON
+	// shapes or legacy replays.
+	ccx := &mockCCXClient{}
+	inner := &resource.StatusResult{
+		ProgressResult: &resource.ProgressResult{
+			Operation:       resource.OperationCreate,
+			OperationStatus: resource.OperationStatusInProgress,
+			RequestID:       "f470d40b-d23c-4d3a-9c11-uuid",
+		},
+	}
+	ccx.On("StatusResource", mock.Anything, mock.Anything, mock.Anything).Return(inner, nil)
+
+	s := newServiceWithMocks(ccx, nil, nil)
+	res, err := s.Status(context.Background(), &resource.StatusRequest{
+		RequestID:    "f470d40b-d23c-4d3a-9c11-uuid",
+		NativeID:     "",
+		ResourceType: "AWS::ECS::Service",
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, resource.OperationStatusInProgress, res.ProgressResult.OperationStatus)
+}
+
+func TestService_Status_MalformedNativeID_TerminalInvalidRequest(t *testing.T) {
+	s := newServiceWithMocks(&mockCCXClient{}, nil, nil)
+	res, err := s.Status(context.Background(), &resource.StatusRequest{
+		RequestID:    "formae-ecs/create/1747526400/tA",
+		NativeID:     "garbage",
+		ResourceType: "AWS::ECS::Service",
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, resource.OperationStatusFailure, res.ProgressResult.OperationStatus)
+	assert.Equal(t, resource.OperationErrorCodeInvalidRequest, res.ProgressResult.ErrorCode)
+}
+
 func TestService_Create_SyncSuccess_RewritesToInProgress(t *testing.T) {
 	ccx := &mockCCXClient{}
 	inner := &resource.CreateResult{

--- a/pkg/cfres/ecs/service_test.go
+++ b/pkg/cfres/ecs/service_test.go
@@ -225,6 +225,104 @@ func TestService_Create_REPLICA_MissingServiceName_InvalidRequest(t *testing.T) 
 	assert.Contains(t, res.ProgressResult.StatusMessage, "ServiceName")
 }
 
+func TestService_Update_REPLICA_ECS_WrapsComposite(t *testing.T) {
+	ccx := &mockCCXClient{}
+	inner := &resource.UpdateResult{
+		ProgressResult: &resource.ProgressResult{
+			Operation:       resource.OperationUpdate,
+			OperationStatus: resource.OperationStatusInProgress,
+			RequestID:       "ccapi-tU",
+			NativeID:        "",
+		},
+	}
+	ccx.On("UpdateResource", mock.Anything, mock.Anything).Return(inner, nil)
+
+	s := newServiceWithMocks(ccx, nil, nil)
+	canonical := "arn:aws:ecs:us-east-1:123:service/my-cluster/my-svc|my-cluster"
+	req := &resource.UpdateRequest{
+		ResourceType:    "AWS::ECS::Service",
+		NativeID:        canonical,
+		PriorProperties: []byte(`{"Cluster":"my-cluster","ServiceName":"my-svc"}`),
+	}
+	res, err := s.Update(context.Background(), req)
+	assert.NoError(t, err)
+	assert.Equal(t, "formae-ecs/update/1747526400/ccapi-tU", res.ProgressResult.RequestID)
+	assert.Equal(t, canonical, res.ProgressResult.NativeID)
+}
+
+func TestService_Update_DAEMON_Passthrough(t *testing.T) {
+	ccx := &mockCCXClient{}
+	inner := &resource.UpdateResult{
+		ProgressResult: &resource.ProgressResult{
+			OperationStatus: resource.OperationStatusInProgress,
+			RequestID:       "ccapi-tU",
+		},
+	}
+	ccx.On("UpdateResource", mock.Anything, mock.Anything).Return(inner, nil)
+
+	s := newServiceWithMocks(ccx, nil, nil)
+	req := &resource.UpdateRequest{
+		ResourceType:    "AWS::ECS::Service",
+		NativeID:        "arn:aws:ecs:us-east-1:123:service/c/s|c",
+		PriorProperties: []byte(`{"SchedulingStrategy":"DAEMON"}`),
+	}
+	res, err := s.Update(context.Background(), req)
+	assert.NoError(t, err)
+	assert.Equal(t, "ccapi-tU", res.ProgressResult.RequestID, "DAEMON passes through")
+}
+
+func TestService_Update_SyncNotFound_RewritesToGeneralServiceException(t *testing.T) {
+	// Simulates ccx.UpdateResource's preflight GetResource returning NotFound
+	// for an OOB-deleted service. NotFound is recoverable in the SDK — we must
+	// rewrite to GeneralServiceException to avoid operator retry loops.
+	ccx := &mockCCXClient{}
+	inner := &resource.UpdateResult{
+		ProgressResult: &resource.ProgressResult{
+			Operation:       resource.OperationUpdate,
+			OperationStatus: resource.OperationStatusFailure,
+			ErrorCode:       resource.OperationErrorCodeNotFound,
+			StatusMessage:   "ResourceNotFoundException",
+		},
+	}
+	ccx.On("UpdateResource", mock.Anything, mock.Anything).Return(inner, nil)
+
+	s := newServiceWithMocks(ccx, nil, nil)
+	req := &resource.UpdateRequest{
+		ResourceType:    "AWS::ECS::Service",
+		NativeID:        "arn:aws:ecs:us-east-1:123:service/c/s|c",
+		PriorProperties: []byte(`{"Cluster":"c","ServiceName":"s"}`),
+	}
+	res, err := s.Update(context.Background(), req)
+	assert.NoError(t, err)
+	assert.Equal(t, resource.OperationStatusFailure, res.ProgressResult.OperationStatus)
+	assert.Equal(t, resource.OperationErrorCodeGeneralServiceException, res.ProgressResult.ErrorCode)
+	assert.Contains(t, res.ProgressResult.StatusMessage, "deleted out-of-band")
+}
+
+func TestService_Update_SyncThrottling_Propagates(t *testing.T) {
+	ccx := &mockCCXClient{}
+	inner := &resource.UpdateResult{
+		ProgressResult: &resource.ProgressResult{
+			Operation:       resource.OperationUpdate,
+			OperationStatus: resource.OperationStatusFailure,
+			ErrorCode:       resource.OperationErrorCodeThrottling,
+			StatusMessage:   "Rate exceeded",
+		},
+	}
+	ccx.On("UpdateResource", mock.Anything, mock.Anything).Return(inner, nil)
+
+	s := newServiceWithMocks(ccx, nil, nil)
+	req := &resource.UpdateRequest{
+		ResourceType:    "AWS::ECS::Service",
+		NativeID:        "arn:aws:ecs:us-east-1:123:service/c/s|c",
+		PriorProperties: []byte(`{"Cluster":"c","ServiceName":"s"}`),
+	}
+	res, err := s.Update(context.Background(), req)
+	assert.NoError(t, err)
+	// Don't over-intercept. Throttling passes through; operator's CRUD retry path handles it.
+	assert.Equal(t, resource.OperationErrorCodeThrottling, res.ProgressResult.ErrorCode)
+}
+
 func TestService_Create_SyncSuccess_RewritesToInProgress(t *testing.T) {
 	ccx := &mockCCXClient{}
 	inner := &resource.CreateResult{

--- a/pkg/cfres/ecs/timeout.go
+++ b/pkg/cfres/ecs/timeout.go
@@ -1,0 +1,64 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package ecs
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+)
+
+// inProgressOrTimeout returns an InProgress ProgressResult within the operation
+// budget, or escalates to terminal Failure (GeneralServiceException) past it.
+// EVERY InProgress site in Status routes through this helper EXCEPT post-stability
+// Read retries (see inProgressOrFinalReadTimeout).
+func (s *Service) inProgressOrTimeout(op resource.Operation, req *resource.StatusRequest,
+	unixStart int64, msg string) *resource.StatusResult {
+	return s.boundedInProgress(op, req, unixStart, s.operationTimeout, msg)
+}
+
+// inProgressOrFinalReadTimeout uses operationTimeout+finalReadGrace as the cutoff.
+// Only finalSuccess calls this — once stability has been observed, the Read gets
+// extra wall-clock time so a brief post-stability NotFound/empty at the 20m
+// boundary doesn't false-fail an actually-healthy service.
+func (s *Service) inProgressOrFinalReadTimeout(op resource.Operation, req *resource.StatusRequest,
+	unixStart int64, msg string) *resource.StatusResult {
+	return s.boundedInProgress(op, req, unixStart, s.operationTimeout+s.finalReadGrace, msg)
+}
+
+func (s *Service) boundedInProgress(op resource.Operation, req *resource.StatusRequest,
+	unixStart int64, budget time.Duration, msg string) *resource.StatusResult {
+	if s.now().Sub(time.Unix(unixStart, 0)) > budget {
+		return &resource.StatusResult{
+			ProgressResult: terminalFailurePR(op, req.NativeID, "",
+				resource.OperationErrorCodeGeneralServiceException,
+				fmt.Sprintf("ECS operation exceeded %s budget: %s", budget, msg)),
+		}
+	}
+	return &resource.StatusResult{
+		ProgressResult: &resource.ProgressResult{
+			Operation:       op,
+			OperationStatus: resource.OperationStatusInProgress,
+			RequestID:       req.RequestID,
+			NativeID:        req.NativeID,
+			StatusMessage:   msg,
+		},
+	}
+}
+
+// classifyForStatus maps a Go/AWS error to either an InProgress (within timeout)
+// or terminal Failure ProgressResult. Used at every Status-mode call site.
+func (s *Service) classifyForStatus(err error, op resource.Operation, req *resource.StatusRequest,
+	unixStart int64, contextMsg string) *resource.StatusResult {
+	code, retryable := classifyAWSError(err)
+	if retryable {
+		return s.inProgressOrTimeout(op, req, unixStart, contextMsg+": "+err.Error())
+	}
+	return &resource.StatusResult{
+		ProgressResult: terminalFailurePR(op, req.NativeID, req.RequestID, code,
+			contextMsg+": "+err.Error()),
+	}
+}

--- a/pkg/cfres/ecs/timeout_test.go
+++ b/pkg/cfres/ecs/timeout_test.go
@@ -1,0 +1,92 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package ecs
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+)
+
+func newServiceWithClock(unixStart, nowUnix int64, opTimeout, grace time.Duration) *Service {
+	return &Service{
+		now:              func() time.Time { return time.Unix(nowUnix, 0) },
+		operationTimeout: opTimeout,
+		finalReadGrace:   grace,
+	}
+}
+
+func TestInProgressOrTimeout_WithinBudget(t *testing.T) {
+	s := newServiceWithClock(0, 60, 20*time.Minute, 2*time.Minute)
+	req := &resource.StatusRequest{RequestID: "rid", NativeID: "nid"}
+	res := s.inProgressOrTimeout(resource.OperationCreate, req, 0, "rolling out")
+	assert.Equal(t, resource.OperationStatusInProgress, res.ProgressResult.OperationStatus)
+	assert.Equal(t, "rid", res.ProgressResult.RequestID)
+	assert.Equal(t, "nid", res.ProgressResult.NativeID)
+	assert.Equal(t, "rolling out", res.ProgressResult.StatusMessage)
+}
+
+func TestInProgressOrTimeout_PastBudget_Escalates(t *testing.T) {
+	// unixStart=0, now=20m + 1s → past 20m budget
+	s := newServiceWithClock(0, 20*60+1, 20*time.Minute, 2*time.Minute)
+	req := &resource.StatusRequest{RequestID: "rid", NativeID: "nid"}
+	res := s.inProgressOrTimeout(resource.OperationCreate, req, 0, "still IN_PROGRESS")
+	assert.Equal(t, resource.OperationStatusFailure, res.ProgressResult.OperationStatus)
+	assert.Equal(t, resource.OperationErrorCodeGeneralServiceException, res.ProgressResult.ErrorCode)
+	assert.Contains(t, res.ProgressResult.StatusMessage, "exceeded")
+}
+
+func TestInProgressOrFinalReadTimeout_GraceExtendsBudget(t *testing.T) {
+	// unixStart=0, now=20m+30s. Inside operationTimeout+grace=22m.
+	s := newServiceWithClock(0, 20*60+30, 20*time.Minute, 2*time.Minute)
+	req := &resource.StatusRequest{RequestID: "rid", NativeID: "nid"}
+	res := s.inProgressOrFinalReadTimeout(resource.OperationCreate, req, 0, "post-stability Read NotFound")
+	assert.Equal(t, resource.OperationStatusInProgress, res.ProgressResult.OperationStatus,
+		"stable services within the 22m total budget should still get InProgress")
+}
+
+func TestInProgressOrFinalReadTimeout_PastExtendedBudget_Escalates(t *testing.T) {
+	// 22m+1s — past operationTimeout+grace
+	s := newServiceWithClock(0, 22*60+1, 20*time.Minute, 2*time.Minute)
+	req := &resource.StatusRequest{RequestID: "rid", NativeID: "nid"}
+	res := s.inProgressOrFinalReadTimeout(resource.OperationCreate, req, 0, "still failing")
+	assert.Equal(t, resource.OperationStatusFailure, res.ProgressResult.OperationStatus)
+	assert.Equal(t, resource.OperationErrorCodeGeneralServiceException, res.ProgressResult.ErrorCode)
+}
+
+func TestClassifyForStatus_Retryable_InProgress(t *testing.T) {
+	s := newServiceWithClock(0, 60, 20*time.Minute, 2*time.Minute)
+	req := &resource.StatusRequest{RequestID: "rid", NativeID: "nid"}
+	res := s.classifyForStatus(&fakeAPIError{code: "Throttling"}, resource.OperationCreate, req, 0, "DescribeServices")
+	assert.Equal(t, resource.OperationStatusInProgress, res.ProgressResult.OperationStatus)
+	assert.Contains(t, res.ProgressResult.StatusMessage, "DescribeServices")
+}
+
+func TestClassifyForStatus_Terminal_Failure(t *testing.T) {
+	s := newServiceWithClock(0, 60, 20*time.Minute, 2*time.Minute)
+	req := &resource.StatusRequest{RequestID: "rid", NativeID: "nid"}
+	res := s.classifyForStatus(&fakeAPIError{code: "AccessDenied"}, resource.OperationCreate, req, 0, "DescribeServices")
+	assert.Equal(t, resource.OperationStatusFailure, res.ProgressResult.OperationStatus)
+	assert.Equal(t, resource.OperationErrorCodeAccessDenied, res.ProgressResult.ErrorCode)
+}
+
+func TestClassifyForStatus_RetryablePastTimeout_Escalates(t *testing.T) {
+	// Throttling past the 20m budget → terminal escalation.
+	s := newServiceWithClock(0, 20*60+1, 20*time.Minute, 2*time.Minute)
+	req := &resource.StatusRequest{RequestID: "rid", NativeID: "nid"}
+	res := s.classifyForStatus(errors.New("net: i/o timeout"), resource.OperationCreate, req, 0, "DescribeServices")
+	// errors.New isn't a net.Error, so this lands as GeneralServiceException terminal.
+	// For the timeout-escalation behavior, fakeAPIError{Throttling} hits the same path:
+	res2 := s.classifyForStatus(&fakeAPIError{code: "Throttling"}, resource.OperationCreate, req, 0, "DescribeServices")
+	assert.Equal(t, resource.OperationStatusFailure, res2.ProgressResult.OperationStatus)
+	assert.Equal(t, resource.OperationErrorCodeGeneralServiceException, res2.ProgressResult.ErrorCode)
+	_ = res
+}

--- a/testdata/ecs-service-with-lb-update.pkl
+++ b/testdata/ecs-service-with-lb-update.pkl
@@ -1,0 +1,226 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/ec2/vpc.pkl"
+import "@aws/ec2/subnet.pkl"
+import "@aws/ec2/securitygroup.pkl"
+import "@aws/ec2/securitygroupingress.pkl"
+import "@aws/elasticloadbalancingv2/loadbalancer.pkl"
+import "@aws/elasticloadbalancingv2/targetgroup.pkl"
+import "@aws/elasticloadbalancingv2/listener.pkl"
+import "@aws/ecs/ecscluster.pkl"
+import "@aws/ecs/taskdefinition.pkl"
+import "@aws/ecs/service.pkl"
+
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local stackName = "plugin-sdk-test-ecs-svc-lb-\(testRunID)"
+
+// All supporting resources mirror the base fixture exactly -- this is an
+// Update, not a Replace, so cluster name / service name / SG names / VPC
+// CIDR / etc. must be identical.
+local testVpc = new vpc.VPC {
+  label = "test-vpc-for-ecs-svc-lb"
+  cidrBlock = "10.231.0.0/16"
+  enableDnsSupport = true
+}
+
+local testSubnetA = new subnet.Subnet {
+  label = "test-subnet-a-for-ecs-svc-lb"
+  vpcId = testVpc.res.vpcId
+  cidrBlock = "10.231.1.0/24"
+  availabilityZone = "us-east-1a"
+}
+
+local testSubnetB = new subnet.Subnet {
+  label = "test-subnet-b-for-ecs-svc-lb"
+  vpcId = testVpc.res.vpcId
+  cidrBlock = "10.231.2.0/24"
+  availabilityZone = "us-east-1b"
+}
+
+local albSG = new securitygroup.SecurityGroup {
+  label = "test-alb-sg-for-ecs-svc-lb"
+  groupDescription = "Allow HTTP to internal ALB for ECS Service conformance test"
+  groupName = "formae-sdk-alb-sg-\(testRunID)"
+  vpcId = testVpc.res.vpcId
+}
+
+local albIngress = new securitygroupingress.SecurityGroupIngress {
+  label = "test-alb-sg-ingress-for-ecs-svc-lb"
+  groupId = albSG.res.groupId
+  ipProtocol = "tcp"
+  fromPort = 80
+  toPort = 80
+  cidrIp = "0.0.0.0/0"
+}
+
+local tasksSG = new securitygroup.SecurityGroup {
+  label = "test-tasks-sg-for-ecs-svc-lb"
+  groupDescription = "Allow HTTP from ALB to ECS tasks for conformance test"
+  groupName = "formae-sdk-tasks-sg-\(testRunID)"
+  vpcId = testVpc.res.vpcId
+}
+
+local tasksIngress = new securitygroupingress.SecurityGroupIngress {
+  label = "test-tasks-sg-ingress-for-ecs-svc-lb"
+  groupId = tasksSG.res.groupId
+  ipProtocol = "tcp"
+  fromPort = 80
+  toPort = 80
+  sourceSecurityGroupId = albSG.res.groupId
+}
+
+local testALB = new loadbalancer.LoadBalancer {
+  label = "test-alb-for-ecs-svc"
+  name = "formae-sdk-alb-\(testRunID)"
+  scheme = "internal"
+  type = "application"
+  subnets {
+    testSubnetA.res.subnetId
+    testSubnetB.res.subnetId
+  }
+  securityGroups {
+    albSG.res.groupId
+  }
+}
+
+local testTG = new targetgroup.TargetGroup {
+  label = "test-tg-for-ecs-svc"
+  name = "formae-sdk-tg-\(testRunID)"
+  port = 80
+  protocol = "HTTP"
+  targetType = "ip"
+  vpcId = testVpc.res.vpcId
+}
+
+local testListener = new listener.Listener {
+  label = "test-listener-for-ecs-svc"
+  loadBalancerArn = testALB.res.loadBalancerArn
+  port = 80
+  protocol = "HTTP"
+  defaultActions {
+    new listener.Action {
+      type = "forward"
+      targetGroupArn = testTG.res.targetGroupArn
+    }
+  }
+}
+
+local testCluster = new ecscluster.Cluster {
+  label = "test-cluster-for-ecs-svc-lb"
+  clusterName = "formae-sdk-svc-lb-cluster-\(testRunID)"
+  clusterSettings {
+    new {
+      name = "containerInsights"
+      value = "disabled"
+    }
+  }
+}
+
+// Updated: container image bumped from nginx:latest to nginx:1.25. This is
+// not a createOnly field on TaskDefinition (the TaskDef itself will be
+// replaced, producing a new TaskDefinitionArn), which in turn causes the
+// ECS Service to roll a new deployment -- exactly the path the Phase B
+// new-deployment detection + grace window logic needs to cover.
+local testTaskDef = new taskdefinition.TaskDefinition {
+  label = "test-taskdef-for-ecs-svc-lb"
+  family = "formae-sdk-svc-lb-taskdef-\(testRunID)"
+  requiresCompatibilities {
+    "FARGATE"
+  }
+  networkMode = "awsvpc"
+  cpu = "256"
+  memory = "512"
+  containerDefinitions {
+    new {
+      name = "test-container"
+      image = "nginx:1.25"
+      essential = true
+      portMappings {
+        new {
+          containerPort = 80
+          protocol = "tcp"
+        }
+      }
+    }
+  }
+}
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for ECS Service with ALB/TG attachment"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  testVpc
+  testSubnetA
+  testSubnetB
+
+  albSG
+  albIngress
+  tasksSG
+  tasksIngress
+
+  testALB
+  testTG
+  testListener
+
+  testCluster
+  testTaskDef
+
+  // ECS Service -- service definition itself is identical to the base
+  // fixture. The TaskDefinitionArn Resolvable picks up the new TaskDef
+  // revision automatically, which triggers a new ECS deployment.
+  new service.Service {
+    label = "plugin-sdk-test-ecs-service-with-lb"
+    serviceName = "formae-sdk-svc-lb-\(testRunID)"
+    cluster = testCluster.res.arn
+    taskDefinition = new formae.Resolvable {
+      label = testTaskDef.label
+      type = "AWS::ECS::TaskDefinition"
+      property = "TaskDefinitionArn"
+    }
+    desiredCount = 1
+    schedulingStrategy = "REPLICA"
+    launchType = "FARGATE"
+    networkConfiguration = new service.NetworkConfiguration {
+      awsvpcConfiguration = new service.AwsVpcConfiguration {
+        assignPublicIp = "DISABLED"
+        subnets {
+          testSubnetA.res.subnetId
+          testSubnetB.res.subnetId
+        }
+        securityGroups {
+          tasksSG.res.groupId
+        }
+      }
+    }
+    loadBalancers {
+      new service.LoadBalancer {
+        containerName = "test-container"
+        containerPort = 80
+        targetGroupArn = testListener.res.targetGroupArn
+      }
+    }
+    healthCheckGracePeriodSeconds = 60
+    deploymentConfiguration = new service.DeploymentConfiguration {
+      maximumPercent = 200
+      minimumHealthyPercent = 100
+    }
+  }
+}

--- a/testdata/ecs-service-with-lb-update.pkl
+++ b/testdata/ecs-service-with-lb-update.pkl
@@ -167,11 +167,14 @@ local testCluster = new ecscluster.Cluster {
   }
 }
 
-// Updated: container image bumped from nginx:latest to nginx:1.25. This is
-// not a createOnly field on TaskDefinition (the TaskDef itself will be
-// replaced, producing a new TaskDefinitionArn), which in turn causes the
-// ECS Service to roll a new deployment -- exactly the path the Phase B
-// new-deployment detection + grace window logic needs to cover.
+// TaskDefinition is identical to the base fixture. We intentionally do NOT
+// change containerDefinitions here because that field is createOnly on
+// AWS::ECS::TaskDefinition -- any change triggers a Replace of the TaskDef,
+// which cascades into a Replace of the Service (delete + create), not the
+// in-place Update we want to test. To trigger a new ECS deployment for
+// Phase B's new-deployment-detection logic, the Update bumps the Service's
+// desiredCount below instead (1 -> 2), which ECS handles as a normal
+// in-place service update with a new deployment.
 local testTaskDef = new taskdefinition.TaskDefinition {
   label = "test-taskdef-for-ecs-svc-lb"
   family = "formae-sdk-svc-lb-taskdef-\(testRunID)"
@@ -184,7 +187,7 @@ local testTaskDef = new taskdefinition.TaskDefinition {
   containerDefinitions {
     new {
       name = "test-container"
-      image = "nginx:1.25"
+      image = "nginx:latest"
       essential = true
       portMappings {
         new {
@@ -249,7 +252,12 @@ forma {
       type = "AWS::ECS::TaskDefinition"
       property = "TaskDefinitionArn"
     }
-    desiredCount = 1
+    // Updated: scale from 1 -> 2 tasks. This triggers ECS to roll a new
+    // deployment to bring up the extra task, which is exactly the path
+    // Phase B's new-deployment-detection + TG-health-gate logic needs to
+    // cover. desiredCount is a normal updatable field on AWS::ECS::Service
+    // (not createOnly), so this is an in-place Update -- no Replace.
+    desiredCount = 2
     schedulingStrategy = "REPLICA"
     launchType = "FARGATE"
     networkConfiguration = new service.NetworkConfiguration {

--- a/testdata/ecs-service-with-lb-update.pkl
+++ b/testdata/ecs-service-with-lb-update.pkl
@@ -11,6 +11,11 @@ import "@aws/aws.pkl"
 
 import "@aws/ec2/vpc.pkl"
 import "@aws/ec2/subnet.pkl"
+import "@aws/ec2/internetgateway.pkl"
+import "@aws/ec2/vpcgatewayattachment.pkl"
+import "@aws/ec2/routetable.pkl"
+import "@aws/ec2/route.pkl"
+import "@aws/ec2/subnetroutetableassociation.pkl"
 import "@aws/ec2/securitygroup.pkl"
 import "@aws/ec2/securitygroupingress.pkl"
 import "@aws/elasticloadbalancingv2/loadbalancer.pkl"
@@ -44,6 +49,43 @@ local testSubnetB = new subnet.Subnet {
   vpcId = testVpc.res.vpcId
   cidrBlock = "10.231.2.0/24"
   availabilityZone = "us-east-1b"
+}
+
+// Internet routing: IGW + VPCGatewayAttachment + RouteTable + default Route +
+// per-subnet associations. Must mirror the base fixture so the update path
+// is a no-op on the network plumbing.
+local testIgw = new internetgateway.InternetGateway {
+  label = "test-igw-for-ecs-svc-lb"
+}
+
+local testIgwAttachment = new vpcgatewayattachment.VPCGatewayAttachment {
+  label = "test-igw-attachment-for-ecs-svc-lb"
+  vpcId = testVpc.res.vpcId
+  internetGatewayId = testIgw.res.internetGatewayId
+}
+
+local testRouteTable = new routetable.RouteTable {
+  label = "test-routetable-for-ecs-svc-lb"
+  vpcId = testVpc.res.vpcId
+}
+
+local testDefaultRoute = new route.Route {
+  label = "test-default-route-for-ecs-svc-lb"
+  routeTableId = testRouteTable.res.routeTableId
+  destinationCidrBlock = "0.0.0.0/0"
+  gatewayId = testIgw.res.internetGatewayId
+}
+
+local testSubnetAAssoc = new subnetroutetableassociation.SubnetRouteTableAssociation {
+  label = "test-subnet-a-rtassoc-for-ecs-svc-lb"
+  subnetId = testSubnetA.res.subnetId
+  routeTableId = testRouteTable.res.routeTableId
+}
+
+local testSubnetBAssoc = new subnetroutetableassociation.SubnetRouteTableAssociation {
+  label = "test-subnet-b-rtassoc-for-ecs-svc-lb"
+  subnetId = testSubnetB.res.subnetId
+  routeTableId = testRouteTable.res.routeTableId
 }
 
 local albSG = new securitygroup.SecurityGroup {
@@ -171,6 +213,14 @@ forma {
   testSubnetA
   testSubnetB
 
+  // Internet routing so FARGATE tasks can pull container images.
+  testIgw
+  testIgwAttachment
+  testRouteTable
+  testDefaultRoute
+  testSubnetAAssoc
+  testSubnetBAssoc
+
   albSG
   albIngress
   tasksSG
@@ -186,6 +236,10 @@ forma {
   // ECS Service -- service definition itself is identical to the base
   // fixture. The TaskDefinitionArn Resolvable picks up the new TaskDef
   // revision automatically, which triggers a new ECS deployment.
+  //
+  // assignPublicIp=ENABLED is required: there is no NAT gateway in this
+  // fixture, so tasks reach the public internet (Docker Hub / ECR Public)
+  // via the IGW + default route + public IPs on their ENIs.
   new service.Service {
     label = "plugin-sdk-test-ecs-service-with-lb"
     serviceName = "formae-sdk-svc-lb-\(testRunID)"
@@ -200,7 +254,7 @@ forma {
     launchType = "FARGATE"
     networkConfiguration = new service.NetworkConfiguration {
       awsvpcConfiguration = new service.AwsVpcConfiguration {
-        assignPublicIp = "DISABLED"
+        assignPublicIp = "ENABLED"
         subnets {
           testSubnetA.res.subnetId
           testSubnetB.res.subnetId

--- a/testdata/ecs-service-with-lb.pkl
+++ b/testdata/ecs-service-with-lb.pkl
@@ -1,0 +1,237 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/ec2/vpc.pkl"
+import "@aws/ec2/subnet.pkl"
+import "@aws/ec2/securitygroup.pkl"
+import "@aws/ec2/securitygroupingress.pkl"
+import "@aws/elasticloadbalancingv2/loadbalancer.pkl"
+import "@aws/elasticloadbalancingv2/targetgroup.pkl"
+import "@aws/elasticloadbalancingv2/listener.pkl"
+import "@aws/ecs/ecscluster.pkl"
+import "@aws/ecs/taskdefinition.pkl"
+import "@aws/ecs/service.pkl"
+
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local stackName = "plugin-sdk-test-ecs-svc-lb-\(testRunID)"
+
+// VPC + multi-AZ Subnets for FARGATE awsvpc networking + ALB (ALB requires
+// at least two subnets in different AZs).
+local testVpc = new vpc.VPC {
+  label = "test-vpc-for-ecs-svc-lb"
+  cidrBlock = "10.231.0.0/16"
+  enableDnsSupport = true
+}
+
+local testSubnetA = new subnet.Subnet {
+  label = "test-subnet-a-for-ecs-svc-lb"
+  vpcId = testVpc.res.vpcId
+  cidrBlock = "10.231.1.0/24"
+  availabilityZone = "us-east-1a"
+}
+
+local testSubnetB = new subnet.Subnet {
+  label = "test-subnet-b-for-ecs-svc-lb"
+  vpcId = testVpc.res.vpcId
+  cidrBlock = "10.231.2.0/24"
+  availabilityZone = "us-east-1b"
+}
+
+// ALB security group + inbound :80 from anywhere (internal scheme, but the
+// ALB still needs an SG and the SG still needs an ingress rule).
+local albSG = new securitygroup.SecurityGroup {
+  label = "test-alb-sg-for-ecs-svc-lb"
+  groupDescription = "Allow HTTP to internal ALB for ECS Service conformance test"
+  groupName = "formae-sdk-alb-sg-\(testRunID)"
+  vpcId = testVpc.res.vpcId
+}
+
+local albIngress = new securitygroupingress.SecurityGroupIngress {
+  label = "test-alb-sg-ingress-for-ecs-svc-lb"
+  groupId = albSG.res.groupId
+  ipProtocol = "tcp"
+  fromPort = 80
+  toPort = 80
+  cidrIp = "0.0.0.0/0"
+}
+
+// Tasks security group + inbound :80 from the ALB SG.
+local tasksSG = new securitygroup.SecurityGroup {
+  label = "test-tasks-sg-for-ecs-svc-lb"
+  groupDescription = "Allow HTTP from ALB to ECS tasks for conformance test"
+  groupName = "formae-sdk-tasks-sg-\(testRunID)"
+  vpcId = testVpc.res.vpcId
+}
+
+local tasksIngress = new securitygroupingress.SecurityGroupIngress {
+  label = "test-tasks-sg-ingress-for-ecs-svc-lb"
+  groupId = tasksSG.res.groupId
+  ipProtocol = "tcp"
+  fromPort = 80
+  toPort = 80
+  sourceSecurityGroupId = albSG.res.groupId
+}
+
+// Internal ALB across the two subnets.
+local testALB = new loadbalancer.LoadBalancer {
+  label = "test-alb-for-ecs-svc"
+  name = "formae-sdk-alb-\(testRunID)"
+  scheme = "internal"
+  type = "application"
+  subnets {
+    testSubnetA.res.subnetId
+    testSubnetB.res.subnetId
+  }
+  securityGroups {
+    albSG.res.groupId
+  }
+}
+
+// Target Group (target-type=ip for FARGATE awsvpc).
+local testTG = new targetgroup.TargetGroup {
+  label = "test-tg-for-ecs-svc"
+  name = "formae-sdk-tg-\(testRunID)"
+  port = 80
+  protocol = "HTTP"
+  targetType = "ip"
+  vpcId = testVpc.res.vpcId
+}
+
+// Listener on :80 forwarding to the TG (this is what wires the TG to the ALB).
+local testListener = new listener.Listener {
+  label = "test-listener-for-ecs-svc"
+  loadBalancerArn = testALB.res.loadBalancerArn
+  port = 80
+  protocol = "HTTP"
+  defaultActions {
+    new listener.Action {
+      type = "forward"
+      targetGroupArn = testTG.res.targetGroupArn
+    }
+  }
+}
+
+// ECS Cluster.
+local testCluster = new ecscluster.Cluster {
+  label = "test-cluster-for-ecs-svc-lb"
+  clusterName = "formae-sdk-svc-lb-cluster-\(testRunID)"
+  clusterSettings {
+    new {
+      name = "containerInsights"
+      value = "disabled"
+    }
+  }
+}
+
+// ECS TaskDefinition (FARGATE, awsvpc, nginx:latest on port 80).
+local testTaskDef = new taskdefinition.TaskDefinition {
+  label = "test-taskdef-for-ecs-svc-lb"
+  family = "formae-sdk-svc-lb-taskdef-\(testRunID)"
+  requiresCompatibilities {
+    "FARGATE"
+  }
+  networkMode = "awsvpc"
+  cpu = "256"
+  memory = "512"
+  containerDefinitions {
+    new {
+      name = "test-container"
+      image = "nginx:latest"
+      essential = true
+      portMappings {
+        new {
+          containerPort = 80
+          protocol = "tcp"
+        }
+      }
+    }
+  }
+}
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for ECS Service with ALB/TG attachment"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  // Network plumbing.
+  testVpc
+  testSubnetA
+  testSubnetB
+
+  // Security groups (declared before the ALB & service that consume them).
+  albSG
+  albIngress
+  tasksSG
+  tasksIngress
+
+  // Load balancer, target group, listener -- listener attaches TG to ALB
+  // before the service is created so we avoid the tgNotAssociatedPattern
+  // ccx remap.
+  testALB
+  testTG
+  testListener
+
+  // ECS plumbing.
+  testCluster
+  testTaskDef
+
+  // ECS Service under test -- desiredCount=1 so the Phase B Target Group
+  // health gate is exercised end-to-end. taskDefinition references the
+  // TaskDefinitionArn via Resolvable (same pattern as ecs-service.pkl).
+  // The service's targetGroupArn is sourced via the listener's
+  // DefaultActions.0.TargetGroupArn so the listener-TG attachment ordering
+  // is enforced (see listener.pkl: targetGroupArn resolvable).
+  new service.Service {
+    label = "plugin-sdk-test-ecs-service-with-lb"
+    serviceName = "formae-sdk-svc-lb-\(testRunID)"
+    cluster = testCluster.res.arn
+    taskDefinition = new formae.Resolvable {
+      label = testTaskDef.label
+      type = "AWS::ECS::TaskDefinition"
+      property = "TaskDefinitionArn"
+    }
+    desiredCount = 1
+    schedulingStrategy = "REPLICA"
+    launchType = "FARGATE"
+    networkConfiguration = new service.NetworkConfiguration {
+      awsvpcConfiguration = new service.AwsVpcConfiguration {
+        assignPublicIp = "DISABLED"
+        subnets {
+          testSubnetA.res.subnetId
+          testSubnetB.res.subnetId
+        }
+        securityGroups {
+          tasksSG.res.groupId
+        }
+      }
+    }
+    loadBalancers {
+      new service.LoadBalancer {
+        containerName = "test-container"
+        containerPort = 80
+        targetGroupArn = testListener.res.targetGroupArn
+      }
+    }
+    healthCheckGracePeriodSeconds = 60
+    deploymentConfiguration = new service.DeploymentConfiguration {
+      maximumPercent = 200
+      minimumHealthyPercent = 100
+    }
+  }
+}

--- a/testdata/ecs-service-with-lb.pkl
+++ b/testdata/ecs-service-with-lb.pkl
@@ -11,6 +11,11 @@ import "@aws/aws.pkl"
 
 import "@aws/ec2/vpc.pkl"
 import "@aws/ec2/subnet.pkl"
+import "@aws/ec2/internetgateway.pkl"
+import "@aws/ec2/vpcgatewayattachment.pkl"
+import "@aws/ec2/routetable.pkl"
+import "@aws/ec2/route.pkl"
+import "@aws/ec2/subnetroutetableassociation.pkl"
 import "@aws/ec2/securitygroup.pkl"
 import "@aws/ec2/securitygroupingress.pkl"
 import "@aws/elasticloadbalancingv2/loadbalancer.pkl"
@@ -43,6 +48,44 @@ local testSubnetB = new subnet.Subnet {
   vpcId = testVpc.res.vpcId
   cidrBlock = "10.231.2.0/24"
   availabilityZone = "us-east-1b"
+}
+
+// Internet routing: IGW + VPCGatewayAttachment + RouteTable + default Route +
+// per-subnet associations. FARGATE tasks need a public-IP egress path to pull
+// container images from Docker Hub / ECR Public (no NAT in this fixture, so
+// the service uses assignPublicIp=ENABLED below).
+local testIgw = new internetgateway.InternetGateway {
+  label = "test-igw-for-ecs-svc-lb"
+}
+
+local testIgwAttachment = new vpcgatewayattachment.VPCGatewayAttachment {
+  label = "test-igw-attachment-for-ecs-svc-lb"
+  vpcId = testVpc.res.vpcId
+  internetGatewayId = testIgw.res.internetGatewayId
+}
+
+local testRouteTable = new routetable.RouteTable {
+  label = "test-routetable-for-ecs-svc-lb"
+  vpcId = testVpc.res.vpcId
+}
+
+local testDefaultRoute = new route.Route {
+  label = "test-default-route-for-ecs-svc-lb"
+  routeTableId = testRouteTable.res.routeTableId
+  destinationCidrBlock = "0.0.0.0/0"
+  gatewayId = testIgw.res.internetGatewayId
+}
+
+local testSubnetAAssoc = new subnetroutetableassociation.SubnetRouteTableAssociation {
+  label = "test-subnet-a-rtassoc-for-ecs-svc-lb"
+  subnetId = testSubnetA.res.subnetId
+  routeTableId = testRouteTable.res.routeTableId
+}
+
+local testSubnetBAssoc = new subnetroutetableassociation.SubnetRouteTableAssociation {
+  label = "test-subnet-b-rtassoc-for-ecs-svc-lb"
+  subnetId = testSubnetB.res.subnetId
+  routeTableId = testRouteTable.res.routeTableId
 }
 
 // ALB security group + inbound :80 from anywhere (internal scheme, but the
@@ -174,6 +217,14 @@ forma {
   testSubnetA
   testSubnetB
 
+  // Internet routing so FARGATE tasks can pull container images.
+  testIgw
+  testIgwAttachment
+  testRouteTable
+  testDefaultRoute
+  testSubnetAAssoc
+  testSubnetBAssoc
+
   // Security groups (declared before the ALB & service that consume them).
   albSG
   albIngress
@@ -197,6 +248,10 @@ forma {
   // The service's targetGroupArn is sourced via the listener's
   // DefaultActions.0.TargetGroupArn so the listener-TG attachment ordering
   // is enforced (see listener.pkl: targetGroupArn resolvable).
+  //
+  // assignPublicIp=ENABLED is required: there is no NAT gateway in this
+  // fixture, so tasks reach the public internet (Docker Hub / ECR Public)
+  // via the IGW + default route + public IPs on their ENIs.
   new service.Service {
     label = "plugin-sdk-test-ecs-service-with-lb"
     serviceName = "formae-sdk-svc-lb-\(testRunID)"
@@ -211,7 +266,7 @@ forma {
     launchType = "FARGATE"
     networkConfiguration = new service.NetworkConfiguration {
       awsvpcConfiguration = new service.AwsVpcConfiguration {
-        assignPublicIp = "DISABLED"
+        assignPublicIp = "ENABLED"
         subnets {
           testSubnetA.res.subnetId
           testSubnetB.res.subnetId


### PR DESCRIPTION
## Summary
- Adds custom `Create`/`Update`/`Status` to the `AWS::ECS::Service` provisioner that holds `InProgress` until the deployment is operationally stable (`rolloutState=COMPLETED`, `runningCount=desiredCount`, ≥1 healthy target per attached TG). Fixes the bug where downstream resources (ALB Listener URL → Grafana/etc.) saw 503s because Create returned Success at CCAPI-ack time, before tasks were serving traffic.
- Two-phase model: Phase A polls CCAPI's request token; once Success, Phase B polls `DescribeServices` + `DescribeTargetHealth`. State is encoded in a composite RequestID (`formae-ecs/<op>/<unixStart>/<ccapiToken>`) set once at Create/Update return and preserved across polls by the SDK's existing `PluginOperatorCheckStatus.StatusCheck` semantics. Non-default shapes (CODE_DEPLOY/EXTERNAL/DAEMON controllers, classic-ELB attachments without `targetGroupArn`, `desiredCount=0`, missing `Cluster`) all fall through to safe defaults.
- New `testdata/ecs-service-with-lb.pkl` + `-update.pkl` exercise the full TG-health-gated lifecycle end-to-end on real AWS; both new fixture and the existing `ecs-service` lifecycle pass conformance (CRUD + Discovery) on this branch. Bumps `debug-conformance.yml` TIMEOUT 60m → 90m so ALB-based fixtures have enough wall-clock headroom.