### PR TITLE
fix(schema): order SG ingress/egress destroy after workloads via parent

### DIFF
--- a/schema/pkl/ec2/securitygroupegress.pkl
+++ b/schema/pkl/ec2/securitygroupegress.pkl
@@ -14,6 +14,15 @@ const type = "AWS::EC2::SecurityGroupEgress"
 @aws.ResourceHint {
     type = module.type
     identifier = "Id"
+    parent = "AWS::EC2::SecurityGroup"
+    parentRefs = new formae.ParentRef {
+        parentProperty = "GroupId"
+        childProperty = "GroupId"
+    }
+    listParam = new formae.ListProperty {
+        parentProperty = "GroupId"
+        listParameter = "GroupId"
+    }
 }
 open class SecurityGroupEgress extends formae.Resource {
     @aws.FieldHint{createOnly = true}

--- a/schema/pkl/ec2/securitygroupingress.pkl
+++ b/schema/pkl/ec2/securitygroupingress.pkl
@@ -14,6 +14,15 @@ const type = "AWS::EC2::SecurityGroupIngress"
 @aws.ResourceHint {
     type = module.type
     identifier = "Id"
+    parent = "AWS::EC2::SecurityGroup"
+    parentRefs = new formae.ParentRef {
+        parentProperty = "GroupId"
+        childProperty = "GroupId"
+    }
+    listParam = new formae.ListProperty {
+        parentProperty = "GroupId"
+        listParameter = "GroupId"
+    }
 }
 open class SecurityGroupIngress extends formae.Resource {
 


### PR DESCRIPTION
## Summary

- `AWS::EC2::SecurityGroupIngress` and `AWS::EC2::SecurityGroupEgress` had no incoming edges in the destroy DAG and dispatched as DAG sources. Deleting SG rules in the first destroy wave severs connectivity to workloads behind the SG (ALB→task health checks, task→EFS NFS, task→internet) and cascade-fails the downstream cleanup chain.
- Adds `parent = "AWS::EC2::SecurityGroup"` plus `parentRefs` and `listParam` on `GroupId` to both schemas, mirroring `efs/mounttarget.pkl` — the working precedent. The parent-implies-child-edge semantic then orders SG rules after any workload referencing the SG: **workload → SG rules → SG itself**.

## Validation

- `make lint` — 0 issues
- `make build` — clean
- `go test -tags unit ./...` — all pass
- `make verify-schema` — 227 modules, 224 types, PASSED
- Debug-conformance on this branch — all green:
  - `ec2-securitygroupingress` ✅ (full CRUD + update phase)
  - `ec2-securitygroupegress` ✅ (full CRUD + update phase)
  - `ecs-service-with-lb` ✅ (44m, the shape closest to the live evidence: SG + rules behind ALB+task)

The unit suite does not exercise destroy ordering — the destroy DAG behavior is validated by the conformance lifecycle tests and end-to-end via re-applying a stack that exercises SG + rules + workload.