### PR TITLE
fix(lambda): strip provider-injected empty DestinationConfig on EventInvokeConfig read

### DIFF
--- a/pkg/ccx/client.go
+++ b/pkg/ccx/client.go
@@ -326,6 +326,17 @@ func (c *Client) ReadResource(ctx context.Context, request *resource.ReadRequest
 		return nil, fmt.Errorf("failed to strip ignored fields: %w", err)
 	}
 
+	// CloudControl injects DestinationConfig:{OnFailure:{},OnSuccess:{}} into
+	// every AWS::Lambda::EventInvokeConfig read, even when the caller never set
+	// it. AWS requires Destination inside OnFailure/OnSuccess, so an empty {}
+	// carries no information; absorbing it makes formae's required-field
+	// validation spuriously reject a valid resource. Strip the empty
+	// sub-objects (and DestinationConfig if it ends up empty); genuine
+	// user-set destinations are non-empty and pass through untouched.
+	if request.ResourceType == "AWS::Lambda::EventInvokeConfig" {
+		stripEmptyCollectionsFromMap(propsMap)
+	}
+
 	transformedProps, err := json.Marshal(propsMap)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal transformed properties: %w", err)

--- a/pkg/ccx/client_test.go
+++ b/pkg/ccx/client_test.go
@@ -672,3 +672,56 @@ func TestStripEmptyCollectionsFromMap_NestedNonEmpty(t *testing.T) {
 		t.Error("OnFailure should be stripped (empty)")
 	}
 }
+
+func TestReadResource_StripsEmptyEventInvokeDestinationConfig(t *testing.T) {
+	mockAPI := new(mockCloudControlAPI)
+	client := &Client{api: mockAPI}
+
+	// CloudControl injects DestinationConfig:{OnFailure:{},OnSuccess:{}} into
+	// every EventInvokeConfig read, even when the caller never set it. Those
+	// empty sub-objects carry no information (AWS requires Destination inside
+	// OnFailure/OnSuccess), and absorbing them makes formae's required-field
+	// validation spuriously fail.
+	mockAPI.On("GetResource", mock.Anything, mock.Anything).Return(&cloudcontrol.GetResourceOutput{
+		ResourceDescription: &cctypes.ResourceDescription{
+			Identifier: ptr.Of("fn|$LATEST"),
+			Properties: ptr.Of(`{"FunctionName":"fn","MaximumRetryAttempts":2,"DestinationConfig":{"OnSuccess":{},"OnFailure":{}}}`),
+		},
+		TypeName: ptr.Of("AWS::Lambda::EventInvokeConfig"),
+	}, nil)
+
+	result, err := client.ReadResource(context.Background(), &resource.ReadRequest{
+		ResourceType: "AWS::Lambda::EventInvokeConfig",
+		NativeID:     "fn|$LATEST",
+	})
+	require.NoError(t, err)
+	require.NotContains(t, string(result.Properties), "DestinationConfig",
+		"empty provider-injected DestinationConfig must be stripped on read")
+	require.Contains(t, string(result.Properties), "MaximumRetryAttempts",
+		"real properties must be preserved")
+}
+
+func TestReadResource_PreservesRealEventInvokeDestination(t *testing.T) {
+	mockAPI := new(mockCloudControlAPI)
+	client := &Client{api: mockAPI}
+
+	// A genuine user-set destination must survive the strip; only the empty
+	// sibling (OnSuccess:{}) should be removed.
+	mockAPI.On("GetResource", mock.Anything, mock.Anything).Return(&cloudcontrol.GetResourceOutput{
+		ResourceDescription: &cctypes.ResourceDescription{
+			Identifier: ptr.Of("fn|$LATEST"),
+			Properties: ptr.Of(`{"FunctionName":"fn","DestinationConfig":{"OnFailure":{"Destination":"arn:aws:sqs:us-east-1:123456789012:dlq"},"OnSuccess":{}}}`),
+		},
+		TypeName: ptr.Of("AWS::Lambda::EventInvokeConfig"),
+	}, nil)
+
+	result, err := client.ReadResource(context.Background(), &resource.ReadRequest{
+		ResourceType: "AWS::Lambda::EventInvokeConfig",
+		NativeID:     "fn|$LATEST",
+	})
+	require.NoError(t, err)
+	require.Contains(t, string(result.Properties), "arn:aws:sqs:us-east-1:123456789012:dlq",
+		"a genuine user-set destination must be preserved")
+	require.NotContains(t, string(result.Properties), "OnSuccess",
+		"the empty OnSuccess sibling should be stripped")
+}


### PR DESCRIPTION
## Summary

- CloudControl injects `DestinationConfig:{OnFailure:{},OnSuccess:{}}` into every `AWS::Lambda::EventInvokeConfig` read, even when the caller never set it. Verified deterministic via direct `cloudcontrol get-resource` probing (14/14 reads, including immediately post-create).
- AWS requires `Destination` inside `OnFailure`/`OnSuccess`, so an empty `{}` carries no information. formae's required-field validator walks into the injected empty parent at persist time and reports the required leaf missing — intermittently failing the `lambda-eventinvokeconfig` conformance test (the failure surfaces only when the create-time read enrichment reaches the persist-time validator, ~10% of runs, on `main` too).
- Fix: wire the existing, already-tested `stripEmptyCollectionsFromMap` into `ReadResource`, gated to `AWS::Lambda::EventInvokeConfig` (matching the per-type `IgnoredFields` pattern). The empty sub-objects are removed on every read path (create enrichment, sync, discovery) so they never reach the validator; genuine user-set destinations are non-empty and pass through untouched.
- `Destination` stays correctly `required`, matching the CloudFormation schema — no schema weakening, no formae-core validator change.