### PR TITLE
fix(schema): tag ContainerDefinitions as EntitySet

### DIFF
--- a/pkg/ccx/client.go
+++ b/pkg/ccx/client.go
@@ -405,6 +405,21 @@ func (c *Client) StatusResource(ctx context.Context, request *resource.StatusReq
 		}, nil
 	}
 
+	// All remap rules above have had their chance. If we still have a Failure at
+	// this point it is reaching the caller as-is and will be surfaced as a real
+	// failure / retry trigger. Dump the full ProgressEvent so future investigations
+	// (notably the ECS Service Delete drain timeout) have the actual ErrorCode and
+	// StatusMessage from prod runs without needing to reproduce them.
+	if operationStatus == resource.OperationStatusFailure {
+		slog.Warn("StatusResource: CCAPI ProgressEvent reports Failure",
+			"operation", string(result.ProgressEvent.Operation),
+			"errorCode", string(result.ProgressEvent.ErrorCode),
+			"statusMessage", aws.ToString(result.ProgressEvent.StatusMessage),
+			"typeName", aws.ToString(result.ProgressEvent.TypeName),
+			"requestToken", aws.ToString(result.ProgressEvent.RequestToken),
+			"identifier", identifier)
+	}
+
 	statusResult := &resource.StatusResult{
 		ProgressResult: &resource.ProgressResult{
 			Operation:       operation,

--- a/pkg/ccx/client_test.go
+++ b/pkg/ccx/client_test.go
@@ -7,9 +7,11 @@
 package ccx
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -724,4 +726,125 @@ func TestReadResource_PreservesRealEventInvokeDestination(t *testing.T) {
 		"a genuine user-set destination must be preserved")
 	require.NotContains(t, string(result.Properties), "OnSuccess",
 		"the empty OnSuccess sibling should be stripped")
+}
+
+// captureSlog redirects slog.Default to write WARN+ records into the returned
+// buffer and restores the previous default at test cleanup. Returned buffer
+// contains the rendered text output.
+func captureSlog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return &buf
+}
+
+// When a Status poll comes back FAILED and none of the remap rules apply, the
+// final ProgressEvent must be warn-logged with the fields needed to decide
+// whether the error code should be remapped in a future patch (Operation,
+// ErrorCode, StatusMessage, TypeName, RequestToken, Identifier). Without this
+// diagnostic we can't tell ServiceTimeout from GeneralServiceException from
+// ServiceInternalError when the next problem destroy hits prod.
+func TestStatusResource_FailedProgress_LogsDiagnosticDetails(t *testing.T) {
+	buf := captureSlog(t)
+
+	mockAPI := new(mockCloudControlAPI)
+	client := &Client{api: mockAPI}
+
+	mockAPI.On("GetResourceRequestStatus", mock.Anything, mock.Anything).Return(
+		&cloudcontrol.GetResourceRequestStatusOutput{
+			ProgressEvent: &cctypes.ProgressEvent{
+				Operation:       cctypes.OperationDelete,
+				OperationStatus: cctypes.OperationStatusFailed,
+				ErrorCode:       cctypes.HandlerErrorCodeServiceTimeout,
+				StatusMessage:   ptr.Of("Resource DELETE operation timed out"),
+				TypeName:        ptr.Of("AWS::ECS::Service"),
+				RequestToken:    ptr.Of("req-token-svc-timeout"),
+				Identifier:      ptr.Of("formae-cluster/formae-service"),
+			},
+		}, nil,
+	)
+
+	_, err := client.StatusResource(
+		context.Background(),
+		&resource.StatusRequest{RequestID: "req-token-svc-timeout"},
+		func(_ context.Context, _ *resource.ReadRequest) (*resource.ReadResult, error) {
+			t.Fatalf("readFunc must not be called on a FAILED status")
+			return nil, nil
+		},
+	)
+	require.NoError(t, err)
+
+	out := buf.String()
+	require.Contains(t, out, `level=WARN`, "must log at WARN level for prod surfacing")
+	require.Contains(t, out, "ServiceTimeout", "must include ErrorCode — the smoking gun for future remap decisions")
+	require.Contains(t, out, "Resource DELETE operation timed out", "must include StatusMessage")
+	require.Contains(t, out, "AWS::ECS::Service", "must include TypeName")
+	require.Contains(t, out, "DELETE", "must include Operation")
+	require.Contains(t, out, "req-token-svc-timeout", "must include RequestToken for CloudTrail correlation")
+	require.Contains(t, out, "formae-cluster/formae-service", "must include Identifier so we can find the resource")
+}
+
+// InProgress events fire on every Status poll during a long-running op (often
+// many per minute). They MUST NOT trigger the diagnostic log or we'd drown
+// real failure signals.
+func TestStatusResource_InProgress_DoesNotLog(t *testing.T) {
+	buf := captureSlog(t)
+
+	mockAPI := new(mockCloudControlAPI)
+	client := &Client{api: mockAPI}
+
+	mockAPI.On("GetResourceRequestStatus", mock.Anything, mock.Anything).Return(
+		&cloudcontrol.GetResourceRequestStatusOutput{
+			ProgressEvent: &cctypes.ProgressEvent{
+				Operation:       cctypes.OperationCreate,
+				OperationStatus: cctypes.OperationStatusInProgress,
+				TypeName:        ptr.Of("AWS::S3::Bucket"),
+				RequestToken:    ptr.Of("req-in-progress"),
+			},
+		}, nil,
+	)
+
+	_, err := client.StatusResource(
+		context.Background(),
+		&resource.StatusRequest{RequestID: "req-in-progress"},
+		func(_ context.Context, _ *resource.ReadRequest) (*resource.ReadResult, error) {
+			return nil, nil
+		},
+	)
+	require.NoError(t, err)
+	require.Empty(t, buf.String(), "must not log for InProgress polls — they fire many times per op")
+}
+
+// NotStabilized is FAILED at the CCAPI layer but our code remaps it to
+// InProgress (see ccx/client.go NotStabilized→InProgress). The diagnostic log
+// must fire AFTER all remaps so remapped-to-InProgress cases stay silent.
+func TestStatusResource_NotStabilizedRemap_DoesNotLog(t *testing.T) {
+	buf := captureSlog(t)
+
+	mockAPI := new(mockCloudControlAPI)
+	client := &Client{api: mockAPI}
+
+	mockAPI.On("GetResourceRequestStatus", mock.Anything, mock.Anything).Return(
+		&cloudcontrol.GetResourceRequestStatusOutput{
+			ProgressEvent: &cctypes.ProgressEvent{
+				Operation:       cctypes.OperationUpdate,
+				OperationStatus: cctypes.OperationStatusFailed,
+				ErrorCode:       cctypes.HandlerErrorCodeNotStabilized,
+				StatusMessage:   ptr.Of("Resource is still stabilizing"),
+				TypeName:        ptr.Of("AWS::DynamoDB::Table"),
+			},
+		}, nil,
+	)
+
+	_, err := client.StatusResource(
+		context.Background(),
+		&resource.StatusRequest{RequestID: "req-not-stabilized"},
+		func(_ context.Context, _ *resource.ReadRequest) (*resource.ReadResult, error) {
+			return nil, nil
+		},
+	)
+	require.NoError(t, err)
+	require.Empty(t, buf.String(), "NotStabilized remaps to InProgress and must not warn-log")
 }

--- a/schema/pkl/ecs/taskdefinition.pkl
+++ b/schema/pkl/ecs/taskdefinition.pkl
@@ -333,7 +333,11 @@ open class TaskDefinition extends formae.Resource {
         stack = parent.stack?.label
     }
 
-    @aws.FieldHint{createOnly = true}
+    @aws.FieldHint{
+        createOnly = true
+        updateMethod = "EntitySet"
+        indexField = "name"
+    }
     containerDefinitions: Listing<ContainerDefinition>?
 
     @aws.FieldHint{createOnly = true}


### PR DESCRIPTION
## Summary

- One-line schema annotation: add `updateMethod = "EntitySet"` and `indexField = "name"` to the existing `@aws.FieldHint` on `containerDefinitions` in `AWS::ECS::TaskDefinition`.
- The patch infrastructure in formae already wires `IndexField`/`UpdateMethod` through to jsonpatch (see `formae/internal/metastructure/patch/patch_document.go:collectionSemanticsFromFieldHints`). Without these hints, jsonpatch falls back to positional matching and produces whole-element add/remove ops.
- Source bug: hub-task-def simulate showed two ~900-char JSON blob lines for a single image tag bump. After this fix, jsonpatch matched-pair diffing produces sub-path `replace` ops that the renderer can format as field-level changes.
- `createOnly = true` and `updateMethod = "EntitySet"` are consumed by independent code paths in the formae core (verified at `patch_document.go:collectionSemanticsFromFieldHints` for `UpdateMethod` and `resource_update_generator.go:anyRefIsCreateOnly` for `CreateOnly`); combining them is safe.