### PR TITLE
fix(schema): skip RDS CustomDBEngineVersion in discovery

### DIFF
--- a/schema/pkl/rds/customdbengineversion.pkl
+++ b/schema/pkl/rds/customdbengineversion.pkl
@@ -32,6 +32,7 @@ open class CustomDBEngineVersionResolvable extends formae.Resolvable {
 @aws.ResourceHint {
     type = module.type
     identifier = "Ref"
+    discoverable = false
 }
 open class CustomDBEngineVersion extends formae.Resource {
 


### PR DESCRIPTION
## Summary

- Mark `AWS::RDS::CustomDBEngineVersion` as `discoverable = false` in the pkl schema.
- CCAPI's `ListResources` for this type returns `InvalidRequestException: Unrecognized engine name: custom-oracle-ee` on every call when no `Engine` filter is supplied. The handler appears to default to a value its own RDS backend rejects.
- Discovery iterates every registered type per cycle, so this fires every sync — a class of error we can't fix from the plugin without first adding an enum-fan-out variant to the `listParam` mechanism (Engine is a 2-value enum, not a foreign key to a discoverable parent).
- CRUD via `formae apply` is unaffected: Create/Read/Update/Delete still work via `cloudcontrol.{Create,Get,Update,Delete}Resource` by-identifier. Only `ListResources` is skipped.
- Same pattern already in use for `AWS::SQS::QueuePolicy`, `AWS::IAM::AccessKey`, `AWS::IAM::UserPolicy`, and other resource types that can't be enumerated cleanly via CCAPI.

If/when an enum-fan-out listParam lands, we can revisit and probe whether the CCAPI handler accepts an explicit `ResourceModel.Engine`.