### PR TITLE
ci: bump conformance matrix max-parallel from 5 to 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,8 @@ jobs:
     strategy:
       matrix:
         test-case: ${{ fromJson(needs.discover-tests.outputs.test-cases) }}
-      max-parallel: 5
+      # Mirrors nightly.yml — see the comment there on quota headroom.
+      max-parallel: 10
       fail-fast: false
     permissions:
       id-token: write

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -121,12 +121,12 @@ jobs:
     strategy:
       matrix:
         test-case: ${{ fromJson(needs.discover-tests.outputs.test-cases) }}
-      # VPC quota in the test account is 5; match the quota exactly.
-      # The original max-parallel=10 worked when on_retry_command was
-      # cascading failures across the matrix (cleanup race). With the
-      # retry wrapper dropped and orphan-VPC cleanup hardened, 5 is the
-      # right cap. Will bump to 10 once the AWS quota is raised to 20+.
-      max-parallel: 5
+      # us-east-1 VPC quota was raised to 30, and the aws-nuke isolation
+      # (region-split into us-west-*) means all of that headroom is the
+      # conformance suite's. EIPs remain at the default 5 but only a
+      # couple of fixtures consume them, so EIP/NAT contention stays
+      # comfortable at this level.
+      max-parallel: 10
       fail-fast: false
     permissions:
       id-token: write


### PR DESCRIPTION
## Summary

- us-east-1 VPC quota was raised from 5 to 30 in the test account, and
  the aws-nuke isolation (region-split into us-west-1/us-west-2) means
  all of that headroom is the conformance suite's. The historical
  comment's pre-stated trigger ("bump to 10 once quota is raised to
  20+") is met.
- Doubles matrix throughput. EIPs remain at the default 5 but are
  consumed by only a couple of fixtures (ec2-eip, ec2-natgateway), so
  EIP/NAT-soft-limit contention stays comfortable at parallelism 10.
- Applied to both `ci.yml` and `nightly.yml` so push CI and nightly
  share the new cap.
- De-conflicted state of both workflows (no cross-repo
  `cloud-e2e-tests` group, isolation enforced in formae's nuke config)
  is unchanged.