### PR TITLE
feat(ecs): add endpoints MappingResolvable on AWS::ECS::Service

### DIFF
--- a/pkg/cfres/ecs/clients.go
+++ b/pkg/cfres/ecs/clients.go
@@ -30,9 +30,13 @@ type ecsClient interface {
 	DescribeServices(ctx context.Context, params *awsecs.DescribeServicesInput, optFns ...func(*awsecs.Options)) (*awsecs.DescribeServicesOutput, error)
 }
 
-// elbv2Client is the surface of the AWS ELBv2 SDK used by the Service provisioner for target-health checks.
+// elbv2Client is the surface of the AWS ELBv2 SDK used by the Service provisioner
+// for target-health checks and endpoint composition.
 type elbv2Client interface {
 	DescribeTargetHealth(ctx context.Context, params *awselbv2.DescribeTargetHealthInput, optFns ...func(*awselbv2.Options)) (*awselbv2.DescribeTargetHealthOutput, error)
+	DescribeTargetGroups(ctx context.Context, params *awselbv2.DescribeTargetGroupsInput, optFns ...func(*awselbv2.Options)) (*awselbv2.DescribeTargetGroupsOutput, error)
+	DescribeLoadBalancers(ctx context.Context, params *awselbv2.DescribeLoadBalancersInput, optFns ...func(*awselbv2.Options)) (*awselbv2.DescribeLoadBalancersOutput, error)
+	DescribeListeners(ctx context.Context, params *awselbv2.DescribeListenersInput, optFns ...func(*awselbv2.Options)) (*awselbv2.DescribeListenersOutput, error)
 }
 
 func defaultCCXClientFactory(cfg *config.Config) (ccxClient, error) {

--- a/pkg/cfres/ecs/endpoints.go
+++ b/pkg/cfres/ecs/endpoints.go
@@ -1,0 +1,415 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package ecs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sort"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	awselbv2 "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	elbv2types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+	"github.com/aws/smithy-go"
+)
+
+// ComposeResult is the outcome of composeEndpoints. Endpoints is the
+// best-effort map composed from the service's loadBalancers[]; TransientError
+// is non-nil ONLY when at least one entry failed due to retryable AWS errors
+// AFTER internal retries were exhausted. Permanent failures (unsupported
+// topology, IAM, etc.) leave TransientError nil but produce missing keys in
+// the Endpoints map.
+//
+// Callers (Phase B finalSuccess, Service Read) branch on TransientError:
+//   - nil  -> publish Endpoints (possibly empty/partial) and proceed to Success
+//   - !nil -> Phase B returns InProgress; Read returns a recoverable plugin
+//     error so ResolveCache and the sync loop retry the Plugin Read
+//     without overwriting persisted state.
+//
+// Design: docs/superpowers/specs/2026-05-27-ecs-service-endpoints-resolvable-design.md
+type ComposeResult struct {
+	Endpoints      map[string]string
+	TransientError error
+}
+
+// composeEndpoints walks each loadBalancers[] entry and composes a URL by
+// joining its TG to the fronting ALB's DNS, the forwarding HTTP(S) listener's
+// port, and the listener's protocol. Read-only; safe to call repeatedly. The
+// helper retries transient AWS errors internally before classifying.
+func composeEndpoints(
+	ctx context.Context,
+	loadBalancers []ecstypes.LoadBalancer,
+	elbv2 elbv2Client,
+	logger *slog.Logger,
+) ComposeResult {
+	if len(loadBalancers) == 0 {
+		return ComposeResult{Endpoints: map[string]string{}}
+	}
+
+	out := ComposeResult{Endpoints: map[string]string{}}
+
+	tgArns := uniqueTGArns(loadBalancers)
+	if len(tgArns) == 0 {
+		return out
+	}
+
+	tgs, err := describeTargetGroupsRetry(ctx, elbv2, tgArns, logger)
+	if err != nil {
+		if isTransient(err) {
+			out.TransientError = err
+			return out
+		}
+		for _, lb := range loadBalancers {
+			logSkip(logger, "DescribeTargetGroups failed permanently", aws.ToString(lb.TargetGroupArn), err)
+		}
+		return out
+	}
+	tgByArn := indexTGsByArn(tgs)
+
+	albArns := uniqueALBArns(tgs)
+	var albs map[string]elbv2types.LoadBalancer
+	if len(albArns) > 0 {
+		lbsOut, err := describeLoadBalancersRetry(ctx, elbv2, albArns, logger)
+		if err != nil {
+			if isTransient(err) {
+				out.TransientError = err
+				return out
+			}
+			for _, lb := range loadBalancers {
+				logSkip(logger, "DescribeLoadBalancers failed permanently", aws.ToString(lb.TargetGroupArn), err)
+			}
+			return out
+		}
+		albs = indexLBsByArn(lbsOut)
+	}
+
+	listenersByALB := map[string][]elbv2types.Listener{}
+	for _, albArn := range albArns {
+		l, err := describeListenersRetry(ctx, elbv2, albArn, logger)
+		if err != nil {
+			if isTransient(err) {
+				out.TransientError = err
+				continue
+			}
+			logSkip(logger, "DescribeListeners failed permanently", albArn, err)
+			continue
+		}
+		listenersByALB[albArn] = l
+	}
+
+	for _, lb := range loadBalancers {
+		key, url, skipped := composeOneEntry(lb, tgByArn, albs, listenersByALB, logger)
+		if skipped {
+			continue
+		}
+		if existing, dup := out.Endpoints[key]; dup && existing != url {
+			logger.Warn("endpoint composition: duplicate key resolves to different URLs; last wins",
+				"op", "composeEndpoints", "key", key, "previous", existing, "chosen", url)
+		}
+		out.Endpoints[key] = url
+	}
+	return out
+}
+
+func uniqueTGArns(lbs []ecstypes.LoadBalancer) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, lb := range lbs {
+		arn := aws.ToString(lb.TargetGroupArn)
+		if arn == "" {
+			continue
+		}
+		if !seen[arn] {
+			seen[arn] = true
+			out = append(out, arn)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func uniqueALBArns(tgs []elbv2types.TargetGroup) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, tg := range tgs {
+		for _, a := range tg.LoadBalancerArns {
+			if !seen[a] {
+				seen[a] = true
+				out = append(out, a)
+			}
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func indexTGsByArn(tgs []elbv2types.TargetGroup) map[string]elbv2types.TargetGroup {
+	m := map[string]elbv2types.TargetGroup{}
+	for _, tg := range tgs {
+		m[aws.ToString(tg.TargetGroupArn)] = tg
+	}
+	return m
+}
+
+func indexLBsByArn(lbs []elbv2types.LoadBalancer) map[string]elbv2types.LoadBalancer {
+	m := map[string]elbv2types.LoadBalancer{}
+	for _, lb := range lbs {
+		m[aws.ToString(lb.LoadBalancerArn)] = lb
+	}
+	return m
+}
+
+// describeTargetGroupsRetry / describeLoadBalancersRetry / describeListenersRetry
+// wrap their AWS SDK calls with a 3-attempt retry loop (500ms / 1s / 2s).
+func describeTargetGroupsRetry(ctx context.Context, cli elbv2Client, arns []string, logger *slog.Logger,
+) ([]elbv2types.TargetGroup, error) {
+	var out *awselbv2.DescribeTargetGroupsOutput
+	err := withRetries(ctx, "DescribeTargetGroups", logger, func() error {
+		var cerr error
+		out, cerr = cli.DescribeTargetGroups(ctx, &awselbv2.DescribeTargetGroupsInput{TargetGroupArns: arns})
+		return cerr
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out.TargetGroups, nil
+}
+
+func describeLoadBalancersRetry(ctx context.Context, cli elbv2Client, arns []string, logger *slog.Logger,
+) ([]elbv2types.LoadBalancer, error) {
+	var out *awselbv2.DescribeLoadBalancersOutput
+	err := withRetries(ctx, "DescribeLoadBalancers", logger, func() error {
+		var cerr error
+		out, cerr = cli.DescribeLoadBalancers(ctx, &awselbv2.DescribeLoadBalancersInput{LoadBalancerArns: arns})
+		return cerr
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out.LoadBalancers, nil
+}
+
+func describeListenersRetry(ctx context.Context, cli elbv2Client, albArn string, logger *slog.Logger,
+) ([]elbv2types.Listener, error) {
+	var out *awselbv2.DescribeListenersOutput
+	err := withRetries(ctx, "DescribeListeners", logger, func() error {
+		var cerr error
+		out, cerr = cli.DescribeListeners(ctx, &awselbv2.DescribeListenersInput{LoadBalancerArn: &albArn})
+		return cerr
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out.Listeners, nil
+}
+
+// withRetries runs fn up to 3 times with 500ms/1s/2s backoff. Stops early on
+// non-transient errors.
+func withRetries(ctx context.Context, op string, logger *slog.Logger, fn func() error) error {
+	backoffs := []time.Duration{500 * time.Millisecond, 1 * time.Second, 2 * time.Second}
+	var lastErr error
+	for attempt := 0; attempt < 3; attempt++ {
+		err := fn()
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		if !isTransient(err) {
+			return err
+		}
+		logger.Info("endpoint composition: transient AWS error; retrying",
+			"op", "composeEndpoints", "call", op, "attempt", attempt+1, "err", err)
+		if attempt < 2 {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(backoffs[attempt]):
+			}
+		}
+	}
+	return lastErr
+}
+
+// composeOneEntry resolves one loadBalancers[] entry to (key, url). Returns
+// skipped=true if the entry should be omitted from the map.
+func composeOneEntry(
+	lb ecstypes.LoadBalancer,
+	tgByArn map[string]elbv2types.TargetGroup,
+	albs map[string]elbv2types.LoadBalancer,
+	listenersByALB map[string][]elbv2types.Listener,
+	logger *slog.Logger,
+) (key, url string, skipped bool) {
+	tgArn := aws.ToString(lb.TargetGroupArn)
+	containerName := aws.ToString(lb.ContainerName)
+	containerPort := int32(0)
+	if lb.ContainerPort != nil {
+		containerPort = *lb.ContainerPort
+	}
+
+	if tgArn == "" || containerName == "" || containerPort == 0 {
+		logSkip(logger, "loadBalancers[] entry missing required fields", tgArn, nil,
+			"containerName", containerName, "containerPort", containerPort)
+		return "", "", true
+	}
+
+	tg, ok := tgByArn[tgArn]
+	if !ok {
+		logSkip(logger, "TG not found in DescribeTargetGroups response", tgArn, nil)
+		return "", "", true
+	}
+	if len(tg.LoadBalancerArns) == 0 {
+		logSkip(logger, "TG attached to zero LBs", tgArn, nil)
+		return "", "", true
+	}
+
+	// Identify the unique ALB that fronts this TG (filter to ALB type).
+	var albArn string
+	albCount := 0
+	for _, a := range tg.LoadBalancerArns {
+		lbObj, present := albs[a]
+		if !present {
+			continue
+		}
+		if lbObj.Type != elbv2types.LoadBalancerTypeEnumApplication {
+			continue
+		}
+		albCount++
+		albArn = a
+	}
+	if albCount == 0 {
+		logSkip(logger, "TG attached to no ALB (NLB-only or unresolved)", tgArn, nil)
+		return "", "", true
+	}
+	if albCount > 1 {
+		logSkip(logger, "multiple ALBs front the same TG", tgArn, nil, "albCount", albCount)
+		return "", "", true
+	}
+
+	albObj := albs[albArn]
+
+	// Find HTTP(S) forward-action listeners referencing this TG.
+	var matches []elbv2types.Listener
+	for _, lst := range listenersByALB[albArn] {
+		if !listenerForwardsTo(lst, tgArn) {
+			continue
+		}
+		if lst.Protocol != elbv2types.ProtocolEnumHttp && lst.Protocol != elbv2types.ProtocolEnumHttps {
+			continue
+		}
+		matches = append(matches, lst)
+	}
+	if len(matches) == 0 {
+		logSkip(logger, "no HTTP(S) forward-action listener references this TG (rule-routing or NLB protocols)", tgArn, nil)
+		return "", "", true
+	}
+	if len(matches) > 1 {
+		arns := make([]string, 0, len(matches))
+		for _, l := range matches {
+			arns = append(arns, aws.ToString(l.ListenerArn))
+		}
+		logSkip(logger, "ambiguous: multiple HTTP(S) forward-action listeners reference this TG; cannot determine primary URL", tgArn, nil,
+			"listenerCount", len(matches), "listenerArns", arns)
+		return "", "", true
+	}
+
+	lst := matches[0]
+	port := int32(0)
+	if lst.Port != nil {
+		port = *lst.Port
+	}
+	scheme := "http"
+	if lst.Protocol == elbv2types.ProtocolEnumHttps {
+		scheme = "https"
+	}
+	dns := aws.ToString(albObj.DNSName)
+
+	return fmt.Sprintf("%s:%d", containerName, containerPort),
+		fmt.Sprintf("%s://%s:%d", scheme, dns, port),
+		false
+}
+
+// listenerForwardsTo returns true if any DefaultActions[] entry has
+// Type=forward referencing tgArn, either directly or via ForwardConfig.
+func listenerForwardsTo(lst elbv2types.Listener, tgArn string) bool {
+	for _, a := range lst.DefaultActions {
+		if a.Type != elbv2types.ActionTypeEnumForward {
+			continue
+		}
+		if aws.ToString(a.TargetGroupArn) == tgArn {
+			return true
+		}
+		if a.ForwardConfig != nil {
+			for _, tg := range a.ForwardConfig.TargetGroups {
+				if aws.ToString(tg.TargetGroupArn) == tgArn {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// isTransient classifies an AWS API error as retryable (transient) vs not.
+// Transient: SDK marks as retryable, 5xx, throttling. Permanent: AccessDenied,
+// validation errors, 4xx (except throttling).
+//
+// Uses smithy.APIError (the interface real AWS SDK v2 errors satisfy via
+// smithy.GenericAPIError). The interface returns ErrorFault as a typed enum,
+// so we compare against smithy.FaultServer rather than a string.
+func isTransient(err error) bool {
+	if err == nil {
+		return false
+	}
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		code := apiErr.ErrorCode()
+		switch code {
+		case "Throttling", "ThrottlingException", "RequestLimitExceeded",
+			"TooManyRequests", "InternalFailure", "ServiceUnavailable":
+			return true
+		case "AccessDenied", "AccessDeniedException", "UnauthorizedOperation",
+			"InvalidParameter", "InvalidParameterValue", "ValidationException",
+			"TargetGroupNotFound", "LoadBalancerNotFound", "ListenerNotFound":
+			return false
+		}
+		if apiErr.ErrorFault() == smithy.FaultServer {
+			return true
+		}
+	}
+	// Unknown errors (network, EOF): treat as transient. The retry budget bounds
+	// runaway loops.
+	return true
+}
+
+// logSkip emits a structured warn-level slog event for permanent per-entry
+// skips. Special-cases AccessDenied with an IAM remediation hint.
+func logSkip(logger *slog.Logger, reason, tgArn string, err error, extras ...any) {
+	attrs := []any{"op", "composeEndpoints", "reason", reason, "tgArn", tgArn}
+	attrs = append(attrs, extras...)
+	if err != nil {
+		attrs = append(attrs, "err", err.Error())
+		if isAccessDenied(err) {
+			attrs = append(attrs,
+				"errorClass", "iam_permission",
+				"remediation", "grant elbv2:Describe* on the agent's IAM role")
+		}
+	}
+	logger.Warn("endpoint composition: skipping entry", attrs...)
+}
+
+func isAccessDenied(err error) bool {
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		switch apiErr.ErrorCode() {
+		case "AccessDenied", "AccessDeniedException", "UnauthorizedOperation":
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/cfres/ecs/endpoints_test.go
+++ b/pkg/cfres/ecs/endpoints_test.go
@@ -1,0 +1,619 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package ecs
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	awselbv2 "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	elbv2types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+	"github.com/aws/smithy-go"
+	"github.com/stretchr/testify/assert"
+)
+
+// testLogger returns a slog.Logger discarding all output, suitable for use in
+// table-driven tests that don't assert on log content.
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelDebug}))
+}
+
+func TestComposeEndpoints_EmptyLoadBalancers(t *testing.T) {
+	cli := &mockELBv2Client{}
+	// Expect zero API calls when there are no LB entries.
+
+	result := composeEndpoints(context.Background(), nil, cli, testLogger())
+
+	assert.NotNil(t, result.Endpoints)
+	assert.Empty(t, result.Endpoints)
+	assert.NoError(t, result.TransientError)
+	cli.AssertExpectations(t)
+
+	// Repeat with empty (non-nil) slice.
+	result2 := composeEndpoints(context.Background(), []ecstypes.LoadBalancer{}, cli, testLogger())
+	assert.Empty(t, result2.Endpoints)
+	assert.NoError(t, result2.TransientError)
+}
+
+// ptr returns a pointer to v. Helper for AWS SDK input/output types
+// where most fields are *T.
+func ptr[T any](v T) *T { return &v }
+
+func TestComposeEndpoints_SingleEntryHTTPS(t *testing.T) {
+	ctx := context.Background()
+	cli := &mockELBv2Client{}
+
+	tgArn := "arn:aws:elasticloadbalancing:us-east-1:123:targetgroup/grafana-tg/abc"
+	albArn := "arn:aws:elasticloadbalancing:us-east-1:123:loadbalancer/app/lgtm-alb/def"
+	listenerArn := "arn:aws:elasticloadbalancing:us-east-1:123:listener/app/lgtm-alb/def/g"
+
+	cli.On("DescribeTargetGroups", ctx, &awselbv2.DescribeTargetGroupsInput{
+		TargetGroupArns: []string{tgArn},
+	}).Return(&awselbv2.DescribeTargetGroupsOutput{
+		TargetGroups: []elbv2types.TargetGroup{
+			{TargetGroupArn: ptr(tgArn), LoadBalancerArns: []string{albArn}},
+		},
+	}, nil)
+
+	cli.On("DescribeLoadBalancers", ctx, &awselbv2.DescribeLoadBalancersInput{
+		LoadBalancerArns: []string{albArn},
+	}).Return(&awselbv2.DescribeLoadBalancersOutput{
+		LoadBalancers: []elbv2types.LoadBalancer{
+			{
+				LoadBalancerArn: ptr(albArn),
+				DNSName:         ptr("lgtm-1234.us-east-1.elb.amazonaws.com"),
+				Type:            elbv2types.LoadBalancerTypeEnumApplication,
+			},
+		},
+	}, nil)
+
+	cli.On("DescribeListeners", ctx, &awselbv2.DescribeListenersInput{
+		LoadBalancerArn: ptr(albArn),
+	}).Return(&awselbv2.DescribeListenersOutput{
+		Listeners: []elbv2types.Listener{
+			{
+				ListenerArn: ptr(listenerArn),
+				Port:        ptr(int32(443)),
+				Protocol:    elbv2types.ProtocolEnumHttps,
+				DefaultActions: []elbv2types.Action{
+					{Type: elbv2types.ActionTypeEnumForward, TargetGroupArn: ptr(tgArn)},
+				},
+			},
+		},
+	}, nil)
+
+	lbs := []ecstypes.LoadBalancer{
+		{ContainerName: ptr("grafana"), ContainerPort: ptr(int32(3000)), TargetGroupArn: ptr(tgArn)},
+	}
+
+	result := composeEndpoints(ctx, lbs, cli, testLogger())
+
+	assert.NoError(t, result.TransientError)
+	assert.Equal(t, map[string]string{
+		"grafana:3000": "https://lgtm-1234.us-east-1.elb.amazonaws.com:443",
+	}, result.Endpoints)
+	cli.AssertExpectations(t)
+}
+
+// captureLogs returns a logger that writes to the returned buffer, plus the buffer.
+// Used by tests asserting on warn-level skip events.
+func captureLogs() (*slog.Logger, *bytes.Buffer) {
+	buf := &bytes.Buffer{}
+	h := slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	return slog.New(h), buf
+}
+
+// awsAPIErr constructs a smithy.APIError with the given code/message for tests
+// of error classification. Uses smithy.GenericAPIError directly so we exercise
+// the same interface the production code's isTransient/isAccessDenied uses.
+func awsAPIErr(code, message string) error {
+	return &smithy.GenericAPIError{Code: code, Message: message}
+}
+
+func TestComposeEndpoints_TGNotInResponse(t *testing.T) {
+	ctx := context.Background()
+	cli := &mockELBv2Client{}
+	tgArn := "arn:aws:elasticloadbalancing:us-east-1:123:targetgroup/missing/abc"
+
+	cli.On("DescribeTargetGroups", ctx, &awselbv2.DescribeTargetGroupsInput{TargetGroupArns: []string{tgArn}}).
+		Return(&awselbv2.DescribeTargetGroupsOutput{TargetGroups: nil}, nil)
+
+	lbs := []ecstypes.LoadBalancer{
+		{ContainerName: ptr("app"), ContainerPort: ptr(int32(80)), TargetGroupArn: ptr(tgArn)},
+	}
+
+	logger, logs := captureLogs()
+	result := composeEndpoints(ctx, lbs, cli, logger)
+
+	assert.NoError(t, result.TransientError)
+	assert.Empty(t, result.Endpoints)
+	assert.Contains(t, logs.String(), "TG not found")
+}
+
+func TestComposeEndpoints_TGAttachedToZeroLBs(t *testing.T) {
+	ctx := context.Background()
+	cli := &mockELBv2Client{}
+	tgArn := "arn:aws:elasticloadbalancing:us-east-1:123:targetgroup/orphan/abc"
+
+	cli.On("DescribeTargetGroups", ctx, &awselbv2.DescribeTargetGroupsInput{TargetGroupArns: []string{tgArn}}).
+		Return(&awselbv2.DescribeTargetGroupsOutput{
+			TargetGroups: []elbv2types.TargetGroup{
+				{TargetGroupArn: ptr(tgArn), LoadBalancerArns: nil},
+			},
+		}, nil)
+
+	lbs := []ecstypes.LoadBalancer{
+		{ContainerName: ptr("app"), ContainerPort: ptr(int32(80)), TargetGroupArn: ptr(tgArn)},
+	}
+
+	logger, logs := captureLogs()
+	result := composeEndpoints(ctx, lbs, cli, logger)
+
+	assert.NoError(t, result.TransientError)
+	assert.Empty(t, result.Endpoints)
+	assert.Contains(t, logs.String(), "attached to zero LBs")
+}
+
+func TestComposeEndpoints_TGOnlyOnNLB(t *testing.T) {
+	ctx := context.Background()
+	cli := &mockELBv2Client{}
+	tgArn := "arn:aws:elasticloadbalancing:us-east-1:123:targetgroup/nlb-tg/abc"
+	nlbArn := "arn:aws:elasticloadbalancing:us-east-1:123:loadbalancer/net/nlb/def"
+
+	cli.On("DescribeTargetGroups", ctx, &awselbv2.DescribeTargetGroupsInput{TargetGroupArns: []string{tgArn}}).
+		Return(&awselbv2.DescribeTargetGroupsOutput{
+			TargetGroups: []elbv2types.TargetGroup{
+				{TargetGroupArn: ptr(tgArn), LoadBalancerArns: []string{nlbArn}},
+			},
+		}, nil)
+	cli.On("DescribeLoadBalancers", ctx, &awselbv2.DescribeLoadBalancersInput{LoadBalancerArns: []string{nlbArn}}).
+		Return(&awselbv2.DescribeLoadBalancersOutput{
+			LoadBalancers: []elbv2types.LoadBalancer{
+				{LoadBalancerArn: ptr(nlbArn), DNSName: ptr("nlb-dns"), Type: elbv2types.LoadBalancerTypeEnumNetwork},
+			},
+		}, nil)
+	cli.On("DescribeListeners", ctx, &awselbv2.DescribeListenersInput{LoadBalancerArn: ptr(nlbArn)}).
+		Return(&awselbv2.DescribeListenersOutput{Listeners: nil}, nil)
+
+	lbs := []ecstypes.LoadBalancer{
+		{ContainerName: ptr("app"), ContainerPort: ptr(int32(80)), TargetGroupArn: ptr(tgArn)},
+	}
+
+	logger, logs := captureLogs()
+	result := composeEndpoints(ctx, lbs, cli, logger)
+
+	assert.NoError(t, result.TransientError)
+	assert.Empty(t, result.Endpoints)
+	assert.Contains(t, logs.String(), "attached to no ALB")
+}
+
+func TestComposeEndpoints_MultiALB(t *testing.T) {
+	ctx := context.Background()
+	cli := &mockELBv2Client{}
+	tgArn := "arn:aws:elasticloadbalancing:us-east-1:123:targetgroup/shared/abc"
+	albA := "arn:aws:elasticloadbalancing:us-east-1:123:loadbalancer/app/a/d1"
+	albB := "arn:aws:elasticloadbalancing:us-east-1:123:loadbalancer/app/b/d2"
+
+	cli.On("DescribeTargetGroups", ctx, &awselbv2.DescribeTargetGroupsInput{TargetGroupArns: []string{tgArn}}).
+		Return(&awselbv2.DescribeTargetGroupsOutput{
+			TargetGroups: []elbv2types.TargetGroup{
+				{TargetGroupArn: ptr(tgArn), LoadBalancerArns: []string{albA, albB}},
+			},
+		}, nil)
+	cli.On("DescribeLoadBalancers", ctx, &awselbv2.DescribeLoadBalancersInput{LoadBalancerArns: []string{albA, albB}}).
+		Return(&awselbv2.DescribeLoadBalancersOutput{
+			LoadBalancers: []elbv2types.LoadBalancer{
+				{LoadBalancerArn: ptr(albA), DNSName: ptr("a-dns"), Type: elbv2types.LoadBalancerTypeEnumApplication},
+				{LoadBalancerArn: ptr(albB), DNSName: ptr("b-dns"), Type: elbv2types.LoadBalancerTypeEnumApplication},
+			},
+		}, nil)
+	cli.On("DescribeListeners", ctx, &awselbv2.DescribeListenersInput{LoadBalancerArn: ptr(albA)}).
+		Return(&awselbv2.DescribeListenersOutput{Listeners: nil}, nil)
+	cli.On("DescribeListeners", ctx, &awselbv2.DescribeListenersInput{LoadBalancerArn: ptr(albB)}).
+		Return(&awselbv2.DescribeListenersOutput{Listeners: nil}, nil)
+
+	lbs := []ecstypes.LoadBalancer{
+		{ContainerName: ptr("app"), ContainerPort: ptr(int32(80)), TargetGroupArn: ptr(tgArn)},
+	}
+
+	logger, logs := captureLogs()
+	result := composeEndpoints(ctx, lbs, cli, logger)
+
+	assert.NoError(t, result.TransientError)
+	assert.Empty(t, result.Endpoints)
+	assert.Contains(t, logs.String(), "multiple ALBs front the same TG")
+}
+
+func TestComposeEndpoints_NoForwardAction(t *testing.T) {
+	ctx := context.Background()
+	cli := &mockELBv2Client{}
+	tgArn := "arn:aws:elasticloadbalancing:us-east-1:123:targetgroup/tg/abc"
+	albArn := "arn:aws:elasticloadbalancing:us-east-1:123:loadbalancer/app/a/d1"
+
+	cli.On("DescribeTargetGroups", ctx, &awselbv2.DescribeTargetGroupsInput{TargetGroupArns: []string{tgArn}}).
+		Return(&awselbv2.DescribeTargetGroupsOutput{
+			TargetGroups: []elbv2types.TargetGroup{
+				{TargetGroupArn: ptr(tgArn), LoadBalancerArns: []string{albArn}},
+			},
+		}, nil)
+	cli.On("DescribeLoadBalancers", ctx, &awselbv2.DescribeLoadBalancersInput{LoadBalancerArns: []string{albArn}}).
+		Return(&awselbv2.DescribeLoadBalancersOutput{
+			LoadBalancers: []elbv2types.LoadBalancer{
+				{LoadBalancerArn: ptr(albArn), DNSName: ptr("a-dns"), Type: elbv2types.LoadBalancerTypeEnumApplication},
+			},
+		}, nil)
+	cli.On("DescribeListeners", ctx, &awselbv2.DescribeListenersInput{LoadBalancerArn: ptr(albArn)}).
+		Return(&awselbv2.DescribeListenersOutput{
+			Listeners: []elbv2types.Listener{
+				{
+					ListenerArn:    ptr("listener-1"),
+					Port:           ptr(int32(80)),
+					Protocol:       elbv2types.ProtocolEnumHttp,
+					DefaultActions: []elbv2types.Action{{Type: elbv2types.ActionTypeEnumRedirect}},
+				},
+			},
+		}, nil)
+
+	lbs := []ecstypes.LoadBalancer{
+		{ContainerName: ptr("app"), ContainerPort: ptr(int32(80)), TargetGroupArn: ptr(tgArn)},
+	}
+
+	logger, logs := captureLogs()
+	result := composeEndpoints(ctx, lbs, cli, logger)
+
+	assert.NoError(t, result.TransientError)
+	assert.Empty(t, result.Endpoints)
+	assert.Contains(t, logs.String(), "no HTTP(S) forward-action listener")
+}
+
+func TestComposeEndpoints_NLBProtocolListener(t *testing.T) {
+	ctx := context.Background()
+	cli := &mockELBv2Client{}
+	tgArn := "arn:aws:elasticloadbalancing:us-east-1:123:targetgroup/tg/abc"
+	albArn := "arn:aws:elasticloadbalancing:us-east-1:123:loadbalancer/app/a/d1"
+
+	cli.On("DescribeTargetGroups", ctx, &awselbv2.DescribeTargetGroupsInput{TargetGroupArns: []string{tgArn}}).
+		Return(&awselbv2.DescribeTargetGroupsOutput{
+			TargetGroups: []elbv2types.TargetGroup{
+				{TargetGroupArn: ptr(tgArn), LoadBalancerArns: []string{albArn}},
+			},
+		}, nil)
+	cli.On("DescribeLoadBalancers", ctx, &awselbv2.DescribeLoadBalancersInput{LoadBalancerArns: []string{albArn}}).
+		Return(&awselbv2.DescribeLoadBalancersOutput{
+			LoadBalancers: []elbv2types.LoadBalancer{
+				{LoadBalancerArn: ptr(albArn), DNSName: ptr("a-dns"), Type: elbv2types.LoadBalancerTypeEnumApplication},
+			},
+		}, nil)
+	cli.On("DescribeListeners", ctx, &awselbv2.DescribeListenersInput{LoadBalancerArn: ptr(albArn)}).
+		Return(&awselbv2.DescribeListenersOutput{
+			Listeners: []elbv2types.Listener{
+				{
+					ListenerArn:    ptr("listener-1"),
+					Port:           ptr(int32(443)),
+					Protocol:       elbv2types.ProtocolEnumTcp,
+					DefaultActions: []elbv2types.Action{{Type: elbv2types.ActionTypeEnumForward, TargetGroupArn: ptr(tgArn)}},
+				},
+			},
+		}, nil)
+
+	lbs := []ecstypes.LoadBalancer{
+		{ContainerName: ptr("app"), ContainerPort: ptr(int32(443)), TargetGroupArn: ptr(tgArn)},
+	}
+
+	logger, logs := captureLogs()
+	result := composeEndpoints(ctx, lbs, cli, logger)
+
+	assert.NoError(t, result.TransientError)
+	assert.Empty(t, result.Endpoints)
+	assert.Contains(t, logs.String(), "no HTTP(S) forward-action listener")
+}
+
+func TestComposeEndpoints_AmbiguousMultiListener(t *testing.T) {
+	ctx := context.Background()
+	cli := &mockELBv2Client{}
+	tgArn := "arn:aws:elasticloadbalancing:us-east-1:123:targetgroup/tg/abc"
+	albArn := "arn:aws:elasticloadbalancing:us-east-1:123:loadbalancer/app/a/d1"
+
+	cli.On("DescribeTargetGroups", ctx, &awselbv2.DescribeTargetGroupsInput{TargetGroupArns: []string{tgArn}}).
+		Return(&awselbv2.DescribeTargetGroupsOutput{
+			TargetGroups: []elbv2types.TargetGroup{
+				{TargetGroupArn: ptr(tgArn), LoadBalancerArns: []string{albArn}},
+			},
+		}, nil)
+	cli.On("DescribeLoadBalancers", ctx, &awselbv2.DescribeLoadBalancersInput{LoadBalancerArns: []string{albArn}}).
+		Return(&awselbv2.DescribeLoadBalancersOutput{
+			LoadBalancers: []elbv2types.LoadBalancer{
+				{LoadBalancerArn: ptr(albArn), DNSName: ptr("a-dns"), Type: elbv2types.LoadBalancerTypeEnumApplication},
+			},
+		}, nil)
+	cli.On("DescribeListeners", ctx, &awselbv2.DescribeListenersInput{LoadBalancerArn: ptr(albArn)}).
+		Return(&awselbv2.DescribeListenersOutput{
+			Listeners: []elbv2types.Listener{
+				{
+					ListenerArn:    ptr("listener-public"),
+					Port:           ptr(int32(443)),
+					Protocol:       elbv2types.ProtocolEnumHttps,
+					DefaultActions: []elbv2types.Action{{Type: elbv2types.ActionTypeEnumForward, TargetGroupArn: ptr(tgArn)}},
+				},
+				{
+					ListenerArn:    ptr("listener-admin"),
+					Port:           ptr(int32(8443)),
+					Protocol:       elbv2types.ProtocolEnumHttps,
+					DefaultActions: []elbv2types.Action{{Type: elbv2types.ActionTypeEnumForward, TargetGroupArn: ptr(tgArn)}},
+				},
+			},
+		}, nil)
+
+	lbs := []ecstypes.LoadBalancer{
+		{ContainerName: ptr("app"), ContainerPort: ptr(int32(443)), TargetGroupArn: ptr(tgArn)},
+	}
+
+	logger, logs := captureLogs()
+	result := composeEndpoints(ctx, lbs, cli, logger)
+
+	assert.NoError(t, result.TransientError)
+	assert.Empty(t, result.Endpoints)
+	assert.Contains(t, logs.String(), "ambiguous")
+	assert.Contains(t, logs.String(), "listener-public")
+	assert.Contains(t, logs.String(), "listener-admin")
+}
+
+func TestComposeEndpoints_MissingContainerNamePort(t *testing.T) {
+	ctx := context.Background()
+	cli := &mockELBv2Client{}
+	tgArn := "arn:aws:elasticloadbalancing:us-east-1:123:targetgroup/tg/abc"
+	albArn := "arn:aws:elasticloadbalancing:us-east-1:123:loadbalancer/app/a/d1"
+
+	cli.On("DescribeTargetGroups", ctx, &awselbv2.DescribeTargetGroupsInput{TargetGroupArns: []string{tgArn}}).
+		Return(&awselbv2.DescribeTargetGroupsOutput{
+			TargetGroups: []elbv2types.TargetGroup{
+				{TargetGroupArn: ptr(tgArn), LoadBalancerArns: []string{albArn}},
+			},
+		}, nil)
+	cli.On("DescribeLoadBalancers", ctx, &awselbv2.DescribeLoadBalancersInput{LoadBalancerArns: []string{albArn}}).
+		Return(&awselbv2.DescribeLoadBalancersOutput{
+			LoadBalancers: []elbv2types.LoadBalancer{
+				{LoadBalancerArn: ptr(albArn), DNSName: ptr("a-dns"), Type: elbv2types.LoadBalancerTypeEnumApplication},
+			},
+		}, nil)
+	cli.On("DescribeListeners", ctx, &awselbv2.DescribeListenersInput{LoadBalancerArn: ptr(albArn)}).
+		Return(&awselbv2.DescribeListenersOutput{
+			Listeners: []elbv2types.Listener{
+				{
+					ListenerArn:    ptr("listener-1"),
+					Port:           ptr(int32(443)),
+					Protocol:       elbv2types.ProtocolEnumHttps,
+					DefaultActions: []elbv2types.Action{{Type: elbv2types.ActionTypeEnumForward, TargetGroupArn: ptr(tgArn)}},
+				},
+			},
+		}, nil)
+
+	lbs := []ecstypes.LoadBalancer{
+		{ContainerName: nil, ContainerPort: ptr(int32(443)), TargetGroupArn: ptr(tgArn)},
+	}
+
+	logger, logs := captureLogs()
+	result := composeEndpoints(ctx, lbs, cli, logger)
+
+	assert.NoError(t, result.TransientError)
+	assert.Empty(t, result.Endpoints)
+	assert.Contains(t, logs.String(), "missing required fields")
+}
+
+func TestComposeEndpoints_TransientRetrySuccess(t *testing.T) {
+	ctx := context.Background()
+	cli := &mockELBv2Client{}
+	tgArn := "arn:aws:elasticloadbalancing:us-east-1:123:targetgroup/tg/abc"
+	albArn := "arn:aws:elasticloadbalancing:us-east-1:123:loadbalancer/app/a/d1"
+
+	cli.On("DescribeTargetGroups", ctx, &awselbv2.DescribeTargetGroupsInput{TargetGroupArns: []string{tgArn}}).
+		Return((*awselbv2.DescribeTargetGroupsOutput)(nil), awsAPIErr("Throttling", "rate exceeded")).Once()
+	cli.On("DescribeTargetGroups", ctx, &awselbv2.DescribeTargetGroupsInput{TargetGroupArns: []string{tgArn}}).
+		Return(&awselbv2.DescribeTargetGroupsOutput{
+			TargetGroups: []elbv2types.TargetGroup{
+				{TargetGroupArn: ptr(tgArn), LoadBalancerArns: []string{albArn}},
+			},
+		}, nil).Once()
+	cli.On("DescribeLoadBalancers", ctx, &awselbv2.DescribeLoadBalancersInput{LoadBalancerArns: []string{albArn}}).
+		Return(&awselbv2.DescribeLoadBalancersOutput{
+			LoadBalancers: []elbv2types.LoadBalancer{
+				{LoadBalancerArn: ptr(albArn), DNSName: ptr("a-dns"), Type: elbv2types.LoadBalancerTypeEnumApplication},
+			},
+		}, nil)
+	cli.On("DescribeListeners", ctx, &awselbv2.DescribeListenersInput{LoadBalancerArn: ptr(albArn)}).
+		Return(&awselbv2.DescribeListenersOutput{
+			Listeners: []elbv2types.Listener{
+				{
+					ListenerArn:    ptr("l1"),
+					Port:           ptr(int32(443)),
+					Protocol:       elbv2types.ProtocolEnumHttps,
+					DefaultActions: []elbv2types.Action{{Type: elbv2types.ActionTypeEnumForward, TargetGroupArn: ptr(tgArn)}},
+				},
+			},
+		}, nil)
+
+	lbs := []ecstypes.LoadBalancer{
+		{ContainerName: ptr("app"), ContainerPort: ptr(int32(443)), TargetGroupArn: ptr(tgArn)},
+	}
+
+	result := composeEndpoints(ctx, lbs, cli, testLogger())
+
+	assert.NoError(t, result.TransientError)
+	assert.Equal(t, map[string]string{"app:443": "https://a-dns:443"}, result.Endpoints)
+	cli.AssertExpectations(t)
+}
+
+func TestComposeEndpoints_TransientRetryExhausted(t *testing.T) {
+	ctx := context.Background()
+	cli := &mockELBv2Client{}
+	tgArn := "arn:aws:elasticloadbalancing:us-east-1:123:targetgroup/tg/abc"
+
+	cli.On("DescribeTargetGroups", ctx, &awselbv2.DescribeTargetGroupsInput{TargetGroupArns: []string{tgArn}}).
+		Return((*awselbv2.DescribeTargetGroupsOutput)(nil), awsAPIErr("Throttling", "rate exceeded")).Times(3)
+
+	lbs := []ecstypes.LoadBalancer{
+		{ContainerName: ptr("app"), ContainerPort: ptr(int32(443)), TargetGroupArn: ptr(tgArn)},
+	}
+
+	result := composeEndpoints(ctx, lbs, cli, testLogger())
+
+	assert.Error(t, result.TransientError)
+	assert.Empty(t, result.Endpoints)
+	cli.AssertExpectations(t)
+}
+
+func TestComposeEndpoints_AccessDeniedIsPermanentWithIAMHint(t *testing.T) {
+	ctx := context.Background()
+	cli := &mockELBv2Client{}
+	tgArn := "arn:aws:elasticloadbalancing:us-east-1:123:targetgroup/tg/abc"
+
+	cli.On("DescribeTargetGroups", ctx, &awselbv2.DescribeTargetGroupsInput{TargetGroupArns: []string{tgArn}}).
+		Return((*awselbv2.DescribeTargetGroupsOutput)(nil), awsAPIErr("AccessDenied", "missing permission")).Once()
+
+	lbs := []ecstypes.LoadBalancer{
+		{ContainerName: ptr("app"), ContainerPort: ptr(int32(443)), TargetGroupArn: ptr(tgArn)},
+	}
+
+	logger, logs := captureLogs()
+	result := composeEndpoints(ctx, lbs, cli, logger)
+
+	assert.NoError(t, result.TransientError)
+	assert.Empty(t, result.Endpoints)
+	assert.Contains(t, logs.String(), "iam_permission")
+	assert.Contains(t, logs.String(), "elbv2:Describe")
+	cli.AssertExpectations(t)
+}
+
+func TestComposeEndpoints_PartialMixedResult(t *testing.T) {
+	ctx := context.Background()
+	cli := &mockELBv2Client{}
+	tgGood := "arn:aws:elasticloadbalancing:us-east-1:123:targetgroup/good/abc"
+	tgRule := "arn:aws:elasticloadbalancing:us-east-1:123:targetgroup/rule-routed/abc"
+	tgTransient := "arn:aws:elasticloadbalancing:us-east-1:123:targetgroup/transient/abc"
+	albGood := "arn:aws:elasticloadbalancing:us-east-1:123:loadbalancer/app/a/g"
+	albRule := "arn:aws:elasticloadbalancing:us-east-1:123:loadbalancer/app/a/r"
+	albTransient := "arn:aws:elasticloadbalancing:us-east-1:123:loadbalancer/app/a/t"
+
+	cli.On("DescribeTargetGroups", ctx, &awselbv2.DescribeTargetGroupsInput{
+		TargetGroupArns: []string{tgGood, tgRule, tgTransient},
+	}).Return(&awselbv2.DescribeTargetGroupsOutput{
+		TargetGroups: []elbv2types.TargetGroup{
+			{TargetGroupArn: ptr(tgGood), LoadBalancerArns: []string{albGood}},
+			{TargetGroupArn: ptr(tgRule), LoadBalancerArns: []string{albRule}},
+			{TargetGroupArn: ptr(tgTransient), LoadBalancerArns: []string{albTransient}},
+		},
+	}, nil)
+
+	cli.On("DescribeLoadBalancers", ctx, &awselbv2.DescribeLoadBalancersInput{
+		LoadBalancerArns: []string{albGood, albRule, albTransient},
+	}).Return(&awselbv2.DescribeLoadBalancersOutput{
+		LoadBalancers: []elbv2types.LoadBalancer{
+			{LoadBalancerArn: ptr(albGood), DNSName: ptr("good-dns"), Type: elbv2types.LoadBalancerTypeEnumApplication},
+			{LoadBalancerArn: ptr(albRule), DNSName: ptr("rule-dns"), Type: elbv2types.LoadBalancerTypeEnumApplication},
+			{LoadBalancerArn: ptr(albTransient), DNSName: ptr("transient-dns"), Type: elbv2types.LoadBalancerTypeEnumApplication},
+		},
+	}, nil)
+
+	cli.On("DescribeListeners", ctx, &awselbv2.DescribeListenersInput{LoadBalancerArn: ptr(albGood)}).
+		Return(&awselbv2.DescribeListenersOutput{
+			Listeners: []elbv2types.Listener{{
+				ListenerArn:    ptr("l1"),
+				Port:           ptr(int32(443)),
+				Protocol:       elbv2types.ProtocolEnumHttps,
+				DefaultActions: []elbv2types.Action{{Type: elbv2types.ActionTypeEnumForward, TargetGroupArn: ptr(tgGood)}},
+			}},
+		}, nil)
+	cli.On("DescribeListeners", ctx, &awselbv2.DescribeListenersInput{LoadBalancerArn: ptr(albRule)}).
+		Return(&awselbv2.DescribeListenersOutput{
+			Listeners: []elbv2types.Listener{{
+				ListenerArn:    ptr("l-rule"),
+				Port:           ptr(int32(80)),
+				Protocol:       elbv2types.ProtocolEnumHttp,
+				DefaultActions: []elbv2types.Action{{Type: elbv2types.ActionTypeEnumRedirect}},
+			}},
+		}, nil)
+	cli.On("DescribeListeners", ctx, &awselbv2.DescribeListenersInput{LoadBalancerArn: ptr(albTransient)}).
+		Return((*awselbv2.DescribeListenersOutput)(nil), awsAPIErr("Throttling", "rate exceeded")).Times(3)
+
+	lbs := []ecstypes.LoadBalancer{
+		{ContainerName: ptr("good"), ContainerPort: ptr(int32(443)), TargetGroupArn: ptr(tgGood)},
+		{ContainerName: ptr("rule"), ContainerPort: ptr(int32(80)), TargetGroupArn: ptr(tgRule)},
+		{ContainerName: ptr("trans"), ContainerPort: ptr(int32(8080)), TargetGroupArn: ptr(tgTransient)},
+	}
+
+	logger, logs := captureLogs()
+	result := composeEndpoints(ctx, lbs, cli, logger)
+
+	assert.Error(t, result.TransientError, "expected TransientError to be set due to throttling on albTransient")
+	assert.Equal(t, map[string]string{"good:443": "https://good-dns:443"}, result.Endpoints)
+	assert.Contains(t, logs.String(), "no HTTP(S) forward-action listener")
+	cli.AssertExpectations(t)
+}
+
+func TestComposeEndpoints_DuplicateKeyLastWins(t *testing.T) {
+	ctx := context.Background()
+	cli := &mockELBv2Client{}
+	tg1 := "arn:aws:elasticloadbalancing:us-east-1:123:targetgroup/tg1/abc"
+	tg2 := "arn:aws:elasticloadbalancing:us-east-1:123:targetgroup/tg2/abc"
+	alb1 := "arn:aws:elasticloadbalancing:us-east-1:123:loadbalancer/app/a/1"
+	alb2 := "arn:aws:elasticloadbalancing:us-east-1:123:loadbalancer/app/a/2"
+
+	cli.On("DescribeTargetGroups", ctx, &awselbv2.DescribeTargetGroupsInput{TargetGroupArns: []string{tg1, tg2}}).
+		Return(&awselbv2.DescribeTargetGroupsOutput{
+			TargetGroups: []elbv2types.TargetGroup{
+				{TargetGroupArn: ptr(tg1), LoadBalancerArns: []string{alb1}},
+				{TargetGroupArn: ptr(tg2), LoadBalancerArns: []string{alb2}},
+			},
+		}, nil)
+	cli.On("DescribeLoadBalancers", ctx, &awselbv2.DescribeLoadBalancersInput{LoadBalancerArns: []string{alb1, alb2}}).
+		Return(&awselbv2.DescribeLoadBalancersOutput{
+			LoadBalancers: []elbv2types.LoadBalancer{
+				{LoadBalancerArn: ptr(alb1), DNSName: ptr("dns-1"), Type: elbv2types.LoadBalancerTypeEnumApplication},
+				{LoadBalancerArn: ptr(alb2), DNSName: ptr("dns-2"), Type: elbv2types.LoadBalancerTypeEnumApplication},
+			},
+		}, nil)
+	cli.On("DescribeListeners", ctx, &awselbv2.DescribeListenersInput{LoadBalancerArn: ptr(alb1)}).
+		Return(&awselbv2.DescribeListenersOutput{
+			Listeners: []elbv2types.Listener{{
+				ListenerArn:    ptr("l1"),
+				Port:           ptr(int32(443)),
+				Protocol:       elbv2types.ProtocolEnumHttps,
+				DefaultActions: []elbv2types.Action{{Type: elbv2types.ActionTypeEnumForward, TargetGroupArn: ptr(tg1)}},
+			}},
+		}, nil)
+	cli.On("DescribeListeners", ctx, &awselbv2.DescribeListenersInput{LoadBalancerArn: ptr(alb2)}).
+		Return(&awselbv2.DescribeListenersOutput{
+			Listeners: []elbv2types.Listener{{
+				ListenerArn:    ptr("l2"),
+				Port:           ptr(int32(80)),
+				Protocol:       elbv2types.ProtocolEnumHttp,
+				DefaultActions: []elbv2types.Action{{Type: elbv2types.ActionTypeEnumForward, TargetGroupArn: ptr(tg2)}},
+			}},
+		}, nil)
+
+	lbs := []ecstypes.LoadBalancer{
+		{ContainerName: ptr("app"), ContainerPort: ptr(int32(80)), TargetGroupArn: ptr(tg1)},
+		{ContainerName: ptr("app"), ContainerPort: ptr(int32(80)), TargetGroupArn: ptr(tg2)},
+	}
+
+	logger, logs := captureLogs()
+	result := composeEndpoints(ctx, lbs, cli, logger)
+
+	assert.NoError(t, result.TransientError)
+	// Last-write-wins. Note: TG ARN map iteration order may vary; either
+	// "http://dns-2:80" (tg2 last) or "http://dns-1:443" (tg1 last) is
+	// acceptable so long as exactly one key/value pair is present and the
+	// warning is logged.
+	assert.Len(t, result.Endpoints, 1)
+	assert.Contains(t, result.Endpoints, "app:80")
+	assert.Contains(t, logs.String(), "duplicate key resolves to different URLs")
+	cli.AssertExpectations(t)
+}

--- a/pkg/cfres/ecs/phase.go
+++ b/pkg/cfres/ecs/phase.go
@@ -7,6 +7,7 @@ package ecs
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -219,9 +220,24 @@ func (s *Service) finalSuccess(ctx context.Context, req *resource.StatusRequest,
 			return s.inProgressOrTimeout(op, req, unixStart,
 				"deployment stable; waiting for healthy targets: "+msg), nil
 		}
+
+		// Endpoint composition gate. Transient AWS errors here block Phase B
+		// Success on the next polling tick rather than fanning out to
+		// consumer fast-fail. Permanent failures (rule-routed, NLB-only,
+		// AccessDenied, etc.) populate missing keys in the map; consumers
+		// requesting those keys fast-fail with a clear diagnostic.
+		composed := composeEndpoints(ctx, svc.LoadBalancers, elbCli, slog.Default())
+		if composed.TransientError != nil {
+			return s.inProgressOrTimeout(op, req, unixStart,
+				"deployment stable; waiting for endpoint composition: "+composed.TransientError.Error()), nil
+		}
+		// composed.Endpoints is intentionally not threaded through here —
+		// the subsequent Read invocation re-derives the same map via
+		// readWithClient, and that becomes the authoritative copy. If we
+		// passed composed.Endpoints into the ProgressResult directly we'd
+		// risk inconsistency with the persisted state on the next sync Read.
 	}
 
-	// Build canonical NativeID.
 	canonical := buildCanonicalNativeID(aws.ToString(svc.ServiceArn),
 		deriveClusterShortName(req.NativeID, svc))
 	readResult, readErr := s.Read(ctx, &resource.ReadRequest{

--- a/pkg/cfres/ecs/phase_test.go
+++ b/pkg/cfres/ecs/phase_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/config"
 )
 
 func TestCheckPhaseA_InProgress(t *testing.T) {
@@ -559,4 +560,233 @@ func TestStatusPhaseB_UpdateNoNewDeployment_PastGrace_NoopUpdate_Success(t *test
 	assert.Equal(t, resource.OperationStatusSuccess, res.ProgressResult.OperationStatus,
 		"no-op Update past grace with stable existing primary should report Success")
 	assert.Equal(t, resource.OperationUpdate, res.ProgressResult.Operation)
+}
+
+func TestStatusPhaseB_TransientComposeError_ReturnsInProgress(t *testing.T) {
+	ctx := context.Background()
+	mockECS := &mockECSClient{}
+	mockELB := &mockELBv2Client{}
+
+	tgArn := "arn:aws:elasticloadbalancing:us-east-1:123:targetgroup/tg/abc"
+
+	// Service is stable + TG healthy — passes existing Phase B gates.
+	now := time.Now()
+	mockECS.On("DescribeServices", ctx, mock.Anything).Return(&awsecs.DescribeServicesOutput{
+		Services: []ecstypes.Service{{
+			ServiceArn:   ptr("arn:aws:ecs:us-east-1:123:service/cluster1/svc1"),
+			ClusterArn:   ptr("arn:aws:ecs:us-east-1:123:cluster/cluster1"),
+			Status:       ptr("ACTIVE"),
+			DesiredCount: 1,
+			RunningCount: 1,
+			Deployments: []ecstypes.Deployment{
+				{
+					Status:       ptr("PRIMARY"),
+					RolloutState: ecstypes.DeploymentRolloutStateCompleted,
+					CreatedAt:    &now,
+				},
+			},
+			LoadBalancers: []ecstypes.LoadBalancer{
+				{ContainerName: ptr("app"), ContainerPort: ptr(int32(443)), TargetGroupArn: ptr(tgArn)},
+			},
+		}},
+	}, nil)
+
+	// TG health passes.
+	mockELB.On("DescribeTargetHealth", ctx, mock.Anything).Return(&awselbv2.DescribeTargetHealthOutput{
+		TargetHealthDescriptions: []elbv2types.TargetHealthDescription{
+			{TargetHealth: &elbv2types.TargetHealth{State: elbv2types.TargetHealthStateEnumHealthy}},
+		},
+	}, nil)
+
+	// composeEndpoints' DescribeTargetGroups all 3 retries throttle.
+	mockELB.On("DescribeTargetGroups", ctx, mock.Anything).
+		Return((*awselbv2.DescribeTargetGroupsOutput)(nil), awsAPIErr("Throttling", "rate exceeded")).Times(3)
+
+	svc := &Service{
+		cfg:                nil,
+		ecsClientFactory:   func(_ *config.Config) (ecsClient, error) { return mockECS, nil },
+		elbv2ClientFactory: func(_ *config.Config) (elbv2Client, error) { return mockELB, nil },
+		now:                time.Now,
+		operationTimeout:   20 * time.Minute,
+		finalReadGrace:     2 * time.Minute,
+	}
+
+	result, _ := svc.statusPhaseB(ctx, &resource.StatusRequest{
+		NativeID:     "cluster1|svc1",
+		ResourceType: "AWS::ECS::Service",
+		RequestID:    "formae-ecs/create/1234567890/ccapi-tok",
+	}, resource.OperationCreate, time.Now().Unix(), "cluster1", "svc1")
+
+	assert.NotNil(t, result.ProgressResult)
+	assert.Equal(t, resource.OperationStatusInProgress, result.ProgressResult.OperationStatus,
+		"expected InProgress when composeEndpoints reports TransientError")
+}
+
+func TestStatusPhaseB_HappyPath_PopulatesEndpointsViaRead(t *testing.T) {
+	ctx := context.Background()
+	mockCCX := &mockCCXClient{}
+	mockECS := &mockECSClient{}
+	mockELB := &mockELBv2Client{}
+
+	tgArn := "arn:aws:elasticloadbalancing:us-east-1:123:targetgroup/tg/abc"
+	albArn := "arn:aws:elasticloadbalancing:us-east-1:123:loadbalancer/app/a/1"
+	serviceArn := "arn:aws:ecs:us-east-1:123:service/cluster1/svc1"
+
+	mockECS.On("DescribeServices", ctx, mock.Anything).Return(&awsecs.DescribeServicesOutput{
+		Services: []ecstypes.Service{{
+			ServiceArn:   ptr(serviceArn),
+			ClusterArn:   ptr("arn:aws:ecs:us-east-1:123:cluster/cluster1"),
+			Status:       ptr("ACTIVE"),
+			DesiredCount: 1,
+			RunningCount: 1,
+			Deployments: []ecstypes.Deployment{{
+				Status:       ptr("PRIMARY"),
+				RolloutState: ecstypes.DeploymentRolloutStateCompleted,
+			}},
+			LoadBalancers: []ecstypes.LoadBalancer{
+				{ContainerName: ptr("app"), ContainerPort: ptr(int32(443)), TargetGroupArn: ptr(tgArn)},
+			},
+		}},
+	}, nil)
+
+	mockELB.On("DescribeTargetHealth", ctx, mock.Anything).Return(&awselbv2.DescribeTargetHealthOutput{
+		TargetHealthDescriptions: []elbv2types.TargetHealthDescription{
+			{TargetHealth: &elbv2types.TargetHealth{State: elbv2types.TargetHealthStateEnumHealthy}},
+		},
+	}, nil)
+	mockELB.On("DescribeTargetGroups", ctx, mock.Anything).Return(&awselbv2.DescribeTargetGroupsOutput{
+		TargetGroups: []elbv2types.TargetGroup{{TargetGroupArn: ptr(tgArn), LoadBalancerArns: []string{albArn}}},
+	}, nil)
+	mockELB.On("DescribeLoadBalancers", ctx, mock.Anything).Return(&awselbv2.DescribeLoadBalancersOutput{
+		LoadBalancers: []elbv2types.LoadBalancer{
+			{LoadBalancerArn: ptr(albArn), DNSName: ptr("dns-1"), Type: elbv2types.LoadBalancerTypeEnumApplication},
+		},
+	}, nil)
+	mockELB.On("DescribeListeners", ctx, mock.Anything).Return(&awselbv2.DescribeListenersOutput{
+		Listeners: []elbv2types.Listener{{
+			ListenerArn:    ptr("l1"),
+			Port:           ptr(int32(443)),
+			Protocol:       elbv2types.ProtocolEnumHttps,
+			DefaultActions: []elbv2types.Action{{Type: elbv2types.ActionTypeEnumForward, TargetGroupArn: ptr(tgArn)}},
+		}},
+	}, nil)
+
+	// CCAPI Read returns the persisted service properties; the readWithClient
+	// post-processor (which uses elbv2ClientFactory) injects the Endpoints map.
+	mockCCX.On("ReadResource", ctx, mock.Anything).Return(&resource.ReadResult{
+		ResourceType: "AWS::ECS::Service",
+		Properties: `{
+			"ServiceArn": "` + serviceArn + `",
+			"Cluster": "arn:aws:ecs:us-east-1:123:cluster/cluster1",
+			"LoadBalancers": [{"ContainerName":"app","ContainerPort":443,"TargetGroupArn":"` + tgArn + `"}]
+		}`,
+	}, nil)
+
+	svc := &Service{
+		cfg:                nil,
+		ccxClientFactory:   func(_ *config.Config) (ccxClient, error) { return mockCCX, nil },
+		ecsClientFactory:   func(_ *config.Config) (ecsClient, error) { return mockECS, nil },
+		elbv2ClientFactory: func(_ *config.Config) (elbv2Client, error) { return mockELB, nil },
+		now:                time.Now,
+		operationTimeout:   20 * time.Minute,
+		finalReadGrace:     2 * time.Minute,
+	}
+
+	result, _ := svc.statusPhaseB(ctx, &resource.StatusRequest{
+		NativeID:     "cluster1|svc1",
+		ResourceType: "AWS::ECS::Service",
+		RequestID:    "formae-ecs/create/1234567890/ccapi-tok",
+	}, resource.OperationCreate, time.Now().Unix(), "cluster1", "svc1")
+
+	assert.NotNil(t, result.ProgressResult)
+	assert.Equal(t, resource.OperationStatusSuccess, result.ProgressResult.OperationStatus)
+	assert.Contains(t, string(result.ProgressResult.ResourceProperties), `"Endpoints":{"app:443":"https://dns-1:443"}`)
+}
+
+func TestStatusPhaseB_TransientClearsAcrossPolls(t *testing.T) {
+	ctx := context.Background()
+	mockCCX := &mockCCXClient{}
+	mockECS := &mockECSClient{}
+	mockELB := &mockELBv2Client{}
+
+	tgArn := "arn:aws:elasticloadbalancing:us-east-1:123:targetgroup/tg/abc"
+	albArn := "arn:aws:elasticloadbalancing:us-east-1:123:loadbalancer/app/a/1"
+
+	mockECS.On("DescribeServices", ctx, mock.Anything).Return(&awsecs.DescribeServicesOutput{
+		Services: []ecstypes.Service{{
+			ServiceArn:   ptr("arn:aws:ecs:us-east-1:123:service/cluster1/svc1"),
+			ClusterArn:   ptr("arn:aws:ecs:us-east-1:123:cluster/cluster1"),
+			Status:       ptr("ACTIVE"),
+			DesiredCount: 1,
+			RunningCount: 1,
+			Deployments: []ecstypes.Deployment{{
+				Status:       ptr("PRIMARY"),
+				RolloutState: ecstypes.DeploymentRolloutStateCompleted,
+			}},
+			LoadBalancers: []ecstypes.LoadBalancer{
+				{ContainerName: ptr("app"), ContainerPort: ptr(int32(443)), TargetGroupArn: ptr(tgArn)},
+			},
+		}},
+	}, nil)
+	mockELB.On("DescribeTargetHealth", ctx, mock.Anything).Return(&awselbv2.DescribeTargetHealthOutput{
+		TargetHealthDescriptions: []elbv2types.TargetHealthDescription{
+			{TargetHealth: &elbv2types.TargetHealth{State: elbv2types.TargetHealthStateEnumHealthy}},
+		},
+	}, nil)
+
+	// First poll: DescribeTargetGroups throttles all 3 retries.
+	mockELB.On("DescribeTargetGroups", ctx, mock.Anything).
+		Return((*awselbv2.DescribeTargetGroupsOutput)(nil), awsAPIErr("Throttling", "rate exceeded")).Times(3)
+
+	// Second poll: success for both the endpoint-composition gate and the subsequent
+	// Read (readWithClient also calls composeEndpoints internally), so register twice.
+	mockELB.On("DescribeTargetGroups", ctx, mock.Anything).Return(&awselbv2.DescribeTargetGroupsOutput{
+		TargetGroups: []elbv2types.TargetGroup{{TargetGroupArn: ptr(tgArn), LoadBalancerArns: []string{albArn}}},
+	}, nil).Times(2)
+	mockELB.On("DescribeLoadBalancers", ctx, mock.Anything).Return(&awselbv2.DescribeLoadBalancersOutput{
+		LoadBalancers: []elbv2types.LoadBalancer{
+			{LoadBalancerArn: ptr(albArn), DNSName: ptr("dns-1"), Type: elbv2types.LoadBalancerTypeEnumApplication},
+		},
+	}, nil)
+	mockELB.On("DescribeListeners", ctx, mock.Anything).Return(&awselbv2.DescribeListenersOutput{
+		Listeners: []elbv2types.Listener{{
+			ListenerArn:    ptr("l1"),
+			Port:           ptr(int32(443)),
+			Protocol:       elbv2types.ProtocolEnumHttps,
+			DefaultActions: []elbv2types.Action{{Type: elbv2types.ActionTypeEnumForward, TargetGroupArn: ptr(tgArn)}},
+		}},
+	}, nil)
+	mockCCX.On("ReadResource", ctx, mock.Anything).Return(&resource.ReadResult{
+		ResourceType: "AWS::ECS::Service",
+		Properties: `{
+			"ServiceArn": "arn:aws:ecs:us-east-1:123:service/cluster1/svc1",
+			"Cluster": "arn:aws:ecs:us-east-1:123:cluster/cluster1",
+			"LoadBalancers": [{"ContainerName":"app","ContainerPort":443,"TargetGroupArn":"` + tgArn + `"}]
+		}`,
+	}, nil)
+
+	svc := &Service{
+		cfg:                nil,
+		ccxClientFactory:   func(_ *config.Config) (ccxClient, error) { return mockCCX, nil },
+		ecsClientFactory:   func(_ *config.Config) (ecsClient, error) { return mockECS, nil },
+		elbv2ClientFactory: func(_ *config.Config) (elbv2Client, error) { return mockELB, nil },
+		now:                time.Now,
+		operationTimeout:   20 * time.Minute,
+		finalReadGrace:     2 * time.Minute,
+	}
+
+	// Poll 1: transient → InProgress.
+	r1, _ := svc.statusPhaseB(ctx, &resource.StatusRequest{
+		NativeID: "cluster1|svc1", ResourceType: "AWS::ECS::Service",
+		RequestID: "formae-ecs/create/1234567890/ccapi-tok",
+	}, resource.OperationCreate, time.Now().Unix(), "cluster1", "svc1")
+	assert.Equal(t, resource.OperationStatusInProgress, r1.ProgressResult.OperationStatus)
+
+	// Poll 2: composeEndpoints succeeds → Success.
+	r2, _ := svc.statusPhaseB(ctx, &resource.StatusRequest{
+		NativeID: "cluster1|svc1", ResourceType: "AWS::ECS::Service",
+		RequestID: "formae-ecs/create/1234567890/ccapi-tok",
+	}, resource.OperationCreate, time.Now().Unix(), "cluster1", "svc1")
+	assert.Equal(t, resource.OperationStatusSuccess, r2.ProgressResult.OperationStatus)
+	assert.Contains(t, string(r2.ProgressResult.ResourceProperties), `"Endpoints":{"app:443":"https://dns-1:443"}`)
 }

--- a/pkg/cfres/ecs/service.go
+++ b/pkg/cfres/ecs/service.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
 	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/cfres/prov"
 	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/cfres/registry"
@@ -112,32 +113,78 @@ func (s *Service) readWithClient(ctx context.Context, client ccxReadClient, requ
 		return nil, fmt.Errorf("parsing Service properties: %w", err)
 	}
 
-	cluster, _ := props["Cluster"].(string)
-	if cluster == "" || strings.HasPrefix(cluster, "arn:") {
-		return result, nil
+	// Cluster ARN re-inflation (legacy behavior).
+	if cluster, ok := props["Cluster"].(string); ok && cluster != "" && !strings.HasPrefix(cluster, "arn:") {
+		serviceArn, _ := props["ServiceArn"].(string)
+		partition, region, account, parsed := parseEcsArn(serviceArn)
+		if !parsed {
+			slog.Debug("AWS::ECS::Service Read: skipping Cluster ARN re-inflation, ServiceArn unparseable",
+				"cluster", cluster, "serviceArn", serviceArn, "nativeID", request.NativeID)
+		} else {
+			props["Cluster"] = fmt.Sprintf("arn:%s:ecs:%s:%s:cluster/%s", partition, region, account, cluster)
+		}
 	}
 
-	// Derive region + account from ServiceArn (format:
-	// arn:<partition>:ecs:<region>:<account>:service/<cluster>/<service>).
-	// If ServiceArn is missing or malformed we can't safely reconstruct the
-	// ARN — leave the short name in place and log enough to find it later.
-	serviceArn, _ := props["ServiceArn"].(string)
-	partition, region, account, ok := parseEcsArn(serviceArn)
-	if !ok {
-		slog.Debug("AWS::ECS::Service Read: skipping Cluster ARN re-inflation, ServiceArn unparseable",
-			"cluster", cluster, "serviceArn", serviceArn, "nativeID", request.NativeID)
-		return result, nil
+	// Endpoint composition: derive `Endpoints` from `LoadBalancers[]`.
+	if s.elbv2ClientFactory != nil {
+		lbs := decodeLoadBalancersFromProps(props)
+		elb, err := s.elbv2ClientFactory(s.cfg)
+		if err != nil {
+			return nil, fmt.Errorf("building ELBv2 client for endpoint composition: %w", err)
+		}
+		composed := composeEndpoints(ctx, lbs, elb, slog.Default())
+		if composed.TransientError != nil {
+			// Surface as a recoverable plugin error so ResolveCache and the
+			// sync loop retry the Plugin Read. Do not return partial
+			// Endpoints data — preserve last-known-good in persisted state.
+			return &resource.ReadResult{
+				ResourceType: result.ResourceType,
+				ErrorCode:    resource.OperationErrorCodeThrottling,
+			}, nil
+		}
+		props["Endpoints"] = composed.Endpoints
 	}
-	props["Cluster"] = fmt.Sprintf("arn:%s:ecs:%s:%s:cluster/%s", partition, region, account, cluster)
 
 	out, err := json.Marshal(props)
 	if err != nil {
-		return nil, fmt.Errorf("marshaling re-inflated Service properties: %w", err)
+		return nil, fmt.Errorf("marshaling Service properties: %w", err)
 	}
 	return &resource.ReadResult{
 		ResourceType: result.ResourceType,
 		Properties:   string(out),
 	}, nil
+}
+
+// decodeLoadBalancersFromProps converts the JSON-shaped LoadBalancers field
+// from the CCAPI Read response into the ECS SDK LoadBalancer type for use
+// with composeEndpoints. Returns nil if the field is missing or malformed.
+func decodeLoadBalancersFromProps(props map[string]any) []ecstypes.LoadBalancer {
+	raw, ok := props["LoadBalancers"].([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]ecstypes.LoadBalancer, 0, len(raw))
+	for _, item := range raw {
+		m, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		entry := ecstypes.LoadBalancer{}
+		if v, ok := m["ContainerName"].(string); ok && v != "" {
+			vc := v
+			entry.ContainerName = &vc
+		}
+		if v, ok := m["ContainerPort"].(float64); ok {
+			vi := int32(v)
+			entry.ContainerPort = &vi
+		}
+		if v, ok := m["TargetGroupArn"].(string); ok && v != "" {
+			vc := v
+			entry.TargetGroupArn = &vc
+		}
+		out = append(out, entry)
+	}
+	return out
 }
 
 // parseEcsArn splits any ECS ARN (cluster, service, task-set, ...) into its

--- a/pkg/cfres/ecs/service_mock_test.go
+++ b/pkg/cfres/ecs/service_mock_test.go
@@ -72,3 +72,24 @@ func (m *mockELBv2Client) DescribeTargetHealth(ctx context.Context, params *awse
 	out, _ := args.Get(0).(*awselbv2.DescribeTargetHealthOutput)
 	return out, args.Error(1)
 }
+
+func (m *mockELBv2Client) DescribeTargetGroups(ctx context.Context, params *awselbv2.DescribeTargetGroupsInput,
+	optFns ...func(*awselbv2.Options)) (*awselbv2.DescribeTargetGroupsOutput, error) {
+	args := m.Called(ctx, params)
+	out, _ := args.Get(0).(*awselbv2.DescribeTargetGroupsOutput)
+	return out, args.Error(1)
+}
+
+func (m *mockELBv2Client) DescribeLoadBalancers(ctx context.Context, params *awselbv2.DescribeLoadBalancersInput,
+	optFns ...func(*awselbv2.Options)) (*awselbv2.DescribeLoadBalancersOutput, error) {
+	args := m.Called(ctx, params)
+	out, _ := args.Get(0).(*awselbv2.DescribeLoadBalancersOutput)
+	return out, args.Error(1)
+}
+
+func (m *mockELBv2Client) DescribeListeners(ctx context.Context, params *awselbv2.DescribeListenersInput,
+	optFns ...func(*awselbv2.Options)) (*awselbv2.DescribeListenersOutput, error) {
+	args := m.Called(ctx, params)
+	out, _ := args.Get(0).(*awselbv2.DescribeListenersOutput)
+	return out, args.Error(1)
+}

--- a/pkg/cfres/ecs/service_test.go
+++ b/pkg/cfres/ecs/service_test.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 	"time"
 
+	awselbv2 "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	elbv2types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
@@ -381,4 +383,129 @@ func TestService_Create_SyncSuccess_RewritesToInProgress(t *testing.T) {
 	assert.Equal(t, resource.OperationStatusInProgress, res.ProgressResult.OperationStatus)
 	assert.Nil(t, res.ProgressResult.ResourceProperties)
 	assert.Equal(t, "formae-ecs/create/1747526400/ccapi-tA", res.ProgressResult.RequestID)
+}
+
+func TestRead_PopulatesEndpoints_HappyPath(t *testing.T) {
+	ctx := context.Background()
+	mockCCX := &mockCCXReadClient{}
+	mockELB := &mockELBv2Client{}
+
+	tgArn := "arn:aws:elasticloadbalancing:us-east-1:123:targetgroup/tg/abc"
+	albArn := "arn:aws:elasticloadbalancing:us-east-1:123:loadbalancer/app/a/1"
+
+	mockCCX.On("ReadResource", ctx, mock.Anything).Return(&resource.ReadResult{
+		ResourceType: "AWS::ECS::Service",
+		Properties: `{
+			"ServiceArn": "arn:aws:ecs:us-east-1:123:service/clusterA/svc1",
+			"Cluster": "clusterA",
+			"LoadBalancers": [
+				{"ContainerName":"app","ContainerPort":443,"TargetGroupArn":"` + tgArn + `"}
+			]
+		}`,
+	}, nil)
+
+	mockELB.On("DescribeTargetGroups", ctx, &awselbv2.DescribeTargetGroupsInput{TargetGroupArns: []string{tgArn}}).
+		Return(&awselbv2.DescribeTargetGroupsOutput{
+			TargetGroups: []elbv2types.TargetGroup{{TargetGroupArn: ptr(tgArn), LoadBalancerArns: []string{albArn}}},
+		}, nil)
+	mockELB.On("DescribeLoadBalancers", ctx, &awselbv2.DescribeLoadBalancersInput{LoadBalancerArns: []string{albArn}}).
+		Return(&awselbv2.DescribeLoadBalancersOutput{
+			LoadBalancers: []elbv2types.LoadBalancer{
+				{LoadBalancerArn: ptr(albArn), DNSName: ptr("dns-1"), Type: elbv2types.LoadBalancerTypeEnumApplication},
+			},
+		}, nil)
+	mockELB.On("DescribeListeners", ctx, &awselbv2.DescribeListenersInput{LoadBalancerArn: ptr(albArn)}).
+		Return(&awselbv2.DescribeListenersOutput{
+			Listeners: []elbv2types.Listener{{
+				ListenerArn:    ptr("l1"),
+				Port:           ptr(int32(443)),
+				Protocol:       elbv2types.ProtocolEnumHttps,
+				DefaultActions: []elbv2types.Action{{Type: elbv2types.ActionTypeEnumForward, TargetGroupArn: ptr(tgArn)}},
+			}},
+		}, nil)
+
+	svc := &Service{
+		cfg:                nil,
+		elbv2ClientFactory: func(_ *config.Config) (elbv2Client, error) { return mockELB, nil },
+		now:                time.Now,
+	}
+
+	out, err := svc.readWithClient(ctx, mockCCX, &resource.ReadRequest{
+		NativeID:     "clusterA|svc1",
+		ResourceType: "AWS::ECS::Service",
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, out)
+	assert.Contains(t, out.Properties, `"Endpoints":{"app:443":"https://dns-1:443"}`)
+}
+
+func TestRead_TransientError_ReturnsRecoverablePluginError(t *testing.T) {
+	ctx := context.Background()
+	mockCCX := &mockCCXReadClient{}
+	mockELB := &mockELBv2Client{}
+
+	tgArn := "arn:aws:elasticloadbalancing:us-east-1:123:targetgroup/tg/abc"
+
+	mockCCX.On("ReadResource", ctx, mock.Anything).Return(&resource.ReadResult{
+		ResourceType: "AWS::ECS::Service",
+		Properties: `{
+			"ServiceArn": "arn:aws:ecs:us-east-1:123:service/clusterA/svc1",
+			"Cluster": "arn:aws:ecs:us-east-1:123:cluster/clusterA",
+			"LoadBalancers": [
+				{"ContainerName":"app","ContainerPort":443,"TargetGroupArn":"` + tgArn + `"}
+			]
+		}`,
+	}, nil)
+
+	// All 3 retries throttle.
+	mockELB.On("DescribeTargetGroups", ctx, mock.Anything).
+		Return((*awselbv2.DescribeTargetGroupsOutput)(nil), awsAPIErr("Throttling", "rate exceeded")).Times(3)
+
+	svc := &Service{
+		cfg:                nil,
+		elbv2ClientFactory: func(_ *config.Config) (elbv2Client, error) { return mockELB, nil },
+		now:                time.Now,
+	}
+
+	out, err := svc.readWithClient(ctx, mockCCX, &resource.ReadRequest{
+		NativeID:     "clusterA|svc1",
+		ResourceType: "AWS::ECS::Service",
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, out)
+	// Recoverable plugin error code surfaced; no Endpoints in the response.
+	assert.Equal(t, resource.OperationErrorCodeThrottling, out.ErrorCode)
+	assert.Empty(t, out.Properties)
+}
+
+func TestRead_EmptyLoadBalancers_EmitsEmptyEndpoints(t *testing.T) {
+	ctx := context.Background()
+	mockCCX := &mockCCXReadClient{}
+	mockELB := &mockELBv2Client{}
+
+	mockCCX.On("ReadResource", ctx, mock.Anything).Return(&resource.ReadResult{
+		ResourceType: "AWS::ECS::Service",
+		Properties: `{
+			"ServiceArn": "arn:aws:ecs:us-east-1:123:service/clusterA/svc1",
+			"Cluster": "arn:aws:ecs:us-east-1:123:cluster/clusterA",
+			"LoadBalancers": []
+		}`,
+	}, nil)
+
+	// composeEndpoints should make ZERO API calls for empty LBs.
+
+	svc := &Service{
+		cfg:                nil,
+		elbv2ClientFactory: func(_ *config.Config) (elbv2Client, error) { return mockELB, nil },
+		now:                time.Now,
+	}
+
+	out, err := svc.readWithClient(ctx, mockCCX, &resource.ReadRequest{
+		NativeID:     "clusterA|svc1",
+		ResourceType: "AWS::ECS::Service",
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, out)
+	assert.Contains(t, out.Properties, `"Endpoints":{}`)
+	mockELB.AssertExpectations(t)
 }

--- a/schema/pkl/ecs/service.pkl
+++ b/schema/pkl/ecs/service.pkl
@@ -199,6 +199,40 @@ open class VpcLatticeConfiguration extends formae.SubResource {
     targetGroupArn: String|formae.Resolvable
 }
 
+/// Resolvable accessor for AWS::ECS::Service. Use via `service.res.<property>`.
+open class ServiceResolvable extends formae.Resolvable {
+    local _self = this
+
+    hidden type = module.type
+
+    hidden id: ServiceResolvable = (this) {
+        property = "ServiceArn"
+    }
+
+    hidden arn: ServiceResolvable = (this) {
+        property = "ServiceArn"
+    }
+
+    hidden serviceArn: ServiceResolvable = (this) {
+        property = "ServiceArn"
+    }
+
+    /// LB-attached endpoints discovered from this service's `loadBalancers[]`.
+    /// Use at() to access individual endpoints by `containerName:containerPort`:
+    ///   service.res.endpoints.at("grafana:3000")
+    /// Resolves only after the Service reaches Success (deployment stable +
+    /// TG health + endpoint composition). For services without LB attachments
+    /// or with unsupported topologies (listener rules, NLB-only, multi-listener
+    /// ambiguity), specific keys may be absent — consumers fast-fail with
+    /// FailedToResolveValue. See the design doc for the full taxonomy.
+    hidden endpoints: formae.MappingResolvable = new formae.MappingResolvable {
+        label = _self.label
+        type = _self.type
+        stack = _self.stack
+        property = "Endpoints"
+    }
+}
+
 @aws.ResourceHint {
     type = module.type
     identifier = "Ref"
@@ -297,4 +331,19 @@ open class Service extends formae.Resource {
     // CC is expected to return [] on Read here too. Annotated defensively.
     @aws.FieldHint{hasProviderDefault = true}
     vpcLatticeConfigurations: Listing<VpcLatticeConfiguration>?
+
+    /// LB-attached endpoints discovered from this service's load balancer
+    /// registrations, keyed by "containerName:containerPort"
+    /// (e.g. "grafana:3000"). Values are reachable URLs composed from the
+    /// fronting ALB's DNSName, listener protocol, and listener port. Computed
+    /// by formae-plugin-aws — do not set manually.
+    @aws.FieldHint{hasProviderDefault = true}
+    endpoints: Mapping<String, String>?
+
+    hidden parent = this
+
+    hidden res: ServiceResolvable = new {
+        label = parent.label
+        stack = parent.stack?.label
+    }
 }

--- a/schema/pkl/elasticloadbalancingv2/listenerrule.pkl
+++ b/schema/pkl/elasticloadbalancingv2/listenerrule.pkl
@@ -137,6 +137,36 @@ open class TargetGroupTuple extends formae.SubResource {
     weight: Int?
 }
 
+open class ListenerRuleResolvable extends formae.Resolvable {
+    local _self = this
+    hidden type = module.type
+
+    hidden id: ListenerRuleResolvable = (this) {
+        property = "RuleArn"
+    }
+
+    hidden arn: ListenerRuleResolvable = (this) {
+        property = "RuleArn"
+    }
+
+    hidden ruleArn: ListenerRuleResolvable = (this) {
+        property = "RuleArn"
+    }
+
+    /// ARN of the target group attached to the listener via this rule's
+    /// first forward action. Prefer this over `tg.res.targetGroupArn` when a
+    /// downstream resource (e.g. ECS::Service) needs the target group to
+    /// already be wired to the load balancer via a listener rule — AWS
+    /// rejects ECS service creation with "target group does not have an
+    /// associated load balancer" if the service is created before the rule
+    /// attaches the TG. Referencing through the rule creates the correct
+    /// create/destroy ordering (same pattern as `listener.res.targetGroupArn`
+    /// for default-action forwarding).
+    hidden targetGroupArn: ListenerRuleResolvable = (this) {
+        property = "Actions.0.TargetGroupArn"
+    }
+}
+
 @aws.ResourceHint {
     type = module.type
     identifier = "RuleArn"
@@ -160,4 +190,11 @@ open class ListenerRule extends formae.Resource {
 
     @aws.FieldHint
     priority: Int
+
+    hidden parent = this
+
+    hidden res: ListenerRuleResolvable = new {
+        label = parent.label
+        stack = parent.stack?.label
+    }
 }

--- a/schema/pkl/elasticloadbalancingv2/loadbalancer.pkl
+++ b/schema/pkl/elasticloadbalancingv2/loadbalancer.pkl
@@ -86,8 +86,13 @@ open class LoadBalancer extends formae.Resource {
     @aws.FieldHint
     minimumLoadBalancerCapacity: Dynamic?
 
+    /// Load balancer name. AWS hard limit: 1-32 characters, alphanumerics
+    /// and hyphens only (the alphanumeric/hyphen restriction is not enforced
+    /// here yet; only the length cap is). Catching length violations at Pkl
+    /// eval time gives users an immediate, actionable error instead of a
+    /// CCAPI ValidationException ~20s into apply.
     @aws.FieldHint{createOnly = true}
-    name: String?
+    name: String(length <= 32)?
 
     @aws.FieldHint{createOnly = true}
     scheme: String?

--- a/testdata/ecs-service-with-lb-rule-routing.pkl
+++ b/testdata/ecs-service-with-lb-rule-routing.pkl
@@ -1,0 +1,318 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/ec2/vpc.pkl"
+import "@aws/ec2/subnet.pkl"
+import "@aws/ec2/internetgateway.pkl"
+import "@aws/ec2/vpcgatewayattachment.pkl"
+import "@aws/ec2/routetable.pkl"
+import "@aws/ec2/route.pkl"
+import "@aws/ec2/subnetroutetableassociation.pkl"
+import "@aws/ec2/securitygroup.pkl"
+import "@aws/ec2/securitygroupingress.pkl"
+import "@aws/elasticloadbalancingv2/loadbalancer.pkl"
+import "@aws/elasticloadbalancingv2/targetgroup.pkl"
+import "@aws/elasticloadbalancingv2/listener.pkl"
+import "@aws/elasticloadbalancingv2/listenerrule.pkl"
+import "@aws/ecs/ecscluster.pkl"
+import "@aws/ecs/taskdefinition.pkl"
+import "@aws/ecs/service.pkl"
+
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local stackName = "plugin-sdk-test-ecs-svc-lb-rule-\(testRunID)"
+
+// VPC + multi-AZ Subnets for FARGATE awsvpc networking + ALB (ALB requires
+// at least two subnets in different AZs).
+local testVpc = new vpc.VPC {
+  label = "test-vpc-for-ecs-svc-lb-rule"
+  cidrBlock = "10.232.0.0/16"
+  enableDnsSupport = true
+}
+
+local testSubnetA = new subnet.Subnet {
+  label = "test-subnet-a-for-ecs-svc-lb-rule"
+  vpcId = testVpc.res.vpcId
+  cidrBlock = "10.232.1.0/24"
+  availabilityZone = "us-east-1a"
+}
+
+local testSubnetB = new subnet.Subnet {
+  label = "test-subnet-b-for-ecs-svc-lb-rule"
+  vpcId = testVpc.res.vpcId
+  cidrBlock = "10.232.2.0/24"
+  availabilityZone = "us-east-1b"
+}
+
+// Internet routing: IGW + VPCGatewayAttachment + RouteTable + default Route +
+// per-subnet associations. FARGATE tasks need a public-IP egress path to pull
+// container images from Docker Hub / ECR Public (no NAT in this fixture, so
+// the service uses assignPublicIp=ENABLED below).
+local testIgw = new internetgateway.InternetGateway {
+  label = "test-igw-for-ecs-svc-lb-rule"
+}
+
+local testIgwAttachment = new vpcgatewayattachment.VPCGatewayAttachment {
+  label = "test-igw-attachment-for-ecs-svc-lb-rule"
+  vpcId = testVpc.res.vpcId
+  internetGatewayId = testIgw.res.internetGatewayId
+}
+
+local testRouteTable = new routetable.RouteTable {
+  label = "test-routetable-for-ecs-svc-lb-rule"
+  vpcId = testVpc.res.vpcId
+}
+
+local testDefaultRoute = new route.Route {
+  label = "test-default-route-for-ecs-svc-lb-rule"
+  routeTableId = testRouteTable.res.routeTableId
+  destinationCidrBlock = "0.0.0.0/0"
+  gatewayId = testIgw.res.internetGatewayId
+}
+
+local testSubnetAAssoc = new subnetroutetableassociation.SubnetRouteTableAssociation {
+  label = "test-subnet-a-rtassoc-for-ecs-svc-lb-rule"
+  subnetId = testSubnetA.res.subnetId
+  routeTableId = testRouteTable.res.routeTableId
+}
+
+local testSubnetBAssoc = new subnetroutetableassociation.SubnetRouteTableAssociation {
+  label = "test-subnet-b-rtassoc-for-ecs-svc-lb-rule"
+  subnetId = testSubnetB.res.subnetId
+  routeTableId = testRouteTable.res.routeTableId
+}
+
+// ALB security group + inbound :80 from anywhere.
+local albSG = new securitygroup.SecurityGroup {
+  label = "test-alb-sg-for-ecs-svc-lb-rule"
+  groupDescription = "Allow HTTP to internal ALB for ECS Service rule-routing conformance test"
+  groupName = "formae-sdk-test-alb-sg-rule-\(testRunID)"
+  vpcId = testVpc.res.vpcId
+}
+
+local albIngress = new securitygroupingress.SecurityGroupIngress {
+  label = "test-alb-sg-ingress-for-ecs-svc-lb-rule"
+  groupId = albSG.res.groupId
+  ipProtocol = "tcp"
+  fromPort = 80
+  toPort = 80
+  cidrIp = "0.0.0.0/0"
+}
+
+// Tasks security group + inbound :80 from the ALB SG.
+local tasksSG = new securitygroup.SecurityGroup {
+  label = "test-tasks-sg-for-ecs-svc-lb-rule"
+  groupDescription = "Allow HTTP from ALB to ECS tasks for rule-routing conformance test"
+  groupName = "formae-sdk-test-tasks-sg-rule-\(testRunID)"
+  vpcId = testVpc.res.vpcId
+}
+
+local tasksIngress = new securitygroupingress.SecurityGroupIngress {
+  label = "test-tasks-sg-ingress-for-ecs-svc-lb-rule"
+  groupId = tasksSG.res.groupId
+  ipProtocol = "tcp"
+  fromPort = 80
+  toPort = 80
+  sourceSecurityGroupId = albSG.res.groupId
+}
+
+// Internal ALB across the two subnets.
+local testALB = new loadbalancer.LoadBalancer {
+  label = "test-alb-for-ecs-svc-rule"
+  name = "formae-sdk-test-alb-rule-\(testRunID)"
+  scheme = "internal"
+  type = "application"
+  subnets {
+    testSubnetA.res.subnetId
+    testSubnetB.res.subnetId
+  }
+  securityGroups {
+    albSG.res.groupId
+  }
+}
+
+// Target Group (target-type=ip for FARGATE awsvpc).
+local appTg = new targetgroup.TargetGroup {
+  label = "test-tg-for-ecs-svc-rule"
+  name = "formae-sdk-test-tg-rule-\(testRunID)"
+  port = 80
+  protocol = "HTTP"
+  targetType = "ip"
+  vpcId = testVpc.res.vpcId
+}
+
+// Listener on :80 with a fixed-response 404 default action.
+// The ECS Service still registers with the TG, but the TG is only reachable
+// via the ListenerRule below — not via the default action. This means
+// composeEndpoints (v1) will classify the TG as having no HTTP(S)
+// forward-action on the default listener action, so Endpoints will be empty.
+local appListener = new listener.Listener {
+  label = "lb-rule-listener"
+  loadBalancerArn = testALB.res.loadBalancerArn
+  port = 80
+  protocol = "HTTP"
+  defaultActions = new Listing {
+    new listener.Action {
+      type = "fixed-response"
+      fixedResponseConfig = new listener.FixedResponseConfig {
+        statusCode = "404"
+        contentType = "text/plain"
+        messageBody = "Not Found"
+      }
+    }
+  }
+}
+
+// ListenerRule forwarding /api/* to the TG.
+local apiRule = new listenerrule.ListenerRule {
+  label = "lb-api-rule"
+  listenerArn = appListener.res.listenerArn
+  priority = 10
+  conditions = new Listing {
+    new listenerrule.Condition {
+      field = "path-pattern"
+      pathPatternConfig = new listenerrule.PathPatternConfig {
+        values = new Listing { "/api/*" }
+      }
+    }
+  }
+  actions = new Listing {
+    new listenerrule.Action {
+      type = "forward"
+      targetGroupArn = appTg.res.targetGroupArn
+    }
+  }
+}
+
+// ECS Cluster.
+local testCluster = new ecscluster.Cluster {
+  label = "test-cluster-for-ecs-svc-lb-rule"
+  clusterName = "formae-sdk-test-svc-lb-rule-cluster-\(testRunID)"
+  clusterSettings {
+    new {
+      name = "containerInsights"
+      value = "disabled"
+    }
+  }
+}
+
+// ECS TaskDefinition (FARGATE, awsvpc, nginx:latest on port 80).
+local testTaskDef = new taskdefinition.TaskDefinition {
+  label = "test-taskdef-for-ecs-svc-lb-rule"
+  family = "formae-sdk-test-svc-lb-rule-taskdef-\(testRunID)"
+  requiresCompatibilities {
+    "FARGATE"
+  }
+  networkMode = "awsvpc"
+  cpu = "256"
+  memory = "512"
+  containerDefinitions {
+    new {
+      name = "test-container"
+      image = "nginx:latest"
+      essential = true
+      portMappings {
+        new {
+          containerPort = 80
+          protocol = "tcp"
+        }
+      }
+    }
+  }
+}
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for ECS Service with rule-routed ALB (default action is fixed-response 404)"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  // Network plumbing.
+  testVpc
+  testSubnetA
+  testSubnetB
+
+  // Internet routing so FARGATE tasks can pull container images.
+  testIgw
+  testIgwAttachment
+  testRouteTable
+  testDefaultRoute
+  testSubnetAAssoc
+  testSubnetBAssoc
+
+  // Security groups (declared before the ALB & service that consume them).
+  albSG
+  albIngress
+  tasksSG
+  tasksIngress
+
+  // Load balancer, target group, listener (fixed-response default action),
+  // and rule forwarding /api/* to the TG.
+  testALB
+  appTg
+  appListener
+  apiRule
+
+  // ECS plumbing.
+  testCluster
+  testTaskDef
+
+  // ECS Service under test -- registers with the TG so Phase B health gate
+  // is exercised. The listener's default action is fixed-response so
+  // composeEndpoints (v1) will leave Endpoints empty for this service.
+  //
+  // assignPublicIp=ENABLED is required: there is no NAT gateway in this
+  // fixture, so tasks reach the public internet (Docker Hub / ECR Public)
+  // via the IGW + default route + public IPs on their ENIs.
+  new service.Service {
+    label = "plugin-sdk-test-ecs-service-with-lb-rule"
+    serviceName = "formae-sdk-test-svc-lb-rule-\(testRunID)"
+    cluster = testCluster.res.arn
+    taskDefinition = new formae.Resolvable {
+      label = testTaskDef.label
+      type = "AWS::ECS::TaskDefinition"
+      property = "TaskDefinitionArn"
+    }
+    desiredCount = 1
+    schedulingStrategy = "REPLICA"
+    launchType = "FARGATE"
+    networkConfiguration = new service.NetworkConfiguration {
+      awsvpcConfiguration = new service.AwsVpcConfiguration {
+        assignPublicIp = "ENABLED"
+        subnets {
+          testSubnetA.res.subnetId
+          testSubnetB.res.subnetId
+        }
+        securityGroups {
+          tasksSG.res.groupId
+        }
+      }
+    }
+    loadBalancers {
+      new service.LoadBalancer {
+        containerName = "test-container"
+        containerPort = 80
+        targetGroupArn = appTg.res.targetGroupArn
+      }
+    }
+    healthCheckGracePeriodSeconds = 60
+    deploymentConfiguration = new service.DeploymentConfiguration {
+      maximumPercent = 200
+      minimumHealthyPercent = 100
+    }
+  }
+}

--- a/testdata/ecs-service-with-lb-rule-routing.pkl
+++ b/testdata/ecs-service-with-lb-rule-routing.pkl
@@ -306,7 +306,14 @@ forma {
       new service.LoadBalancer {
         containerName = "test-container"
         containerPort = 80
-        targetGroupArn = appTg.res.targetGroupArn
+        // Route the TG ref through the ListenerRule's resolvable so formae's
+        // DAG orders Service create AFTER the rule attaches the TG to the
+        // ALB. Same pattern as the default-action variant in
+        // ecs-service-with-lb.pkl (which uses `listener.res.targetGroupArn`).
+        // Without this indirection, the Service races the rule and AWS
+        // rejects with "target group does not have an associated load
+        // balancer."
+        targetGroupArn = apiRule.res.targetGroupArn
       }
     }
     healthCheckGracePeriodSeconds = 60

--- a/testdata/ecs-service-with-lb-rule-routing.pkl
+++ b/testdata/ecs-service-with-lb-rule-routing.pkl
@@ -126,7 +126,11 @@ local tasksIngress = new securitygroupingress.SecurityGroupIngress {
 // Internal ALB across the two subnets.
 local testALB = new loadbalancer.LoadBalancer {
   label = "test-alb-for-ecs-svc-rule"
-  name = "formae-sdk-test-alb-rule-\(testRunID)"
+  // AWS ALB name max length is 32 characters. Prefix "formae-sdk-test-alb-r-"
+  // (22 chars) + 8-char run UUID = 30 chars. Keep this trimmed; longer
+  // suffixes like "alb-rule-" push past the limit and CCAPI rejects with
+  // ValidationException in ~20s.
+  name = "formae-sdk-test-alb-r-\(testRunID)"
   scheme = "internal"
   type = "application"
   subnets {


### PR DESCRIPTION
## Summary

Exposes `service.res.endpoints.at("containerName:containerPort")` on `AWS::ECS::Service` so downstream consumers (Grafana targets, hub URL, future Route53 wiring) wire their config URL through the service rather than through the listener. Phase B's deployment-stability + TG-health gating then blocks downstream resolvables until the service is actually serving — fixes the fresh-apply race where `listener.res.url` resolves seconds before tasks are healthy.

- New `composeEndpoints` helper (`pkg/cfres/ecs/endpoints.go`) walks each `loadBalancers[]` entry, batch-describes its TG/ALB, and finds the unique HTTP(S) forward-action listener to compose `scheme://albDns:port`. Returns `ComposeResult{Endpoints, TransientError}`.
- Phase B `finalSuccess` gate: `TransientError != nil` → `InProgress` (the existing polling cadence becomes the retry budget, absorbing ELB blips).
- Service `Read` path: `TransientError != nil` → recoverable plugin error (`OperationErrorCodeThrottling`) so ResolveCache and the sync loop retry the Plugin Read without overwriting persisted state.
- Permanent failures (rule-routed-only, NLB-only, multi-listener ambiguity, `AccessDenied`) → missing keys in the persisted map; consumers requesting those keys fast-fail with `FailedToResolveValue` and a clear log diagnostic (`AccessDenied` is enriched with an IAM remediation hint).
- Internal retries: 3× / 500ms-1s-2s backoff against ELBv2 describes. `isTransient` uses `smithy.APIError` — a bug discovered mid-implementation where an ad-hoc interface mismatch caused `AccessDenied` to be misclassified as transient was also fixed.
- Conformance fixture `ecs-service-with-lb-rule-routing.pkl` exercises the rule-routed unsupported-topology path (Service reaches Success with empty endpoints; consumers fast-fail).

## Out of scope (v1.5+ follow-ups)

Listener-rule traversal (path / host-based routing), weighted TGs, NLB endpoint composition, Route53 alias preference. Design notes for these and the propagation-lag / IAM-taxonomy / outage-envelope known limitations live in `~/dev/personal/engineering-notes/formae-plugin-aws/design/`.

## Test coverage

19 new unit tests across `endpoints_test.go`, `service_test.go`, `phase_test.go`; full ECS unit suite (~8s) passes; `make lint` clean; `make build` clean.