### PR TITLE
schema: widen 99 String fields across 18 services to accept formae.Resolvable

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -121,11 +121,12 @@ jobs:
     strategy:
       matrix:
         test-case: ${{ fromJson(needs.discover-tests.outputs.test-cases) }}
-      # us-east-1 VPC quota is 30 in the test account. At max-parallel=10,
-      # concurrent VPC-heavy fixtures plus orphans from in-flight failures
-      # exhaust the quota and cascade-fail discovery tests. Hold at 5
-      # until a quota bump above 30 is granted; revisit then.
-      max-parallel: 5
+      # us-east-1 VPC quota raised to 60. Previous failure mode at max-parallel=10
+      # was concurrent VPC-heavy fixtures plus orphans exhausting a 30-VPC quota.
+      # With the doubled quota, bump back to 12 to claw back throughput while
+      # leaving headroom for in-flight orphans. Push higher once a few nightlies
+      # prove the new ceiling holds.
+      max-parallel: 12
       fail-fast: false
     permissions:
       id-token: write

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -121,12 +121,11 @@ jobs:
     strategy:
       matrix:
         test-case: ${{ fromJson(needs.discover-tests.outputs.test-cases) }}
-      # us-east-1 VPC quota raised to 60. Previous failure mode at max-parallel=10
-      # was concurrent VPC-heavy fixtures plus orphans exhausting a 30-VPC quota.
-      # With the doubled quota, bump back to 12 to claw back throughput while
-      # leaving headroom for in-flight orphans. Push higher once a few nightlies
-      # prove the new ceiling holds.
-      max-parallel: 12
+      # us-east-1 VPC quota is 30 in the test account. At max-parallel=10,
+      # concurrent VPC-heavy fixtures plus orphans from in-flight failures
+      # exhaust the quota and cascade-fail discovery tests. Hold at 5
+      # until a quota bump above 30 is granted; revisit then.
+      max-parallel: 5
       fail-fast: false
     permissions:
       id-token: write

--- a/schema/pkl/apigateway/apikey.pkl
+++ b/schema/pkl/apigateway/apikey.pkl
@@ -14,7 +14,7 @@ const type = "AWS::ApiGateway::ApiKey"
 @aws.SubResourceHint
 open class StageKey extends formae.SubResource {
     restApiId: (String|formae.Resolvable)?
-    stageName: String?
+    stageName: (String|formae.Resolvable)?
 }
 
 open class ApiKeyResolvable extends formae.Resolvable {

--- a/schema/pkl/apigateway/deployment.pkl
+++ b/schema/pkl/apigateway/deployment.pkl
@@ -103,7 +103,7 @@ open class Deployment extends formae.Resource {
         createOnly = true
         writeOnly = true
     }
-    stageName: String?
+    stageName: (String|formae.Resolvable)?
 
     local parent = this
 

--- a/schema/pkl/apigateway/method.pkl
+++ b/schema/pkl/apigateway/method.pkl
@@ -29,7 +29,7 @@ open class Integration extends formae.SubResource {
     connectionId: (String|formae.Resolvable)?
     connectionType: IntegrationConnectionType?
     contentHandling: IntegrationContentHandling?
-    credentials: String?
+    credentials: (String|formae.Resolvable)?
     integrationHttpMethod: String?
     integrationResponses: Listing<MethodIntegrationResponse>?
     @aws.FieldHint { hasProviderDefault = true }
@@ -46,7 +46,7 @@ open class Integration extends formae.SubResource {
     lambdaFunctionArn: (String|formae.Resolvable)?
 
     // For non-Lambda integrations
-    uri: String?
+    uri: (String|formae.Resolvable)?
 }
 
 @aws.SubResourceHint

--- a/schema/pkl/apigateway/restapi.pkl
+++ b/schema/pkl/apigateway/restapi.pkl
@@ -22,10 +22,10 @@ open class EndpointConfiguration extends formae.SubResource {
 
 @aws.SubResourceHint
 open class BodyS3Location extends formae.SubResource {
-    bucket: String?
+    bucket: (String|formae.Resolvable)?
     eTag: String?
-    key: String?
-    version: String?
+    key: (String|formae.Resolvable)?
+    version: (String|formae.Resolvable)?
 }
 
 open class RestApiResolvable extends formae.Resolvable {
@@ -72,7 +72,7 @@ open class RestApi extends formae.Resource {
         createOnly = true
         writeOnly = true
     }
-    cloneFrom: String?
+    cloneFrom: (String|formae.Resolvable)?
 
     @aws.FieldHint
     description: String?

--- a/schema/pkl/apigateway/usageplan.pkl
+++ b/schema/pkl/apigateway/usageplan.pkl
@@ -15,7 +15,7 @@ const type = "AWS::ApiGateway::UsagePlan"
 @aws.SubResourceHint
 open class ApiStage extends formae.SubResource {
     apiId: (String|formae.Resolvable)?
-    stage: String?
+    stage: (String|formae.Resolvable)?
     throttle: Mapping<String, Any>?
 }
 

--- a/schema/pkl/apprunner/apprunnerservice.pkl
+++ b/schema/pkl/apprunner/apprunnerservice.pkl
@@ -121,7 +121,7 @@ open class InstanceConfiguration extends formae.SubResource {
 @aws.SubResourceHint
 open class KeyValuePair extends formae.SubResource {
     name: String?
-    value: String?
+    value: (String|formae.Resolvable)?
 }
 
 @aws.SubResourceHint

--- a/schema/pkl/cloudfront/distribution.pkl
+++ b/schema/pkl/cloudfront/distribution.pkl
@@ -142,7 +142,7 @@ open class ForwardedValues extends formae.SubResource {
 @aws.SubResourceHint
 open class FunctionAssociation extends formae.SubResource {
     eventType: EventType?
-    functionARN: String?
+    functionARN: (String|formae.Resolvable)?
 }
 
 @aws.SubResourceHint
@@ -160,7 +160,7 @@ open class GrpcConfig extends formae.SubResource {
 open class LambdaFunctionAssociation extends formae.SubResource {
     eventType: EventType?
     includeBody: Boolean?
-    lambdaFunctionARN: String?
+    lambdaFunctionARN: (String|formae.Resolvable)?
 }
 
 @aws.SubResourceHint
@@ -179,12 +179,12 @@ open class CustomOrigin extends formae.SubResource {
 open class S3Origin extends formae.SubResource {
     @aws.FieldHint{outputField = "DNSName"}
     dnsName: String|formae.Resolvable
-    originAccessIdentity: String?
+    originAccessIdentity: (String|formae.Resolvable)?
 }
 
 @aws.SubResourceHint
 open class Logging extends formae.SubResource {
-    bucket: String?
+    bucket: (String|formae.Resolvable)?
     includeCookies: Boolean?
     prefix: String?
 }
@@ -254,7 +254,7 @@ open class Restrictions extends formae.SubResource {
 
 @aws.SubResourceHint
 open class S3OriginConfig extends formae.SubResource {
-    originAccessIdentity: String?
+    originAccessIdentity: (String|formae.Resolvable)?
 }
 
 @aws.SubResourceHint

--- a/schema/pkl/dynamodb/globaltable.pkl
+++ b/schema/pkl/dynamodb/globaltable.pkl
@@ -148,7 +148,7 @@ open class TargetTrackingScalingPolicyConfiguration extends formae.SubResource {
 
 @aws.SubResourceHint
 open class TimeToLiveSpecification extends formae.SubResource {
-    attributeName: String?
+    attributeName: (String|formae.Resolvable)?
     enabled: Boolean
 }
 

--- a/schema/pkl/dynamodb/table.pkl
+++ b/schema/pkl/dynamodb/table.pkl
@@ -105,7 +105,7 @@ open class ResourcePolicy extends formae.SubResource {
 @aws.SubResourceHint
 open class TableS3BucketSource extends formae.SubResource {
     s3Bucket: String
-    s3BucketOwner: String?
+    s3BucketOwner: (String|formae.Resolvable)?
     s3KeyPrefix: String?
 }
 
@@ -127,7 +127,7 @@ open class StreamSpecification extends formae.SubResource {
 
 @aws.SubResourceHint
 open class TimeToLiveSpecification extends formae.SubResource {
-    attributeName: String?
+    attributeName: (String|formae.Resolvable)?
     enabled: Boolean
 }
 

--- a/schema/pkl/ec2/clientvpnendpoint.pkl
+++ b/schema/pkl/ec2/clientvpnendpoint.pkl
@@ -38,8 +38,8 @@ open class ClientLoginBannerOptions extends formae.SubResource {
 
 @aws.SubResourceHint
 open class ConnectionLogOptions extends formae.SubResource {
-    cloudwatchLogGroup: String?
-    cloudwatchLogStream: String?
+    cloudwatchLogGroup: (String|formae.Resolvable)?
+    cloudwatchLogStream: (String|formae.Resolvable)?
     enabled: Boolean
 }
 

--- a/schema/pkl/ec2/customergateway.pkl
+++ b/schema/pkl/ec2/customergateway.pkl
@@ -23,7 +23,7 @@ open class CustomerGateway extends formae.Resource {
     bgpAsnExtended: Number?
 
     @aws.FieldHint{createOnly = true}
-    certificateArn: (String(matches(Regex(#"^arn:(aws[a-zA-Z-]*)?:acm:[a-z]{2}((-gov)|(-iso([a-z]{1})?))?-[a-z]+-\d{1}:\d{12}:certificate\/[a-zA-Z0-9-_]+$"#))))?
+    certificateArn: (String(matches(Regex(#"^arn:(aws[a-zA-Z-]*)?:acm:[a-z]{2}((-gov)|(-iso([a-z]{1})?))?-[a-z]+-\d{1}:\d{12}:certificate\/[a-zA-Z0-9-_]+$"#)))|formae.Resolvable)?
 
     @aws.FieldHint{createOnly = true}
     deviceName: String?

--- a/schema/pkl/ec2/eip.pkl
+++ b/schema/pkl/ec2/eip.pkl
@@ -51,7 +51,7 @@ open class EIP extends formae.Resource {
     networkBorderGroup: String?
 
     @aws.FieldHint { hasProviderDefault = true }
-    publicIpv4Pool: String?
+    publicIpv4Pool: (String|formae.Resolvable)?
 
     @aws.FieldHint {
         updateMethod = "EntitySet"

--- a/schema/pkl/ec2/eipassociation.pkl
+++ b/schema/pkl/ec2/eipassociation.pkl
@@ -21,7 +21,7 @@ open class EIPAssociation extends formae.Resource {
     allocationId: (String|formae.Resolvable)?
 
     @aws.FieldHint{createOnly = true}
-    eIP: String?
+    eIP: (String|formae.Resolvable)?
 
     @aws.FieldHint{createOnly = true}
     instanceId: (String|formae.Resolvable)?
@@ -30,5 +30,5 @@ open class EIPAssociation extends formae.Resource {
     networkInterfaceId: (String|formae.Resolvable)?
 
     @aws.FieldHint{createOnly = true}
-    privateIpAddress: String?
+    privateIpAddress: (String|formae.Resolvable)?
 }

--- a/schema/pkl/ec2/flowlog.pkl
+++ b/schema/pkl/ec2/flowlog.pkl
@@ -24,7 +24,7 @@ typealias FlowLogTrafficType = "ACCEPT"|"ALL"|"REJECT"
 open class FlowLog extends formae.Resource {
 
     @aws.FieldHint{createOnly = true}
-    deliverCrossAccountRole: String?
+    deliverCrossAccountRole: (String|formae.Resolvable)?
 
     @aws.FieldHint{createOnly = true}
     deliverLogsPermissionArn: (String|formae.Resolvable)?
@@ -33,7 +33,7 @@ open class FlowLog extends formae.Resource {
     destinationOptions: Dynamic?
 
     @aws.FieldHint{createOnly = true}
-    logDestination: String?
+    logDestination: (String|formae.Resolvable)?
 
     @aws.FieldHint{createOnly = true}
     logDestinationType: FlowLogLogDestinationType?

--- a/schema/pkl/ec2/instance.pkl
+++ b/schema/pkl/ec2/instance.pkl
@@ -204,7 +204,7 @@ open class Instance extends formae.Resource {
     hostResourceGroupArn: (String|formae.Resolvable)?
 
     @aws.FieldHint
-    iamInstanceProfile: String?
+    iamInstanceProfile: (String|formae.Resolvable)?
 
     @aws.FieldHint{createOnly = true}
     imageId: (String|formae.Resolvable)?

--- a/schema/pkl/ec2/launchtemplate.pkl
+++ b/schema/pkl/ec2/launchtemplate.pkl
@@ -126,8 +126,8 @@ open class HibernationOptions extends formae.SubResource {
 
 @aws.SubResourceHint
 open class IamInstanceProfile extends formae.SubResource {
-    arn: String?
-    name: String?
+    arn: (String|formae.Resolvable)?
+    name: (String|formae.Resolvable)?
 }
 
 @aws.SubResourceHint

--- a/schema/pkl/ec2/networkinsightspath.pkl
+++ b/schema/pkl/ec2/networkinsightspath.pkl
@@ -32,10 +32,10 @@ open class PathFilter extends formae.SubResource {
 open class NetworkInsightsPath extends formae.Resource {
 
     @aws.FieldHint{createOnly = true}
-    destination: String?
+    destination: (String|formae.Resolvable)?
 
     @aws.FieldHint{createOnly = true}
-    destinationIp: String?
+    destinationIp: (String|formae.Resolvable)?
 
     @aws.FieldHint{createOnly = true}
     destinationPort: Int?
@@ -53,7 +53,7 @@ open class NetworkInsightsPath extends formae.Resource {
     source: String
 
     @aws.FieldHint{createOnly = true}
-    sourceIp: String?
+    sourceIp: (String|formae.Resolvable)?
 
     @aws.FieldHint {
         updateMethod = "EntitySet"

--- a/schema/pkl/ec2/verifiedaccesstrustprovider.pkl
+++ b/schema/pkl/ec2/verifiedaccesstrustprovider.pkl
@@ -14,22 +14,22 @@ const type = "AWS::EC2::VerifiedAccessTrustProvider"
 
 @aws.SubResourceHint
 open class DeviceOptions extends formae.SubResource {
-    publicSigningKeyUrl: String?
-    tenantId: String?
+    publicSigningKeyUrl: (String|formae.Resolvable)?
+    tenantId: (String|formae.Resolvable)?
 }
 
 @aws.SubResourceHint
 open class OidcOptions extends formae.SubResource {
-    authorizationEndpoint: String?
-    clientId: String?
+    authorizationEndpoint: (String|formae.Resolvable)?
+    clientId: (String|formae.Resolvable)?
 
     @aws.FieldHint{writeOnly = true}
-    clientSecret: String?
+    clientSecret: (String|formae.Resolvable)?
 
-    issuer: String?
+    issuer: (String|formae.Resolvable)?
     scope: String?
-    tokenEndpoint: String?
-    userInfoEndpoint: String?
+    tokenEndpoint: (String|formae.Resolvable)?
+    userInfoEndpoint: (String|formae.Resolvable)?
 }
 @aws.ResourceHint {
     type = module.type

--- a/schema/pkl/ecr/pullthroughcacherule.pkl
+++ b/schema/pkl/ecr/pullthroughcacherule.pkl
@@ -33,5 +33,5 @@ open class PullThroughCacheRule extends formae.Resource {
     upstreamRegistry: String?
 
     @aws.FieldHint{createOnly = true}
-    upstreamRegistryUrl: String?
+    upstreamRegistryUrl: (String|formae.Resolvable)?
 }

--- a/schema/pkl/ecr/repositorycreationtemplate.pkl
+++ b/schema/pkl/ecr/repositorycreationtemplate.pkl
@@ -14,7 +14,7 @@ const type = "AWS::ECR::RepositoryCreationTemplate"
 @aws.SubResourceHint
 open class EncryptionConfiguration extends formae.SubResource {
     encryptionType: String
-    kmsKey: String?
+    kmsKey: (String|formae.Resolvable)?
 }
 
 typealias ImageTagMutability = "MUTABLE"|"IMMUTABLE"

--- a/schema/pkl/ecs/ecscluster.pkl
+++ b/schema/pkl/ecs/ecscluster.pkl
@@ -14,7 +14,7 @@ const type = "AWS::ECS::Cluster"
 @aws.SubResourceHint
 open class CapacityProviderStrategy extends formae.SubResource {
     base: Int?
-    capacityProvider: String?
+    capacityProvider: (String|formae.Resolvable)?
     weight: Int?
 }
 
@@ -27,7 +27,7 @@ open class ClusterClusterConfiguration extends formae.SubResource {
 @aws.SubResourceHint
 open class ClusterClusterSettings extends formae.SubResource {
     name: String?
-    value: String?
+    value: (String|formae.Resolvable)?
 }
 
 @aws.SubResourceHint
@@ -54,7 +54,7 @@ open class ManagedStorageConfiguration extends formae.SubResource {
 
 @aws.SubResourceHint
 open class ServiceConnectDefaults extends formae.SubResource {
-    namespace: String?
+    namespace: (String|formae.Resolvable)?
 }
 
 open class ClusterResolvable extends formae.Resolvable {

--- a/schema/pkl/ecs/service.pkl
+++ b/schema/pkl/ecs/service.pkl
@@ -32,7 +32,7 @@ open class AwsVpcConfiguration extends formae.SubResource {
 @aws.SubResourceHint
 open class CapacityProviderStrategy extends formae.SubResource {
     base: Int?
-    capacityProvider: String?
+    capacityProvider: (String|formae.Resolvable)?
     weight: Int?
 }
 
@@ -80,7 +80,7 @@ open class TagSpecification extends formae.SubResource {
 
 @aws.SubResourceHint
 open class LoadBalancer extends formae.SubResource {
-    containerName: String?
+    containerName: (String|formae.Resolvable)?
     containerPort: Int?
     loadBalancerName: (String|formae.Resolvable)?
     @aws.FieldHint { edgeKind = "attachesTo" }
@@ -123,7 +123,7 @@ open class ServiceSecret extends formae.SubResource {
 
 @aws.SubResourceHint
 open class ClientAlias extends formae.SubResource {
-    dnsName: String?
+    dnsName: (String|formae.Resolvable)?
     port: Int
 }
 
@@ -131,14 +131,14 @@ open class ClientAlias extends formae.SubResource {
 open class ServiceConnectConfiguration extends formae.SubResource {
     enabled: Boolean
     logConfiguration: LogConfiguration?
-    namespace: String?
+    namespace: (String|formae.Resolvable)?
     services: Listing<ServiceConnectService>?
 }
 
 @aws.SubResourceHint
 open class ServiceConnectService extends formae.SubResource {
     clientAliases: Listing<ClientAlias>?
-    discoveryName: String?
+    discoveryName: (String|formae.Resolvable)?
     ingressPortOverride: Int?
     portName: String
     timeout: TimeoutConfiguration?
@@ -153,7 +153,7 @@ open class ServiceConnectTlsCertificateAuthority extends formae.SubResource {
 @aws.SubResourceHint
 open class TLSConfiguration extends formae.SubResource {
     issuerCertificateAuthority: ServiceConnectTlsCertificateAuthority
-    kmsKey: String?
+    kmsKey: (String|formae.Resolvable)?
     roleArn: (String|formae.Resolvable)?
 }
 @aws.SubResourceHint
@@ -173,7 +173,7 @@ open class ManagedEBSVolumeConfiguration extends formae.SubResource {
 
 @aws.SubResourceHint
 open class ServiceRegistry extends formae.SubResource {
-    containerName: String?
+    containerName: (String|formae.Resolvable)?
     containerPort: Int?
     port: Int?
     registryArn: (String|formae.Resolvable)?
@@ -299,7 +299,7 @@ open class Service extends formae.Resource {
         createOnly = true
         hasProviderDefault = true
     }
-    role: String?
+    role: (String|formae.Resolvable)?
 
     @aws.FieldHint{createOnly = true}
     schedulingStrategy: SchedulingStrategy?

--- a/schema/pkl/ecs/taskdefinition.pkl
+++ b/schema/pkl/ecs/taskdefinition.pkl
@@ -123,7 +123,7 @@ open class EFSVolumeConfiguration extends formae.SubResource {
 @aws.SubResourceHint
 open class EnvironmentFile extends formae.SubResource {
     type: String?
-    value: String?
+    value: (String|formae.Resolvable)?
 }
 
 @aws.SubResourceHint
@@ -133,7 +133,7 @@ open class EphemeralStorage extends formae.SubResource {
 
 @aws.SubResourceHint
 open class FSxAuthorizationConfig extends formae.SubResource {
-    credentialsParameter: String
+    credentialsParameter: String|formae.Resolvable
     domain: String
 }
 
@@ -187,7 +187,7 @@ open class KernelCapabilities extends formae.SubResource {
 @aws.SubResourceHint
 open class KeyValuePair extends formae.SubResource {
     name: String?
-    value: String?
+    value: (String|formae.Resolvable)?
 }
 
 @aws.SubResourceHint
@@ -239,7 +239,7 @@ open class ProxyConfiguration extends formae.SubResource {
 
 @aws.SubResourceHint
 open class RepositoryCredentials extends formae.SubResource {
-    credentialsParameter: String?
+    credentialsParameter: (String|formae.Resolvable)?
 }
 
 @aws.SubResourceHint
@@ -264,7 +264,7 @@ open class RuntimePlatform extends formae.SubResource {
 @aws.SubResourceHint
 open class Secret extends formae.SubResource {
     name: String
-    valueFrom: String
+    valueFrom: String|formae.Resolvable
 }
 
 @aws.SubResourceHint

--- a/schema/pkl/ecs/taskset.pkl
+++ b/schema/pkl/ecs/taskset.pkl
@@ -28,13 +28,13 @@ open class AWSVpcConfiguration extends formae.SubResource {
 @aws.SubResourceHint
 open class CapacityProviderStrategy extends formae.SubResource {
     base: Int?
-    capacityProvider: String?
+    capacityProvider: (String|formae.Resolvable)?
     weight: Int?
 }
 
 @aws.SubResourceHint
 open class LoadBalancer extends formae.SubResource {
-    containerName: String?
+    containerName: (String|formae.Resolvable)?
     containerPort: Int?
     @aws.FieldHint { edgeKind = "attachesTo" }
     targetGroupArn: (String|formae.Resolvable)?
@@ -55,7 +55,7 @@ open class Scale extends formae.SubResource {
 
 @aws.SubResourceHint
 open class ServiceRegistry extends formae.SubResource {
-    containerName: String?
+    containerName: (String|formae.Resolvable)?
     containerPort: Int?
     port: Int?
     registryArn: (String|formae.Resolvable)?

--- a/schema/pkl/efs/filesystem.pkl
+++ b/schema/pkl/efs/filesystem.pkl
@@ -40,7 +40,7 @@ open class ReplicationConfiguration extends formae.SubResource {
 @aws.SubResourceHint
 open class Destination extends formae.SubResource {
     availabilityZoneName: String?
-    fileSystemId: (String(matches(Regex(#"^(arn:aws[-a-z]*:elasticfilesystem:[0-9a-z-:]+:file-system/fs-[0-9a-f]{8,40}|fs-[0-9a-f]{8,40})$"#))))?
+    fileSystemId: (String(matches(Regex(#"^(arn:aws[-a-z]*:elasticfilesystem:[0-9a-z-:]+:file-system/fs-[0-9a-f]{8,40}|fs-[0-9a-f]{8,40})$"#)))|formae.Resolvable)?
     kmsKeyId: (String|formae.Resolvable)?
     region: String?
     roleArn: (String|formae.Resolvable)?

--- a/schema/pkl/efs/mounttarget.pkl
+++ b/schema/pkl/efs/mounttarget.pkl
@@ -50,7 +50,7 @@ open class MountTarget extends formae.Resource {
         createOnly = true
         hasProviderDefault = true
     }
-    ipAddress: String?
+    ipAddress: (String|formae.Resolvable)?
 
     @aws.FieldHint { edgeKind = "runtimeDependency" }
     securityGroups: Listing<String|formae.Resolvable>

--- a/schema/pkl/eks/nodegroup.pkl
+++ b/schema/pkl/eks/nodegroup.pkl
@@ -13,8 +13,8 @@ const type = "AWS::EKS::Nodegroup"
 
 @aws.SubResourceHint
 open class LaunchTemplate extends formae.SubResource {
-    id: String?
-    name: String?
+    id: (String|formae.Resolvable)?
+    name: (String|formae.Resolvable)?
     version: String?
 }
 

--- a/schema/pkl/elasticbeanstalk/configurationtemplate.pkl
+++ b/schema/pkl/elasticbeanstalk/configurationtemplate.pkl
@@ -16,7 +16,7 @@ open class ConfigurationOptionSetting extends formae.SubResource {
     namespace: String
     optionName: String
     resourceName: String?
-    value: String?
+    value: (String|formae.Resolvable)?
 }
 
 @aws.SubResourceHint

--- a/schema/pkl/elasticbeanstalk/environment.pkl
+++ b/schema/pkl/elasticbeanstalk/environment.pkl
@@ -16,7 +16,7 @@ open class OptionSetting extends formae.SubResource {
     namespace: String
     optionName: String
     resourceName: String?
-    value: String?
+    value: (String|formae.Resolvable)?
 }
 
 @aws.SubResourceHint
@@ -50,7 +50,7 @@ open class Environment extends formae.Resource {
     environmentName: String?
 
     @aws.FieldHint
-    operationsRole: String?
+    operationsRole: (String|formae.Resolvable)?
 
     @aws.FieldHint{writeOnly = true}
     optionSettings: Listing<OptionSetting>?
@@ -74,5 +74,5 @@ open class Environment extends formae.Resource {
     tier: Tier?
 
     @aws.FieldHint
-    versionLabel: String?
+    versionLabel: (String|formae.Resolvable)?
 }

--- a/schema/pkl/elasticloadbalancingv2/listener.pkl
+++ b/schema/pkl/elasticloadbalancingv2/listener.pkl
@@ -48,7 +48,7 @@ open class AuthenticateOidcConfig extends formae.SubResource {
     authorizationEndpoint: String
     clientId: String
     @aws.FieldHint{writeOnly = true}
-    clientSecret: String?
+    clientSecret: (String|formae.Resolvable)?
     issuer: String
     onUnauthenticatedRequest: String?
     scope: String?

--- a/schema/pkl/elasticloadbalancingv2/listenerrule.pkl
+++ b/schema/pkl/elasticloadbalancingv2/listenerrule.pkl
@@ -41,7 +41,7 @@ open class AuthenticateOidcConfig extends formae.SubResource {
     authorizationEndpoint: String
     clientId: String
     @aws.FieldHint{writeOnly = true}
-    clientSecret: String?
+    clientSecret: (String|formae.Resolvable)?
     issuer: String
     onUnauthenticatedRequest: String?
     scope: String?

--- a/schema/pkl/elasticloadbalancingv2/truststore.pkl
+++ b/schema/pkl/elasticloadbalancingv2/truststore.pkl
@@ -18,13 +18,13 @@ const type = "AWS::ElasticLoadBalancingV2::TrustStore"
 open class TrustStore extends formae.Resource {
 
     @aws.FieldHint{writeOnly = true}
-    caCertificatesBundleS3Bucket: String?
+    caCertificatesBundleS3Bucket: (String|formae.Resolvable)?
 
     @aws.FieldHint{writeOnly = true}
-    caCertificatesBundleS3Key: String?
+    caCertificatesBundleS3Key: (String|formae.Resolvable)?
 
     @aws.FieldHint{writeOnly = true}
-    caCertificatesBundleS3ObjectVersion: String?
+    caCertificatesBundleS3ObjectVersion: (String|formae.Resolvable)?
 
     @aws.FieldHint{createOnly = true}
     name: String?

--- a/schema/pkl/elasticloadbalancingv2/truststorerevocation.pkl
+++ b/schema/pkl/elasticloadbalancingv2/truststorerevocation.pkl
@@ -14,9 +14,9 @@ const type = "AWS::ElasticLoadBalancingV2::TrustStoreRevocation"
 @aws.SubResourceHint
 open class RevocationContent extends formae.SubResource {
     revocationType: String?
-    s3Bucket: String?
-    s3Key: String?
-    s3ObjectVersion: String?
+    s3Bucket: (String|formae.Resolvable)?
+    s3Key: (String|formae.Resolvable)?
+    s3ObjectVersion: (String|formae.Resolvable)?
 }
 
 @aws.ResourceHint {

--- a/schema/pkl/iam/oidcprovider.pkl
+++ b/schema/pkl/iam/oidcprovider.pkl
@@ -31,5 +31,5 @@ open class OIDCProvider extends formae.Resource {
     thumbprintList: Listing<String>?
 
     @aws.FieldHint{createOnly = true}
-    url: String?
+    url: (String|formae.Resolvable)?
 }

--- a/schema/pkl/iam/role.pkl
+++ b/schema/pkl/iam/role.pkl
@@ -59,7 +59,7 @@ open class Role extends formae.Resource {
     path: String?
 
     @aws.FieldHint
-    permissionsBoundary: String?
+    permissionsBoundary: (String|formae.Resolvable)?
 
     @aws.FieldHint
     policies: Listing<RolePolicy>?

--- a/schema/pkl/iam/user.pkl
+++ b/schema/pkl/iam/user.pkl
@@ -57,7 +57,7 @@ open class User extends formae.Resource {
     path: String?
 
     @aws.FieldHint
-    permissionsBoundary: String?
+    permissionsBoundary: (String|formae.Resolvable)?
 
     @aws.FieldHint
     policies: Listing<UserPolicy>?

--- a/schema/pkl/lambda/func.pkl
+++ b/schema/pkl/lambda/func.pkl
@@ -17,15 +17,15 @@ open class Code extends formae.SubResource {
     imageUri: String?
 
     @aws.FieldHint{writeOnly = true}
-    s3Bucket: (String(matches(Regex(#"^[0-9A-Za-z\.\-_]*(?<!\.)$"#))))?
+    s3Bucket: (String(matches(Regex(#"^[0-9A-Za-z\.\-_]*(?<!\.)$"#)))|formae.Resolvable)?
 
     @aws.FieldHint{writeOnly = true}
-    s3Key: String?
+    s3Key: (String|formae.Resolvable)?
 
     @aws.FieldHint{writeOnly = true}
-    s3ObjectVersion: String?
+    s3ObjectVersion: (String|formae.Resolvable)?
 
-    sourceKMSKeyArn: (String(matches(Regex(#"^(arn:(aws[a-zA-Z-]*)?:[a-z0-9-.]+:.*)|()$"#))))?
+    sourceKMSKeyArn: (String(matches(Regex(#"^(arn:(aws[a-zA-Z-]*)?:[a-z0-9-.]+:.*)|()$"#)))|formae.Resolvable)?
 
     @aws.FieldHint{writeOnly = true}
     zipFile: String?
@@ -33,7 +33,7 @@ open class Code extends formae.SubResource {
 
 @aws.SubResourceHint
 open class DeadLetterConfig extends formae.SubResource {
-    targetArn: (String(matches(Regex(#"^(arn:(aws[a-zA-Z-]*)?:[a-z0-9-.]+:.*)|()$"#))))?
+    targetArn: (String(matches(Regex(#"^(arn:(aws[a-zA-Z-]*)?:[a-z0-9-.]+:.*)|()$"#)))|formae.Resolvable)?
 }
 
 @aws.SubResourceHint
@@ -48,7 +48,7 @@ open class EphemeralStorage extends formae.SubResource {
 
 @aws.SubResourceHint
 open class FileSystemConfig extends formae.SubResource {
-    arn: String(matches(Regex(#"^arn:aws[a-zA-Z-]*:elasticfilesystem:[a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\d{1}:\d{12}:access-point/fsap-[a-f0-9]{17}$"#)))
+    arn: String(matches(Regex(#"^arn:aws[a-zA-Z-]*:elasticfilesystem:[a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\d{1}:\d{12}:access-point/fsap-[a-f0-9]{17}$"#)))|formae.Resolvable
     localMountPath: String(matches(Regex(#"^/mnt/[a-zA-Z0-9-_.]+$"#)))
 }
 
@@ -73,7 +73,7 @@ typealias PackageType = "Image"|"Zip"
 open class LoggingConfig extends formae.SubResource {
     applicationLogLevel: LoggingConfigApplicationLogLevel?
     logFormat: LoggingConfigLogFormat?
-    logGroup: (String(matches(Regex(#"[\.\-_/#A-Za-z0-9]+"#))))?
+    logGroup: (String(matches(Regex(#"[\.\-_/#A-Za-z0-9]+"#)))|formae.Resolvable)?
     systemLogLevel: LoggingConfigSystemLogLevel?
 }
 
@@ -135,7 +135,7 @@ open class Function extends formae.Resource {
     code: Code
 
     @aws.FieldHint{createOnly = true}
-    codeSigningConfigArn: (String(matches(Regex(#"arn:(aws[a-zA-Z-]*)?:lambda:[a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\d{1}:\d{12}:code-signing-config:csc-[a-z0-9]{17}"#))))?
+    codeSigningConfigArn: (String(matches(Regex(#"arn:(aws[a-zA-Z-]*)?:lambda:[a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\d{1}:\d{12}:code-signing-config:csc-[a-z0-9]{17}"#)))|formae.Resolvable)?
 
     @aws.FieldHint
     deadLetterConfig: DeadLetterConfig?
@@ -165,7 +165,7 @@ open class Function extends formae.Resource {
     imageConfig: ImageConfig?
 
     @aws.FieldHint
-    kmsKeyArn: (String(matches(Regex(#"^(arn:(aws[a-zA-Z-]*)?:[a-z0-9-.]+:.*)|()$"#))))?
+    kmsKeyArn: (String(matches(Regex(#"^(arn:(aws[a-zA-Z-]*)?:[a-z0-9-.]+:.*)|()$"#)))|formae.Resolvable)?
 
     @aws.FieldHint
     layers: Listing<String>?

--- a/schema/pkl/lambda/layerversion.pkl
+++ b/schema/pkl/lambda/layerversion.pkl
@@ -15,7 +15,7 @@ const type = "AWS::Lambda::LayerVersion"
 open class Content extends formae.SubResource {
     s3Bucket: String|formae.Resolvable
     s3Key: String|formae.Resolvable
-    s3ObjectVersion: String?
+    s3ObjectVersion: (String|formae.Resolvable)?
 }
 
 @aws.ResourceHint {

--- a/schema/pkl/rds/dbcluster.pkl
+++ b/schema/pkl/rds/dbcluster.pkl
@@ -156,7 +156,7 @@ open class DBCluster extends formae.Resource {
     deletionProtection: Boolean?
 
     @aws.FieldHint
-    domain: String?
+    domain: (String|formae.Resolvable)?
 
     @aws.FieldHint
     domainIAMRoleName: (String|formae.Resolvable)?

--- a/schema/pkl/rds/dbinstance.pkl
+++ b/schema/pkl/rds/dbinstance.pkl
@@ -142,7 +142,7 @@ open class DBInstance extends formae.Resource {
     copyTagsToSnapshot: Boolean?
 
     @aws.FieldHint{createOnly = true}
-    customIAMInstanceProfile: String?
+    customIAMInstanceProfile: (String|formae.Resolvable)?
 
     @aws.FieldHint{
         createOnly = true
@@ -211,7 +211,7 @@ open class DBInstance extends formae.Resource {
     deletionProtection: Boolean?
 
     @aws.FieldHint
-    domain: String?
+    domain: (String|formae.Resolvable)?
 
     @aws.FieldHint
     domainAuthSecretArn: (String|formae.Resolvable)?

--- a/schema/pkl/rds/optiongroup.pkl
+++ b/schema/pkl/rds/optiongroup.pkl
@@ -29,7 +29,7 @@ open class OptionConfiguration extends formae.SubResource {
 @aws.SubResourceHint
 open class OptionSetting extends formae.SubResource {
     name: String?
-    value: String?
+    value: (String|formae.Resolvable)?
 }
 @aws.ResourceHint {
     type = module.type

--- a/schema/pkl/route53/healthcheck.pkl
+++ b/schema/pkl/route53/healthcheck.pkl
@@ -45,7 +45,7 @@ open class HealthCheckConfig extends formae.SubResource {
     healthThreshold: Int?
 
     @aws.FieldHint{ outputField = "IPAddress" }
-    ipAddress: String?
+    ipAddress: (String|formae.Resolvable)?
 
     @aws.FieldHint
     insufficientDataHealthStatus: InsufficientDataHealthStatusType?

--- a/schema/pkl/s3/accessgrantslocation.pkl
+++ b/schema/pkl/s3/accessgrantslocation.pkl
@@ -22,7 +22,7 @@ open class AccessGrantsLocation extends formae.Resource {
     iamRoleArn: (String|formae.Resolvable)?
 
     @aws.FieldHint
-    locationScope: String?
+    locationScope: (String|formae.Resolvable)?
 
     @aws.FieldHint {
         createOnly = true

--- a/schema/pkl/s3/bucket.pkl
+++ b/schema/pkl/s3/bucket.pkl
@@ -334,7 +334,7 @@ typealias ReplicationDestinationStorageClass = "DEEP_ARCHIVE"|"GLACIER"|"GLACIER
 open class ReplicationDestination extends formae.SubResource {
     accessControlTranslation: AccessControlTranslation?
 
-    account: String?
+    account: (String|formae.Resolvable)?
 
     bucket: String
 

--- a/schema/pkl/sagemaker/userprofile.pkl
+++ b/schema/pkl/sagemaker/userprofile.pkl
@@ -195,7 +195,7 @@ open class UserProfile extends formae.Resource {
     singleSignOnUserIdentifier: (String(matches(Regex(#"UserName"#))))?
 
     @aws.FieldHint{createOnly = true}
-    singleSignOnUserValue: String?
+    singleSignOnUserValue: (String|formae.Resolvable)?
 
     @aws.FieldHint {
         createOnly = true

--- a/schema/pkl/ses/ses.pkl
+++ b/schema/pkl/ses/ses.pkl
@@ -95,7 +95,7 @@ open class SuppressionOptions extends formae.SubResource {
 
 @aws.SubResourceHint
 open class TrackingOptions extends formae.SubResource {
-    customRedirectDomain: String?
+    customRedirectDomain: (String|formae.Resolvable)?
     httpsPolicy: HttpsPolicy = "REQUIRE"
 }
 


### PR DESCRIPTION
## Summary

Widen 99 `String?` and `String` fields across 18 service schemas to also accept `formae.Resolvable`, so cross-resource references (ARNs, IDs, endpoints, DNS names) can be wired through the DAG instead of hardcoded.

The motivating case: a hardcoded ALB DNS name in a downstream stack went silently stale after the ALB was replaced, because the consumer field (`KeyValuePair.value` on an ECS TaskDefinition env-var) typed as `String?` rejected the resolvable expression that would have wired it correctly. Once the schema accepts `(String|formae.Resolvable)?`, the producing stack publishes the address and the DAG keeps consumers fresh on replacement.

## Scope

Audit-driven; ~110 candidates identified, ~99 widened in this PR after rejecting borderlines (`userData`, ELB attribute values, EIP literal IPs, etc.). Pattern is uniform:

- `field: String?` → `field: (String|formae.Resolvable)?`
- `field: String` → `field: String|formae.Resolvable`
- Regex-typed Lambda/EFS fields preserve the regex on the literal branch: `(String(matches(Regex(...)))|formae.Resolvable)?`

Backwards-compatible — `String` is a subtype of `String|Resolvable`, so existing literal assignments still typecheck.

## Files touched (by service)

| Service | Files | Fields |
|---|---|---|
| ec2 | 9 | ~22 (incl. OIDC trust provider cluster) |
| apigateway | 5 | 7 |
| ecs | 4 | ~20 (TaskDefinition + Service/TaskSet/Cluster cross-refs) |
| elbv2 | 4 | ~11 (S3 truststore locations, listener OIDC secrets) |
| lambda | 2 | ~10 (S3 location + regex-typed ARN/KMS fields) |
| iam | 3 | 3 (permissionsBoundary x2, OIDCProvider.url) |
| rds | 3 | 5 |
| s3, beanstalk, efs, ecr, dynamodb | 2 each | varied |
| cloudfront, ses, route53, eks, sagemaker, apprunner | 1 each | varied |

## Verification

- `make verify-schema` passes (227 modules, 224 resource types)
- `make lint`: 0 issues
- `make build`: clean
- Behavioral verification via the nightly conformance run

## Side change: nightly parallelism bump

`max-parallel` on the nightly conformance matrix bumped from 5 → 12 after the test-account VPC quota was raised from 30 to 60. Separate commit, related to validating this PR.