### PR TITLE
schema: EdgeKind edge annotations + EFS runtimeDependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,13 +62,9 @@ jobs:
   # Integration tests run against real AWS resources (Route53, EC2, etc.)
   # These are self-contained: each test creates and cleans up its own resources.
   test-integration:
-    # Shared with formae's e2e-tests workflow, which runs aws-nuke against
-    # the same AWS account. Without this group, aws-nuke can delete
-    # hosted zones mid-test. Until the cloud-account tests are made
-    # parallel-safe, serialize across all three workflows.
-    concurrency:
-      group: cloud-e2e-tests
-      cancel-in-progress: false
+    # Isolation from formae-e2e's aws-nuke is enforced in the nuke config
+    # (region split + global allowlist), not via concurrency — GitHub
+    # concurrency groups are per-repo and cannot serialize across repos.
     needs: [checks]
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/debug-conformance.yml
+++ b/.github/workflows/debug-conformance.yml
@@ -136,63 +136,6 @@ jobs:
           done
           go mod tidy
 
-      # PKL-side counterpart of the Go replace step above. The plugin's PklProject
-      # files pin formae to a published registry version (e.g. formae@0.85.0).
-      # When the AWS plugin branch carries RFC-0043 schema annotations
-      # (edgeKind, parentRefs) that only exist on the source formae ref,
-      # extraction against the registry-pinned schema fails. Rewrite the
-      # ["formae"] dependency block in each PklProject to import the local
-      # checkout's PklProject by path, then re-resolve.
-      - name: Inject formae PKL replace
-        if: inputs.formae_ref != ''
-        run: |
-          FORMAE_PKL_PROJECT=/tmp/formae/internal/schema/pkl/schema/PklProject
-          if [ ! -f "$FORMAE_PKL_PROJECT" ]; then
-            echo "::error::Expected formae PKL project at $FORMAE_PKL_PROJECT (formae checkout layout changed?)"
-            exit 1
-          fi
-          for pkl_project in schema/pkl/PklProject testdata/PklProject; do
-            if [ ! -f "$pkl_project" ]; then
-              continue
-            fi
-            echo "::group::Before patch: $pkl_project"
-            cat "$pkl_project"
-            echo "::endgroup::"
-            # The pinned block spans 3 lines:
-            #   ["formae"] {
-            #     uri = "package://.../formae@<version>"
-            #   }
-            # Replace it with a single-line path import. python3 is the
-            # ubuntu-latest standard interpreter; this avoids fragile multi-line
-            # sed and keeps the substitution idempotent.
-            python3 - "$pkl_project" "$FORMAE_PKL_PROJECT" <<'PY'
-          import re, sys, pathlib
-          path = pathlib.Path(sys.argv[1])
-          target = sys.argv[2]
-          original = path.read_text()
-          pattern = re.compile(
-              r'\["formae"\]\s*\{[^}]*uri\s*=\s*"package://[^"]+"[^}]*\}',
-              re.DOTALL,
-          )
-          replacement = f'["formae"] = import("{target}")'
-          patched, n = pattern.subn(replacement, original)
-          if n == 0:
-              raise SystemExit(f"no formae dependency block matched in {path}")
-          path.write_text(patched)
-          PY
-            echo "::group::After patch: $pkl_project"
-            cat "$pkl_project"
-            echo "::endgroup::"
-          done
-          # Re-resolve so each project's PklProject.deps.json matches the
-          # local import. `make install` resolves the schema project below;
-          # do testdata explicitly. Tolerate failures here — `make install`
-          # is the authoritative resolve step.
-          if command -v pkl >/dev/null 2>&1; then
-            (cd schema/pkl && pkl project resolve) || true
-            (cd testdata && pkl project resolve) || true
-          fi
-
       # Note: nightly's "Align plugin branch with formae Makefile" step is
       # intentionally omitted. Debug runs test the plugin code at the ref
       # the workflow was dispatched on, regardless of formae's Makefile pin.

--- a/.github/workflows/debug-conformance.yml
+++ b/.github/workflows/debug-conformance.yml
@@ -16,6 +16,11 @@ on:
         required: false
         default: ""
         type: string
+      formae_version:
+        description: "Override the VERSION string used when building formae from source. Use this with formae_ref to validate against a pre-released PKL schema (e.g., 0.86.0 published via schema-prerelease workflow). Leave empty to default to the latest released tag."
+        required: false
+        default: ""
+        type: string
       pre_cleanup:
         description: "Run pre-cleanup before tests"
         required: false
@@ -114,8 +119,12 @@ jobs:
           git fetch --tags
           # Latest release tag becomes the build's VERSION (skips pre-releases).
           LATEST_TAG=$(git tag -l "[0-9]*" --sort=-version:refname | grep -v -- '-' | head -1)
-          echo "Building formae with VERSION=${LATEST_TAG}"
-          make build VERSION="${LATEST_TAG}"
+          FORMAE_BUILD_VERSION="${{ inputs.formae_version }}"
+          if [ -z "$FORMAE_BUILD_VERSION" ]; then
+              FORMAE_BUILD_VERSION="${LATEST_TAG}"
+          fi
+          echo "Building formae with VERSION=${FORMAE_BUILD_VERSION}"
+          make build VERSION="${FORMAE_BUILD_VERSION}"
 
           # formae main expects an orbital tree at the path derived from the
           # binary location (introduced in formae#bfeeb541). `make build`

--- a/.github/workflows/debug-conformance.yml
+++ b/.github/workflows/debug-conformance.yml
@@ -136,6 +136,63 @@ jobs:
           done
           go mod tidy
 
+      # PKL-side counterpart of the Go replace step above. The plugin's PklProject
+      # files pin formae to a published registry version (e.g. formae@0.85.0).
+      # When the AWS plugin branch carries RFC-0043 schema annotations
+      # (edgeKind, parentRefs) that only exist on the source formae ref,
+      # extraction against the registry-pinned schema fails. Rewrite the
+      # ["formae"] dependency block in each PklProject to import the local
+      # checkout's PklProject by path, then re-resolve.
+      - name: Inject formae PKL replace
+        if: inputs.formae_ref != ''
+        run: |
+          FORMAE_PKL_PROJECT=/tmp/formae/internal/schema/pkl/schema/PklProject
+          if [ ! -f "$FORMAE_PKL_PROJECT" ]; then
+            echo "::error::Expected formae PKL project at $FORMAE_PKL_PROJECT (formae checkout layout changed?)"
+            exit 1
+          fi
+          for pkl_project in schema/pkl/PklProject testdata/PklProject; do
+            if [ ! -f "$pkl_project" ]; then
+              continue
+            fi
+            echo "::group::Before patch: $pkl_project"
+            cat "$pkl_project"
+            echo "::endgroup::"
+            # The pinned block spans 3 lines:
+            #   ["formae"] {
+            #     uri = "package://.../formae@<version>"
+            #   }
+            # Replace it with a single-line path import. python3 is the
+            # ubuntu-latest standard interpreter; this avoids fragile multi-line
+            # sed and keeps the substitution idempotent.
+            python3 - "$pkl_project" "$FORMAE_PKL_PROJECT" <<'PY'
+          import re, sys, pathlib
+          path = pathlib.Path(sys.argv[1])
+          target = sys.argv[2]
+          original = path.read_text()
+          pattern = re.compile(
+              r'\["formae"\]\s*\{[^}]*uri\s*=\s*"package://[^"]+"[^}]*\}',
+              re.DOTALL,
+          )
+          replacement = f'["formae"] = import("{target}")'
+          patched, n = pattern.subn(replacement, original)
+          if n == 0:
+              raise SystemExit(f"no formae dependency block matched in {path}")
+          path.write_text(patched)
+          PY
+            echo "::group::After patch: $pkl_project"
+            cat "$pkl_project"
+            echo "::endgroup::"
+          done
+          # Re-resolve so each project's PklProject.deps.json matches the
+          # local import. `make install` resolves the schema project below;
+          # do testdata explicitly. Tolerate failures here — `make install`
+          # is the authoritative resolve step.
+          if command -v pkl >/dev/null 2>&1; then
+            (cd schema/pkl && pkl project resolve) || true
+            (cd testdata && pkl project resolve) || true
+          fi
+
       # Note: nightly's "Align plugin branch with formae Makefile" step is
       # intentionally omitted. Debug runs test the plugin code at the ref
       # the workflow was dispatched on, regardless of formae's Makefile pin.

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -39,13 +39,9 @@ jobs:
   # Integration tests run against real AWS resources (Route53, EC2, etc.)
   # These are self-contained: each test creates and cleans up its own resources.
   test-integration:
-    # Shared with formae's e2e-tests workflow, which runs aws-nuke against
-    # the same AWS account. Without this group, aws-nuke can delete
-    # hosted zones mid-test. Until the cloud-account tests are made
-    # parallel-safe, serialize across all three workflows.
-    concurrency:
-      group: cloud-e2e-tests
-      cancel-in-progress: false
+    # Isolation from formae-e2e's aws-nuke is enforced in the nuke config
+    # (region split + global allowlist), not via concurrency — GitHub
+    # concurrency groups are per-repo and cannot serialize across repos.
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/pkg/cfres/ecs/service_schema_test.go
+++ b/pkg/cfres/ecs/service_schema_test.go
@@ -7,10 +7,11 @@
 package ecs
 
 // TestService_Schema_AttachesToAnnotations is a textual smoke test that verifies
-// the two targetGroupArn fields on AWS::ECS::Service carry @aws.FieldHint{attachesTo = true}
-// in the PKL schema source. This guards against a future refactor accidentally
-// removing the annotation and silently breaking the AttachesTo-based destroy
-// ordering that ECS load-balancer and VPC Lattice wiring depends on.
+// the two targetGroupArn fields on AWS::ECS::Service carry the attachesTo edge
+// annotation (RFC-0043: @aws.FieldHint { edgeKind = "attachesTo" }) in the PKL
+// schema source. This guards against a future refactor accidentally removing
+// the annotation and silently breaking the AttachesTo-based destroy ordering
+// that ECS load-balancer and VPC Lattice wiring depends on.
 //
 // This is intentionally a textual test rather than a full schema-emission test:
 // running ExtractSchema in a unit test requires a live pkl CLI subprocess and
@@ -75,8 +76,8 @@ func TestService_Schema_LoadBalancer_TargetGroupArn_AttachesTo(t *testing.T) {
 				t.Fatal("targetGroupArn is the first line of LoadBalancer body — no preceding annotation line")
 			}
 			prev := strings.TrimSpace(lines[i-1])
-			if !strings.Contains(prev, "attachesTo") || !strings.Contains(prev, "true") {
-				t.Errorf("LoadBalancer.targetGroupArn: expected @aws.FieldHint{attachesTo = true} on preceding line, got %q", prev)
+			if !strings.Contains(prev, "edgeKind") || !strings.Contains(prev, "attachesTo") {
+				t.Errorf("LoadBalancer.targetGroupArn: expected @aws.FieldHint { edgeKind = \"attachesTo\" } on preceding line, got %q", prev)
 			}
 			return
 		}
@@ -102,8 +103,8 @@ func TestService_Schema_VpcLatticeConfiguration_TargetGroupArn_AttachesTo(t *tes
 				t.Fatal("targetGroupArn is the first line of VpcLatticeConfiguration body — no preceding annotation line")
 			}
 			prev := strings.TrimSpace(lines[i-1])
-			if !strings.Contains(prev, "attachesTo") || !strings.Contains(prev, "true") {
-				t.Errorf("VpcLatticeConfiguration.targetGroupArn: expected @aws.FieldHint{attachesTo = true} on preceding line, got %q", prev)
+			if !strings.Contains(prev, "edgeKind") || !strings.Contains(prev, "attachesTo") {
+				t.Errorf("VpcLatticeConfiguration.targetGroupArn: expected @aws.FieldHint { edgeKind = \"attachesTo\" } on preceding line, got %q", prev)
 			}
 			return
 		}

--- a/pkg/cfres/ecs/service_schema_test.go
+++ b/pkg/cfres/ecs/service_schema_test.go
@@ -8,7 +8,7 @@ package ecs
 
 // TestService_Schema_AttachesToAnnotations is a textual smoke test that verifies
 // the two targetGroupArn fields on AWS::ECS::Service carry the attachesTo edge
-// annotation (RFC-0043: @aws.FieldHint { edgeKind = "attachesTo" }) in the PKL
+// annotation (@aws.FieldHint { edgeKind = "attachesTo" }) in the PKL
 // schema source. This guards against a future refactor accidentally removing
 // the annotation and silently breaking the AttachesTo-based destroy ordering
 // that ECS load-balancer and VPC Lattice wiring depends on.

--- a/pkg/cfres/ecs/taskset_schema_test.go
+++ b/pkg/cfres/ecs/taskset_schema_test.go
@@ -1,0 +1,63 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package ecs
+
+// TestTaskSet_Schema_AttachesToAnnotations is a textual smoke test that verifies
+// the targetGroupArn field on AWS::ECS::TaskSet's LoadBalancer carries the
+// attachesTo edge annotation (RFC-0043: @aws.FieldHint { edgeKind = "attachesTo" })
+// in the PKL schema source. TaskSet uses the same load balancer wiring as
+// AWS::ECS::Service, so it must mirror the same reachability semantics.
+// Without this annotation the AttachesTo-based destroy ordering for TaskSet
+// load-balancer wiring would silently break.
+//
+// This is intentionally a textual test rather than a full schema-emission test:
+// running ExtractSchema in a unit test requires a live pkl CLI subprocess and
+// network access for package resolution, making it unsuitable for make test-unit.
+// A proper emission test should live in a dedicated schema integration test suite.
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func tasksetSchemaPath() string {
+	_, filename, _, _ := runtime.Caller(0)
+	// pkg/cfres/ecs/ -> (repo root)/schema/pkl/ecs/taskset.pkl
+	root := filepath.Join(filepath.Dir(filename), "..", "..", "..", "schema", "pkl", "ecs")
+	return filepath.Join(root, "taskset.pkl")
+}
+
+func TestTaskSet_Schema_LoadBalancer_TargetGroupArn_AttachesTo(t *testing.T) {
+	content, err := os.ReadFile(tasksetSchemaPath())
+	if err != nil {
+		t.Fatalf("could not read taskset.pkl: %v", err)
+	}
+
+	body := extractClassBody(string(content), "LoadBalancer")
+	if body == "" {
+		t.Fatal("LoadBalancer class not found in taskset.pkl")
+	}
+
+	lines := strings.Split(body, "\n")
+	for i, line := range lines {
+		if strings.Contains(line, "targetGroupArn") {
+			// The annotation must appear on the line immediately before.
+			if i == 0 {
+				t.Fatal("targetGroupArn is the first line of LoadBalancer body — no preceding annotation line")
+			}
+			prev := strings.TrimSpace(lines[i-1])
+			if !strings.Contains(prev, "edgeKind") || !strings.Contains(prev, "attachesTo") {
+				t.Errorf("LoadBalancer.targetGroupArn: expected @aws.FieldHint { edgeKind = \"attachesTo\" } on preceding line, got %q", prev)
+			}
+			return
+		}
+	}
+	t.Fatal("targetGroupArn field not found inside LoadBalancer class body in taskset.pkl")
+}

--- a/pkg/cfres/ecs/taskset_schema_test.go
+++ b/pkg/cfres/ecs/taskset_schema_test.go
@@ -8,7 +8,7 @@ package ecs
 
 // TestTaskSet_Schema_AttachesToAnnotations is a textual smoke test that verifies
 // the targetGroupArn field on AWS::ECS::TaskSet's LoadBalancer carries the
-// attachesTo edge annotation (RFC-0043: @aws.FieldHint { edgeKind = "attachesTo" })
+// attachesTo edge annotation (@aws.FieldHint { edgeKind = "attachesTo" })
 // in the PKL schema source. TaskSet uses the same load balancer wiring as
 // AWS::ECS::Service, so it must mirror the same reachability semantics.
 // Without this annotation the AttachesTo-based destroy ordering for TaskSet

--- a/schema/pkl/PklProject
+++ b/schema/pkl/PklProject
@@ -2,7 +2,7 @@ amends "pkl:Project"
 
 dependencies {
   ["formae"] {
-    uri = "package://hub.platform.engineering/plugins/pkl/schema/pkl/formae/formae@0.85.0"
+    uri = "package://hub.platform.engineering/plugins/pkl/schema/pkl/formae/formae@0.86.0"
   }
 }
 

--- a/schema/pkl/ecs/service.pkl
+++ b/schema/pkl/ecs/service.pkl
@@ -83,7 +83,7 @@ open class LoadBalancer extends formae.SubResource {
     containerName: String?
     containerPort: Int?
     loadBalancerName: (String|formae.Resolvable)?
-    @aws.FieldHint{attachesTo = true}
+    @aws.FieldHint { edgeKind = "attachesTo" }
     targetGroupArn: (String|formae.Resolvable)?
 }
 
@@ -195,7 +195,7 @@ open class TimeoutConfiguration extends formae.SubResource {
 open class VpcLatticeConfiguration extends formae.SubResource {
     portName: String
     roleArn: String|formae.Resolvable
-    @aws.FieldHint{attachesTo = true}
+    @aws.FieldHint { edgeKind = "attachesTo" }
     targetGroupArn: String|formae.Resolvable
 }
 

--- a/schema/pkl/ecs/taskdefinition.pkl
+++ b/schema/pkl/ecs/taskdefinition.pkl
@@ -112,6 +112,7 @@ typealias EFSVolumeConfigurationTransitEncryption = "ENABLED"|"DISABLED"
 @aws.SubResourceHint
 open class EFSVolumeConfiguration extends formae.SubResource {
     authorizationConfig: AuthorizationConfig?
+    @aws.FieldHint { edgeKind = "runtimeDependency" }
     filesystemId: String|formae.Resolvable
     @aws.FieldHint{hasProviderDefault = true}
     rootDirectory: String?

--- a/schema/pkl/ecs/taskset.pkl
+++ b/schema/pkl/ecs/taskset.pkl
@@ -36,6 +36,7 @@ open class CapacityProviderStrategy extends formae.SubResource {
 open class LoadBalancer extends formae.SubResource {
     containerName: String?
     containerPort: Int?
+    @aws.FieldHint { edgeKind = "attachesTo" }
     targetGroupArn: (String|formae.Resolvable)?
 }
 

--- a/schema/pkl/efs/accesspoint.pkl
+++ b/schema/pkl/efs/accesspoint.pkl
@@ -51,6 +51,11 @@ open class AccessPointResolvable extends formae.Resolvable {
 @aws.ResourceHint {
     type = module.type
     identifier = "AccessPointId"
+    parent = "AWS::EFS::FileSystem"
+    parentRefs = new formae.ParentRef {
+        parentProperty = "FileSystemId"
+        childProperty = "FileSystemId"
+    }
 }
 open class AccessPoint extends formae.Resource {
 

--- a/schema/pkl/efs/mounttarget.pkl
+++ b/schema/pkl/efs/mounttarget.pkl
@@ -31,6 +31,10 @@ open class MountTargetResolvable extends formae.Resolvable {
     type = module.type
     identifier = "Id"
     parent = "AWS::EFS::FileSystem"
+    parentRefs = new formae.ParentRef {
+        parentProperty = "FileSystemId"
+        childProperty = "FileSystemId"
+    }
     listParam = new formae.ListProperty {
         parentProperty = "FileSystemId"
         listParameter = "FileSystemId"

--- a/testdata/PklProject
+++ b/testdata/PklProject
@@ -6,6 +6,6 @@ dependencies {
 
   // Formae schema - fetched from public registry
   ["formae"] {
-    uri = "package://hub.platform.engineering/plugins/pkl/schema/pkl/formae/formae@0.85.0"
+    uri = "package://hub.platform.engineering/plugins/pkl/schema/pkl/formae/formae@0.86.0"
   }
 }

--- a/testdata/ecs-taskdef-efs-mount-destroy-order.pkl
+++ b/testdata/ecs-taskdef-efs-mount-destroy-order.pkl
@@ -3,16 +3,16 @@
  *
  * SPDX-License-Identifier: FSL-1.1-ALv2
  *
- * RFC-0043 runtimeDependency validation case.
+ * runtimeDependency destroy-ordering validation case.
  *
- * Exercises the destroy-order race the RFC is designed to fix: an ECS
- * TaskDefinition with an EFSVolumeConfiguration referencing an EFS FileSystem,
- * where the FileSystem also has MountTargets. Without `edgeKind = "runtimeDependency"`,
- * the destroy DAG has no edge from TaskDef to the MountTargets — the engine
- * may attempt to delete the FileSystem while MountTargets still hold it open,
- * stranding both. With the RFC-0043 annotation in place, the engine inserts
- * TaskDef → MountTarget edges into the destroy DAG so MountTargets are
- * destroyed before the FileSystem.
+ * Exercises the destroy-order race the runtimeDependency edge is designed to
+ * fix: an ECS TaskDefinition with an EFSVolumeConfiguration referencing an EFS
+ * FileSystem, where the FileSystem also has MountTargets. Without
+ * `edgeKind = "runtimeDependency"`, the destroy DAG has no edge from TaskDef to
+ * the MountTargets — the engine may attempt to delete the FileSystem while
+ * MountTargets still hold it open, stranding both. With the runtimeDependency
+ * annotation in place, the engine inserts TaskDef → MountTarget edges into the
+ * destroy DAG so MountTargets are destroyed before the FileSystem.
  *
  * Intended for one-off pre-merge validation via debug-conformance.yml.
  * Permanent regression coverage should live in the formae e2e suite once
@@ -33,11 +33,11 @@ import "@aws/ecs/ecscluster.pkl"
 import "@aws/ecs/taskdefinition.pkl"
 
 local testRunID = read("env:FORMAE_TEST_RUN_ID")
-local stackName = "plugin-sdk-test-rfc0043-runtimedep-\(testRunID)"
+local stackName = "plugin-sdk-test-efs-mount-order-\(testRunID)"
 
 // VPC dependency
 local testVpc = new vpc.VPC {
-  label = "test-vpc-for-rfc0043"
+  label = "test-vpc-for-efs-mount-order"
   cidrBlock = "10.243.0.0/16"
   enableDnsSupport = true
 }
@@ -46,14 +46,14 @@ local testVpc = new vpc.VPC {
 // AZ within the file system. Two MountTargets are required for the race to
 // manifest — a single child does not exercise the multi-child propagation.
 local testSubnetA = new subnet.Subnet {
-  label = "test-subnet-a-for-rfc0043"
+  label = "test-subnet-a-for-efs-mount-order"
   vpcId = testVpc.res.vpcId
   cidrBlock = "10.243.1.0/24"
   availabilityZone = "us-east-1a"
 }
 
 local testSubnetB = new subnet.Subnet {
-  label = "test-subnet-b-for-rfc0043"
+  label = "test-subnet-b-for-efs-mount-order"
   vpcId = testVpc.res.vpcId
   cidrBlock = "10.243.2.0/24"
   availabilityZone = "us-east-1b"
@@ -61,15 +61,15 @@ local testSubnetB = new subnet.Subnet {
 
 // Security Group dependency
 local testSg = new securitygroup.SecurityGroup {
-  label = "test-sg-for-rfc0043"
-  groupDescription = "Security group for RFC-0043 runtimeDependency test"
-  groupName = "formae-sdk-test-rfc0043-sg-\(testRunID)"
+  label = "test-sg-for-efs-mount-order"
+  groupDescription = "Security group for the runtimeDependency destroy-order test"
+  groupName = "formae-sdk-test-efs-mt-sg-\(testRunID)"
   vpcId = testVpc.res.vpcId
 }
 
 // FileSystem — the resource targeted by the TaskDef's runtimeDependency.
 local testFs = new filesystem.FileSystem {
-  label = "test-fs-for-rfc0043"
+  label = "test-fs-for-efs-mount-order"
   encrypted = true
   performanceMode = "generalPurpose"
   throughputMode = "bursting"
@@ -77,8 +77,8 @@ local testFs = new filesystem.FileSystem {
 
 // ECS Cluster — TaskDef's containing cluster.
 local testCluster = new ecscluster.Cluster {
-  label = "test-cluster-for-rfc0043"
-  clusterName = "formae-sdk-test-rfc0043-cluster-\(testRunID)"
+  label = "test-cluster-for-efs-mount-order"
+  clusterName = "formae-sdk-test-efs-mt-cluster-\(testRunID)"
   clusterSettings {
     new {
       name = "containerInsights"
@@ -90,10 +90,10 @@ local testCluster = new ecscluster.Cluster {
 // TaskDefinition with an EFSVolumeConfiguration referencing testFs.
 // The container mounts the volume so the EFS reference is "active" — this
 // is what gives the destroy DAG a meaningful runtime edge to the FileSystem
-// (and, with RFC-0043 propagation, to its child MountTargets).
+// (and, with runtimeDependency propagation, to its child MountTargets).
 local testTaskDef = new taskdefinition.TaskDefinition {
-  label = "plugin-sdk-test-rfc0043-taskdef"
-  family = "formae-sdk-test-rfc0043-td-\(testRunID)"
+  label = "plugin-sdk-test-efs-mount-order-taskdef"
+  family = "formae-sdk-test-efs-mt-td-\(testRunID)"
   requiresCompatibilities {
     "FARGATE"
   }
@@ -154,7 +154,7 @@ local testTaskDef = new taskdefinition.TaskDefinition {
 forma {
   new formae.Stack {
     label = stackName
-    description = "Plugin SDK test for RFC-0043 runtimeDependency destroy ordering"
+    description = "Plugin SDK test for runtimeDependency destroy ordering"
   }
 
   new formae.Target {
@@ -173,7 +173,7 @@ forma {
 
   // Two MountTargets — the multi-child shape that triggers the race.
   new mounttarget.MountTarget {
-    label = "plugin-sdk-test-rfc0043-mt-a"
+    label = "plugin-sdk-test-efs-mount-order-mt-a"
     fileSystemId = testFs.res.fileSystemId
     subnetId = testSubnetA.res.subnetId
     securityGroups {
@@ -182,7 +182,7 @@ forma {
   }
 
   new mounttarget.MountTarget {
-    label = "plugin-sdk-test-rfc0043-mt-b"
+    label = "plugin-sdk-test-efs-mount-order-mt-b"
     fileSystemId = testFs.res.fileSystemId
     subnetId = testSubnetB.res.subnetId
     securityGroups {

--- a/testdata/rfc0043-runtimedep.pkl
+++ b/testdata/rfc0043-runtimedep.pkl
@@ -1,0 +1,194 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ *
+ * RFC-0043 runtimeDependency validation case.
+ *
+ * Exercises the destroy-order race the RFC is designed to fix: an ECS
+ * TaskDefinition with an EFSVolumeConfiguration referencing an EFS FileSystem,
+ * where the FileSystem also has MountTargets. Without `edgeKind = "runtimeDependency"`,
+ * the destroy DAG has no edge from TaskDef to the MountTargets — the engine
+ * may attempt to delete the FileSystem while MountTargets still hold it open,
+ * stranding both. With the RFC-0043 annotation in place, the engine inserts
+ * TaskDef → MountTarget edges into the destroy DAG so MountTargets are
+ * destroyed before the FileSystem.
+ *
+ * Intended for one-off pre-merge validation via debug-conformance.yml.
+ * Permanent regression coverage should live in the formae e2e suite once
+ * the engine and AWS plugin PRs have merged.
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/ec2/vpc.pkl"
+import "@aws/ec2/subnet.pkl"
+import "@aws/ec2/securitygroup.pkl"
+import "@aws/efs/filesystem.pkl"
+import "@aws/efs/mounttarget.pkl"
+import "@aws/ecs/ecscluster.pkl"
+import "@aws/ecs/taskdefinition.pkl"
+
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local stackName = "plugin-sdk-test-rfc0043-runtimedep-\(testRunID)"
+
+// VPC dependency
+local testVpc = new vpc.VPC {
+  label = "test-vpc-for-rfc0043"
+  cidrBlock = "10.243.0.0/16"
+  enableDnsSupport = true
+}
+
+// Two subnets in different AZs: EFS MountTargets must each be in a distinct
+// AZ within the file system. Two MountTargets are required for the race to
+// manifest — a single child does not exercise the multi-child propagation.
+local testSubnetA = new subnet.Subnet {
+  label = "test-subnet-a-for-rfc0043"
+  vpcId = testVpc.res.vpcId
+  cidrBlock = "10.243.1.0/24"
+  availabilityZone = "us-east-1a"
+}
+
+local testSubnetB = new subnet.Subnet {
+  label = "test-subnet-b-for-rfc0043"
+  vpcId = testVpc.res.vpcId
+  cidrBlock = "10.243.2.0/24"
+  availabilityZone = "us-east-1b"
+}
+
+// Security Group dependency
+local testSg = new securitygroup.SecurityGroup {
+  label = "test-sg-for-rfc0043"
+  groupDescription = "Security group for RFC-0043 runtimeDependency test"
+  groupName = "formae-sdk-test-rfc0043-sg-\(testRunID)"
+  vpcId = testVpc.res.vpcId
+}
+
+// FileSystem — the resource targeted by the TaskDef's runtimeDependency.
+local testFs = new filesystem.FileSystem {
+  label = "test-fs-for-rfc0043"
+  encrypted = true
+  performanceMode = "generalPurpose"
+  throughputMode = "bursting"
+}
+
+// ECS Cluster — TaskDef's containing cluster.
+local testCluster = new ecscluster.Cluster {
+  label = "test-cluster-for-rfc0043"
+  clusterName = "formae-sdk-test-rfc0043-cluster-\(testRunID)"
+  clusterSettings {
+    new {
+      name = "containerInsights"
+      value = "disabled"
+    }
+  }
+}
+
+// TaskDefinition with an EFSVolumeConfiguration referencing testFs.
+// The container mounts the volume so the EFS reference is "active" — this
+// is what gives the destroy DAG a meaningful runtime edge to the FileSystem
+// (and, with RFC-0043 propagation, to its child MountTargets).
+local testTaskDef = new taskdefinition.TaskDefinition {
+  label = "plugin-sdk-test-rfc0043-taskdef"
+  family = "formae-sdk-test-rfc0043-td-\(testRunID)"
+  requiresCompatibilities {
+    "FARGATE"
+  }
+  networkMode = "awsvpc"
+  cpu = "256"
+  memory = "512"
+  // AWS returns Tags as [] when unset. The conformance harness's reverse
+  // loop flags "extra" actual fields not in expected and not marked as
+  // hasProviderDefault. Set explicitly so the harness sees Tags as
+  // "in expected" and skips the check.
+  tags = new Listing<aws.Tag> {}
+  volumes {
+    new {
+      name = "efs-volume"
+      eFSVolumeConfiguration = new {
+        filesystemId = testFs.res.fileSystemId
+      }
+    }
+  }
+  containerDefinitions {
+    new {
+      name = "test-container"
+      image = "nginx:latest"
+      essential = true
+      mountPoints {
+        new {
+          sourceVolume = "efs-volume"
+          containerPath = "/mnt/efs"
+          readOnly = false
+        }
+      }
+      environment {
+        new { name = "INITIAL_VAR"; value = "v1" }
+      }
+      // AWS returns these container fields as [] / {} when unset. Same harness
+      // reason as Tags above.
+      command = new Listing<String> {}
+      credentialSpecs = new Listing<String> {}
+      dependsOn = new Listing<taskdefinition.ContainerDependency> {}
+      dnsSearchDomains = new Listing<String> {}
+      dnsServers = new Listing<String> {}
+      dockerLabels = new Mapping<String, Any> {}
+      dockerSecurityOptions = new Listing<String> {}
+      entryPoint = new Listing<String> {}
+      environmentFiles = new Listing<taskdefinition.EnvironmentFile> {}
+      extraHosts = new Listing<taskdefinition.HostEntry> {}
+      links = new Listing<String> {}
+      portMappings = new Listing<taskdefinition.PortMapping> {}
+      resourceRequirements = new Listing<taskdefinition.ResourceRequirement> {}
+      secrets = new Listing<taskdefinition.Secret> {}
+      systemControls = new Listing<taskdefinition.SystemControl> {}
+      ulimits = new Listing<taskdefinition.Ulimit> {}
+      volumesFrom = new Listing<taskdefinition.VolumeFrom> {}
+    }
+  }
+}
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for RFC-0043 runtimeDependency destroy ordering"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  testVpc
+  testSubnetA
+  testSubnetB
+  testSg
+  testFs
+  testCluster
+
+  // Two MountTargets — the multi-child shape that triggers the race.
+  new mounttarget.MountTarget {
+    label = "plugin-sdk-test-rfc0043-mt-a"
+    fileSystemId = testFs.res.fileSystemId
+    subnetId = testSubnetA.res.subnetId
+    securityGroups {
+      testSg.res.groupId
+    }
+  }
+
+  new mounttarget.MountTarget {
+    label = "plugin-sdk-test-rfc0043-mt-b"
+    fileSystemId = testFs.res.fileSystemId
+    subnetId = testSubnetB.res.subnetId
+    securityGroups {
+      testSg.res.groupId
+    }
+  }
+
+  testTaskDef
+}


### PR DESCRIPTION
## Summary

Adds the typed-edge annotations to the AWS plugin schema, paired with the engine's `EdgeKind` work:

- Migrate `AWS::ECS::Service.LoadBalancers.targetGroupArn` (and the `AWS::ECS::TaskSet` mirror) to `edgeKind = "attachesTo"` for reachability-aware destroy ordering.
- Add `edgeKind = "runtimeDependency"` to `AWS::ECS::TaskDefinition.EFSVolumeConfiguration.filesystemId` so the engine pulls a FileSystem's MountTargets into the destroy ordering ahead of the FileSystem.
- Declare explicit `parentRefs` on `AWS::EFS::AccessPoint` / `AWS::EFS::MountTarget` (behaviorally a no-op where the `listParam` fallback already derives the same mapping; `parentRefs` is the canonical form going forward).

Includes a conformance fixture, `testdata/ecs-taskdef-efs-mount-destroy-order.pkl`, exercising the destroy-order race: VPC + 2 subnets + SG + EFS FileSystem + 2 MountTargets + ECS Cluster + TaskDef-with-EFSVolume. Destroy completes with no stranded resources.

Requires the matching engine change (formae #484) — built from that branch in CI via the `formae_version` workflow input until it ships in a release.