### PR TITLE
feat(ccx): log full ProgressEvent details when StatusResource sees a Failure

### DIFF
--- a/pkg/ccx/client.go
+++ b/pkg/ccx/client.go
@@ -405,6 +405,21 @@ func (c *Client) StatusResource(ctx context.Context, request *resource.StatusReq
 		}, nil
 	}
 
+	// All remap rules above have had their chance. If we still have a Failure at
+	// this point it is reaching the caller as-is and will be surfaced as a real
+	// failure / retry trigger. Dump the full ProgressEvent so future investigations
+	// (notably the ECS Service Delete drain timeout) have the actual ErrorCode and
+	// StatusMessage from prod runs without needing to reproduce them.
+	if operationStatus == resource.OperationStatusFailure {
+		slog.Warn("StatusResource: CCAPI ProgressEvent reports Failure",
+			"operation", string(result.ProgressEvent.Operation),
+			"errorCode", string(result.ProgressEvent.ErrorCode),
+			"statusMessage", aws.ToString(result.ProgressEvent.StatusMessage),
+			"typeName", aws.ToString(result.ProgressEvent.TypeName),
+			"requestToken", aws.ToString(result.ProgressEvent.RequestToken),
+			"identifier", identifier)
+	}
+
 	statusResult := &resource.StatusResult{
 		ProgressResult: &resource.ProgressResult{
 			Operation:       operation,

--- a/pkg/ccx/client_test.go
+++ b/pkg/ccx/client_test.go
@@ -7,9 +7,11 @@
 package ccx
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -724,4 +726,125 @@ func TestReadResource_PreservesRealEventInvokeDestination(t *testing.T) {
 		"a genuine user-set destination must be preserved")
 	require.NotContains(t, string(result.Properties), "OnSuccess",
 		"the empty OnSuccess sibling should be stripped")
+}
+
+// captureSlog redirects slog.Default to write WARN+ records into the returned
+// buffer and restores the previous default at test cleanup. Returned buffer
+// contains the rendered text output.
+func captureSlog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return &buf
+}
+
+// When a Status poll comes back FAILED and none of the remap rules apply, the
+// final ProgressEvent must be warn-logged with the fields needed to decide
+// whether the error code should be remapped in a future patch (Operation,
+// ErrorCode, StatusMessage, TypeName, RequestToken, Identifier). Without this
+// diagnostic we can't tell ServiceTimeout from GeneralServiceException from
+// ServiceInternalError when the next problem destroy hits prod.
+func TestStatusResource_FailedProgress_LogsDiagnosticDetails(t *testing.T) {
+	buf := captureSlog(t)
+
+	mockAPI := new(mockCloudControlAPI)
+	client := &Client{api: mockAPI}
+
+	mockAPI.On("GetResourceRequestStatus", mock.Anything, mock.Anything).Return(
+		&cloudcontrol.GetResourceRequestStatusOutput{
+			ProgressEvent: &cctypes.ProgressEvent{
+				Operation:       cctypes.OperationDelete,
+				OperationStatus: cctypes.OperationStatusFailed,
+				ErrorCode:       cctypes.HandlerErrorCodeServiceTimeout,
+				StatusMessage:   ptr.Of("Resource DELETE operation timed out"),
+				TypeName:        ptr.Of("AWS::ECS::Service"),
+				RequestToken:    ptr.Of("req-token-svc-timeout"),
+				Identifier:      ptr.Of("formae-cluster/formae-service"),
+			},
+		}, nil,
+	)
+
+	_, err := client.StatusResource(
+		context.Background(),
+		&resource.StatusRequest{RequestID: "req-token-svc-timeout"},
+		func(_ context.Context, _ *resource.ReadRequest) (*resource.ReadResult, error) {
+			t.Fatalf("readFunc must not be called on a FAILED status")
+			return nil, nil
+		},
+	)
+	require.NoError(t, err)
+
+	out := buf.String()
+	require.Contains(t, out, `level=WARN`, "must log at WARN level for prod surfacing")
+	require.Contains(t, out, "ServiceTimeout", "must include ErrorCode — the smoking gun for future remap decisions")
+	require.Contains(t, out, "Resource DELETE operation timed out", "must include StatusMessage")
+	require.Contains(t, out, "AWS::ECS::Service", "must include TypeName")
+	require.Contains(t, out, "DELETE", "must include Operation")
+	require.Contains(t, out, "req-token-svc-timeout", "must include RequestToken for CloudTrail correlation")
+	require.Contains(t, out, "formae-cluster/formae-service", "must include Identifier so we can find the resource")
+}
+
+// InProgress events fire on every Status poll during a long-running op (often
+// many per minute). They MUST NOT trigger the diagnostic log or we'd drown
+// real failure signals.
+func TestStatusResource_InProgress_DoesNotLog(t *testing.T) {
+	buf := captureSlog(t)
+
+	mockAPI := new(mockCloudControlAPI)
+	client := &Client{api: mockAPI}
+
+	mockAPI.On("GetResourceRequestStatus", mock.Anything, mock.Anything).Return(
+		&cloudcontrol.GetResourceRequestStatusOutput{
+			ProgressEvent: &cctypes.ProgressEvent{
+				Operation:       cctypes.OperationCreate,
+				OperationStatus: cctypes.OperationStatusInProgress,
+				TypeName:        ptr.Of("AWS::S3::Bucket"),
+				RequestToken:    ptr.Of("req-in-progress"),
+			},
+		}, nil,
+	)
+
+	_, err := client.StatusResource(
+		context.Background(),
+		&resource.StatusRequest{RequestID: "req-in-progress"},
+		func(_ context.Context, _ *resource.ReadRequest) (*resource.ReadResult, error) {
+			return nil, nil
+		},
+	)
+	require.NoError(t, err)
+	require.Empty(t, buf.String(), "must not log for InProgress polls — they fire many times per op")
+}
+
+// NotStabilized is FAILED at the CCAPI layer but our code remaps it to
+// InProgress (see ccx/client.go NotStabilized→InProgress). The diagnostic log
+// must fire AFTER all remaps so remapped-to-InProgress cases stay silent.
+func TestStatusResource_NotStabilizedRemap_DoesNotLog(t *testing.T) {
+	buf := captureSlog(t)
+
+	mockAPI := new(mockCloudControlAPI)
+	client := &Client{api: mockAPI}
+
+	mockAPI.On("GetResourceRequestStatus", mock.Anything, mock.Anything).Return(
+		&cloudcontrol.GetResourceRequestStatusOutput{
+			ProgressEvent: &cctypes.ProgressEvent{
+				Operation:       cctypes.OperationUpdate,
+				OperationStatus: cctypes.OperationStatusFailed,
+				ErrorCode:       cctypes.HandlerErrorCodeNotStabilized,
+				StatusMessage:   ptr.Of("Resource is still stabilizing"),
+				TypeName:        ptr.Of("AWS::DynamoDB::Table"),
+			},
+		}, nil,
+	)
+
+	_, err := client.StatusResource(
+		context.Background(),
+		&resource.StatusRequest{RequestID: "req-not-stabilized"},
+		func(_ context.Context, _ *resource.ReadRequest) (*resource.ReadResult, error) {
+			return nil, nil
+		},
+	)
+	require.NoError(t, err)
+	require.Empty(t, buf.String(), "NotStabilized remaps to InProgress and must not warn-log")
 }


### PR DESCRIPTION
## Summary

- Add a `slog.Warn` line in `ccx.Client.StatusResource` that dumps the full CloudControl `ProgressEvent` (operation, errorCode, statusMessage, typeName, requestToken, identifier) whenever a Status poll comes back as a `Failure` after all the existing remap rules have run.
- Gated AFTER the remaps so cases we already handle silently (NotStabilized→InProgress, Create+NotFound→InProgress, target-group race→InProgress, Delete+NotFound→Success) stay silent. Volume is bound to one log per genuine Failure — no spam on the InProgress polls that happen many times per long-running op.
- Three new unit tests: one positive (Failure path emits the expected fields), two negative (InProgress polls do not log, and NotStabilized→InProgress remap stays silent).

## Why

When CCAPI returns FAILED with one of the codes we do not currently remap — `ServiceTimeout`, `ServiceInternalError`, `GeneralServiceException`, etc. — the failure flows to the caller as-is and the PluginOperator triggers a retry. Until now nothing in the plugin logged what the actual ErrorCode was, so post-mortem debugging of resource-type-specific timeout or stabilization behaviour required reproducing the failure live.

The immediate motivation is multi-container ECS Service Delete: the first attempt sometimes fails and the second succeeds, but we have no record of which CCAPI error code AWS returned on the failed attempt. With this in place, the next destroy that exhibits the pattern gives us the actual code in the agent logs and lets us decide whether `ServiceTimeout` (or some other code) should be added to the remap rules.

Generally useful for any future investigation of CCAPI Failure semantics — the constants in the SDK enum (16 distinct `HandlerErrorCode` values) carry meaningfully different operational implications and we want to see them when they fire.