### PR TITLE
fix(schema): mark SG-reference fields as runtimeDependency edges

### DIFF
--- a/schema/pkl/apprunner/vpcconnector.pkl
+++ b/schema/pkl/apprunner/vpcconnector.pkl
@@ -28,7 +28,7 @@ open class VpcConnectorResolvable extends formae.Resolvable {
 }
 open class VpcConnector extends formae.Resource {
 
-    @aws.FieldHint{createOnly = true}
+    @aws.FieldHint{edgeKind = "runtimeDependency"; createOnly = true}
     securityGroups: Listing<String|formae.Resolvable>?
 
     @aws.FieldHint{required = true; createOnly = true}

--- a/schema/pkl/ec2/clientvpnendpoint.pkl
+++ b/schema/pkl/ec2/clientvpnendpoint.pkl
@@ -89,7 +89,7 @@ open class ClientVpnEndpoint extends formae.Resource {
     @aws.FieldHint
     dnsServers: Listing<String>?
 
-    @aws.FieldHint
+    @aws.FieldHint { edgeKind = "runtimeDependency" }
     securityGroupIds: Listing<String|formae.Resolvable>?
 
     @aws.FieldHint

--- a/schema/pkl/ec2/instance.pkl
+++ b/schema/pkl/ec2/instance.pkl
@@ -263,7 +263,7 @@ open class Instance extends formae.Resource {
     @aws.FieldHint
     ramdiskId: (String|formae.Resolvable)?
 
-    @aws.FieldHint
+    @aws.FieldHint { edgeKind = "runtimeDependency" }
     securityGroupIds: Listing<String|formae.Resolvable>?
 
     @aws.FieldHint{createOnly = true}

--- a/schema/pkl/ec2/instanceconnectendpoint.pkl
+++ b/schema/pkl/ec2/instanceconnectendpoint.pkl
@@ -26,7 +26,7 @@ open class InstanceConnectEndpoint extends formae.Resource {
     @aws.FieldHint{createOnly = true}
     preserveClientIp: (Boolean|formae.Resolvable)?
 
-    @aws.FieldHint{createOnly = true}
+    @aws.FieldHint{edgeKind = "runtimeDependency"; createOnly = true}
     securityGroupIds: Listing<String|formae.Resolvable>?
 
     @aws.FieldHint{createOnly = true}

--- a/schema/pkl/ec2/launchtemplate.pkl
+++ b/schema/pkl/ec2/launchtemplate.pkl
@@ -221,7 +221,9 @@ open class LaunchTemplateData extends formae.SubResource {
     placement: Placement?
     privateDnsNameOptions: PrivateDnsNameOptions?
     ramDiskId: (String|formae.Resolvable)?
+    @aws.FieldHint { edgeKind = "runtimeDependency" }
     securityGroupIds: Listing<String|formae.Resolvable>?
+    @aws.FieldHint { edgeKind = "runtimeDependency" }
     securityGroups: Listing<String|formae.Resolvable>?
     tagSpecifications: Listing<TagSpecification>?
     userData: String?

--- a/schema/pkl/ec2/spotfleet.pkl
+++ b/schema/pkl/ec2/spotfleet.pkl
@@ -78,6 +78,7 @@ open class LaunchTemplateSpecification extends formae.SubResource {
 
 @aws.SubResourceHint
 open class SecurityGroupIdentifier extends formae.SubResource {
+    @aws.FieldHint { edgeKind = "runtimeDependency" }
     groupId: String|formae.Resolvable
 }
 

--- a/schema/pkl/ec2/verifiedaccessendpoint.pkl
+++ b/schema/pkl/ec2/verifiedaccessendpoint.pkl
@@ -70,7 +70,7 @@ open class VerifiedAccessEndpoint extends formae.Resource {
     @aws.FieldHint
     policyEnabled: Boolean?
 
-    @aws.FieldHint{createOnly = true}
+    @aws.FieldHint{edgeKind = "runtimeDependency"; createOnly = true}
     securityGroupIds: Listing<String|formae.Resolvable>?
 
     @aws.FieldHint

--- a/schema/pkl/ec2/vpcendpoint.pkl
+++ b/schema/pkl/ec2/vpcendpoint.pkl
@@ -49,7 +49,7 @@ open class VPCEndpoint extends formae.Resource {
     @aws.FieldHint { hasProviderDefault = true }
     routeTableIds: Listing<String|formae.Resolvable>?
 
-    @aws.FieldHint { hasProviderDefault = true }
+    @aws.FieldHint { edgeKind = "runtimeDependency"; hasProviderDefault = true }
     securityGroupIds: Listing<String|formae.Resolvable>?
 
     @aws.FieldHint{createOnly = true}

--- a/schema/pkl/ecs/expressgatewayservice.pkl
+++ b/schema/pkl/ecs/expressgatewayservice.pkl
@@ -59,6 +59,7 @@ open class ScalingTarget extends formae.SubResource {
 
 @aws.SubResourceHint
 open class NetworkConfiguration extends formae.SubResource {
+    @aws.FieldHint { edgeKind = "runtimeDependency" }
     securityGroups: Listing<String|formae.Resolvable>?
     subnets: Listing<String|formae.Resolvable>?
 }

--- a/schema/pkl/ecs/service.pkl
+++ b/schema/pkl/ecs/service.pkl
@@ -24,7 +24,7 @@ typealias SchedulingStrategy = "DAEMON"|"REPLICA"
 @aws.SubResourceHint
 open class AwsVpcConfiguration extends formae.SubResource {
     assignPublicIp: AwsVpcConfigurationAssignPublicIp?
-    @aws.FieldHint{hasProviderDefault = true}
+    @aws.FieldHint{edgeKind = "runtimeDependency"; hasProviderDefault = true}
     securityGroups: Listing<String|formae.Resolvable>?
     subnets: Listing<String|formae.Resolvable>?
 }

--- a/schema/pkl/ecs/taskset.pkl
+++ b/schema/pkl/ecs/taskset.pkl
@@ -20,7 +20,7 @@ open class AWSVpcConfiguration extends formae.SubResource {
     // caller doesn't specify one, so without this hint an unchanged
     // TaskSet reapply produces a phantom diff on the CreateOnly
     // NetworkConfiguration and forces a full replacement.
-    @aws.FieldHint{hasProviderDefault = true}
+    @aws.FieldHint{edgeKind = "runtimeDependency"; hasProviderDefault = true}
     securityGroups: Listing<String|formae.Resolvable>?
     subnets: Listing<String|formae.Resolvable>
 }

--- a/schema/pkl/efs/mounttarget.pkl
+++ b/schema/pkl/efs/mounttarget.pkl
@@ -52,7 +52,7 @@ open class MountTarget extends formae.Resource {
     }
     ipAddress: String?
 
-    @aws.FieldHint
+    @aws.FieldHint { edgeKind = "runtimeDependency" }
     securityGroups: Listing<String|formae.Resolvable>
 
     @aws.FieldHint{createOnly = true}

--- a/schema/pkl/eks/ekscluster.pkl
+++ b/schema/pkl/eks/ekscluster.pkl
@@ -115,7 +115,7 @@ open class ResourcesVpcConfig extends formae.SubResource {
     endpointPublicAccess: Boolean?
     @aws.FieldHint{hasProviderDefault = true}
     publicAccessCidrs: Listing<String>?
-    @aws.FieldHint{hasProviderDefault = true}
+    @aws.FieldHint{edgeKind = "runtimeDependency"; hasProviderDefault = true}
     securityGroupIds: Listing<String|formae.Resolvable>?
     subnetIds: Listing<String|formae.Resolvable>
 }

--- a/schema/pkl/elasticloadbalancingv2/loadbalancer.pkl
+++ b/schema/pkl/elasticloadbalancingv2/loadbalancer.pkl
@@ -97,7 +97,7 @@ open class LoadBalancer extends formae.Resource {
     @aws.FieldHint{createOnly = true}
     scheme: String?
 
-    @aws.FieldHint{hasProviderDefault = true}
+    @aws.FieldHint{edgeKind = "runtimeDependency"; hasProviderDefault = true}
     securityGroups: Listing<String|formae.Resolvable>?
 
     @aws.FieldHint{hasProviderDefault = true}

--- a/schema/pkl/lambda/func.pkl
+++ b/schema/pkl/lambda/func.pkl
@@ -102,6 +102,7 @@ open class TracingConfig extends formae.SubResource {
 @aws.SubResourceHint
 open class VPCConfig extends formae.SubResource {
     ipv6AllowedForDualStack: Boolean?
+    @aws.FieldHint { edgeKind = "runtimeDependency" }
     securityGroupIds: Listing<String|formae.Resolvable>?
     subnetIds: Listing<String|formae.Resolvable>?
 }

--- a/schema/pkl/rds/dbcluster.pkl
+++ b/schema/pkl/rds/dbcluster.pkl
@@ -297,7 +297,7 @@ open class DBCluster extends formae.Resource {
     }
     useLatestRestorableTime: Boolean?
 
-    @aws.FieldHint
+    @aws.FieldHint { edgeKind = "runtimeDependency" }
     vpcSecurityGroupIds: Listing<String|formae.Resolvable>?
 
     hidden parent = this

--- a/schema/pkl/rds/dbinstance.pkl
+++ b/schema/pkl/rds/dbinstance.pkl
@@ -374,6 +374,7 @@ open class DBInstance extends formae.Resource {
     useLatestRestorableTime: Boolean?
 
     @aws.FieldHint{
+        edgeKind = "runtimeDependency"
         outputField = "VPCSecurityGroups"
         hasProviderDefault = true
     }

--- a/schema/pkl/rds/dbproxy.pkl
+++ b/schema/pkl/rds/dbproxy.pkl
@@ -93,7 +93,7 @@ open class DBProxy extends formae.Resource {
     }
     tags: Listing<aws.Tag>?
 
-    @aws.FieldHint
+    @aws.FieldHint { edgeKind = "runtimeDependency" }
     vpcSecurityGroupIds: (Listing<String|formae.Resolvable>)?
 
     @aws.FieldHint{createOnly = true}

--- a/schema/pkl/rds/dbproxyendpoint.pkl
+++ b/schema/pkl/rds/dbproxyendpoint.pkl
@@ -70,7 +70,7 @@ open class DBProxyEndpoint extends formae.Resource {
     targetRole: DBProxyEndpointTargetRole?
 
 
-    @aws.FieldHint
+    @aws.FieldHint { edgeKind = "runtimeDependency" }
     vpcSecurityGroupIds: (Listing<String|formae.Resolvable>)?
 
 

--- a/schema/pkl/sagemaker/domain.pkl
+++ b/schema/pkl/sagemaker/domain.pkl
@@ -77,6 +77,7 @@ open class DefaultSpaceSettings extends formae.SubResource {
     jupyterLabAppSettings: JupyterLabAppSettings?
     jupyterServerAppSettings: JupyterServerAppSettings?
     kernelGatewayAppSettings: KernelGatewayAppSettings?
+    @aws.FieldHint { edgeKind = "runtimeDependency" }
     securityGroups: (Listing<String|formae.Resolvable>)?
     spaceStorageSettings: SpaceStorageSettings?
 }
@@ -98,6 +99,7 @@ open class DomainSettings extends formae.SubResource {
     dockerSettings: DockerSettings?
     executionRoleIdentityConfig: ExecutionRoleIdentityConfig?
     rStudioServerProDomainSettings: RStudioServerProDomainSettings?
+    @aws.FieldHint { edgeKind = "runtimeDependency" }
     securityGroupIds: (Listing<String|formae.Resolvable>)?
 }
 
@@ -197,6 +199,7 @@ open class DefaultUserSettings extends formae.SubResource {
     kernelGatewayAppSettings: KernelGatewayAppSettings?
     rSessionAppSettings: RSessionAppSettings?
     rStudioServerProAppSettings: RStudioServerProAppSettings?
+    @aws.FieldHint { edgeKind = "runtimeDependency" }
     securityGroups: (Listing<String|formae.Resolvable>)?
     sharingSettings: SharingSettings?
     spaceStorageSettings: SpaceStorageSettings?

--- a/schema/pkl/sagemaker/userprofile.pkl
+++ b/schema/pkl/sagemaker/userprofile.pkl
@@ -149,6 +149,7 @@ open class UserSettings extends formae.SubResource {
     jupyterServerAppSettings: JupyterServerAppSettings?
     kernelGatewayAppSettings: KernelGatewayAppSettings?
     rStudioServerProAppSettings: RStudioServerProAppSettings?
+    @aws.FieldHint { edgeKind = "runtimeDependency" }
     securityGroups: Listing<String|formae.Resolvable>?
     sharingSettings: SharingSettings?
     spaceStorageSettings: DefaultSpaceStorageSettings?

--- a/schema/pkl/secretsmanager/rotationschedule.pkl
+++ b/schema/pkl/secretsmanager/rotationschedule.pkl
@@ -22,6 +22,7 @@ open class HostedRotationLambda extends formae.SubResource {
     runtime: String?
     superuserSecretArn: (String|formae.Resolvable)?
     superuserSecretKmsKeyArn: (String|formae.Resolvable)?
+    @aws.FieldHint { edgeKind = "runtimeDependency" }
     vpcSecurityGroupIds: (String|formae.Resolvable)?
     vpcSubnetIds: (String|formae.Resolvable)?
 }


### PR DESCRIPTION
## Summary

- Without an `edgeKind` annotation on the consumer-side fields that reference a SecurityGroup, the parent-implies-child-edge logic in the destroy DAG does not fire — so the child-side `parent` annotation on SG ingress/egress rules (which landed in `0.1.11-dev.2`) has no effect on destroy ordering. SG rules stay as DAG leaves, dispatch in the first wave, and sever connectivity before the workloads behind the SG can clean up.
- Annotates every consumer-side SG ID field across the plugin schema with `edgeKind = "runtimeDependency"`. **22 fields across 17 resource types**: ECS Service/TaskSet/ExpressGatewayService, Lambda VPCConfig, EKS Cluster, EFS MountTarget, ELBv2 LoadBalancer, EC2 Instance/LaunchTemplate/SpotFleet/VPCEndpoint/ClientVpnEndpoint/VerifiedAccessEndpoint/InstanceConnectEndpoint, AppRunner VpcConnector, SageMaker Domain/UserProfile, RDS DBCluster/DBInstance/DBProxy/DBProxyEndpoint, SecretsManager RotationSchedule.
- For `EC2::SpotFleet.securityGroups: Listing<SecurityGroupIdentifier>` the annotation lives on `SecurityGroupIdentifier.groupId` (the field that actually holds the SG resolvable), mirroring the precedent on `ECS::TaskDefinition.EFSVolumeConfiguration.filesystemId`.
- With both sides annotated the destroy DAG orders SG rules after workloads using the SG, matching the mechanism that already works for `EFS::MountTarget` behind `ECS::TaskDefinition`.

## Validation

- `make lint` — 0 issues
- `make build` — clean
- `go test -tags unit ./...` — all pass
- `make verify-schema` — 227 modules, 224 types, PASSED

The unit suite does not exercise destroy ordering. Debug-conformance covers the runtime path through the SG-consuming fixtures (ECS-with-LB, Lambda VpcConfig, RDS, etc.).