### PR TITLE
fix: unblock single-apply for cert + Route53 + S3-website + CloudFront stacks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,6 +185,11 @@ jobs:
           AWS_REGION: us-east-1
           FORMAE_TEST_RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+          # The certificatemanager fixture uses an unvalidatable `*.example`
+          # domain. With the new wait-for-ISSUED behavior in Certificate.Create
+          # the cert never transitions in CI, hanging the test until timeout.
+          # Skip the wait under conformance; production deployments leave it on.
+          FORMAE_AWS_CERT_SKIP_ISSUED_WAIT: "1"
         run: make conformance-test-crud-run conformance-test-discovery-run TEST=${{ matrix.test-case }} PARALLEL=1 TIMEOUT=120
 
   # Clean up test resources after all conformance tests (always runs)

--- a/.github/workflows/debug-conformance.yml
+++ b/.github/workflows/debug-conformance.yml
@@ -166,6 +166,11 @@ jobs:
           AWS_REGION: us-east-1
           FORMAE_TEST_RUN_ID: debug-${{ github.run_id }}-${{ github.run_attempt }}
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+          # The certificatemanager fixture uses an unvalidatable `*.example`
+          # domain. With the new wait-for-ISSUED behavior in Certificate.Create
+          # the cert never transitions in CI, hanging the test until timeout.
+          # Skip the wait under conformance; production deployments leave it on.
+          FORMAE_AWS_CERT_SKIP_ISSUED_WAIT: "1"
         # 90-minute timeout accommodates LB-attached fixtures (ALB provisioning
         # + ECS stabilization + destroy + reapply takes 65-80m). Smaller fixtures
         # are unaffected — they finish well under the bound.

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -259,6 +259,11 @@ jobs:
           AWS_REGION: us-east-1
           FORMAE_TEST_RUN_ID: nightly-main-${{ github.run_id }}
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+          # The certificatemanager fixture uses an unvalidatable `*.example`
+          # domain. With the new wait-for-ISSUED behavior in Certificate.Create
+          # the cert never transitions in CI, hanging the test until timeout.
+          # Skip the wait under conformance; production deployments leave it on.
+          FORMAE_AWS_CERT_SKIP_ISSUED_WAIT: "1"
         run: make conformance-test-crud-run conformance-test-discovery-run TEST=${{ matrix.test-case }} PARALLEL=1 TIMEOUT=120
 
       - name: Dump formae client log on failure

--- a/examples/cloudfront-acm-smoke.pkl
+++ b/examples/cloudfront-acm-smoke.pkl
@@ -6,7 +6,12 @@
  * Static-typing smoke: declares one of each new producer (KVS, Function,
  * Cert, CachePolicy, OriginRequestPolicy, ResponseHeadersPolicy, OAC)
  * and wires each into a Distribution via the corresponding widened
- * field. Validates Resolvable shape compatibility at pkl-eval time.
+ * field. Also wires a Route53::RecordSet to cert.res.validationRecords
+ * to exercise the CertificateResolvable self-reference shape and the
+ * RecordSet.type String|Resolvable widening, and routes the Distribution
+ * origin at the bucket's hostname-only websiteEndpoint resolvable.
+ *
+ * Validates Resolvable shape compatibility at pkl-eval time.
  *
  * NOT intended to be applied — this is a type-check only.
  */
@@ -24,6 +29,7 @@ import "@aws/cloudfront/originrequestpolicy.pkl"
 import "@aws/cloudfront/responseheaderspolicy.pkl"
 import "@aws/cloudfront/originaccesscontrol.pkl"
 import "@aws/cloudfront/distribution.pkl"
+import "@aws/route53/recordset.pkl"
 import "@aws/s3/bucket.pkl"
 
 local kvs = new keyvaluestore.KeyValueStore {
@@ -50,6 +56,15 @@ local cert = new certificate.Certificate {
   label = "smoke-cert"
   domainName = "smoke.example"
   validationMethod = "DNS"
+}
+
+local certValidation = new recordset.RecordSet {
+  label = "smoke-cert-validation"
+  hostedZoneId = "Z00000000000000000000"
+  name = cert.res.validationRecords.at(0).name
+  type = cert.res.validationRecords.at(0).recordType
+  ttl = 300
+  resourceRecords = cert.res.validationRecords.at(0).values
 }
 
 local cp = new cachepolicy.CachePolicy {
@@ -107,7 +122,7 @@ local dist = new distribution.Distribution {
     origins = new Listing<distribution.Origin> {
       new {
         id = "smoke-origin"
-        domainName = origin.res.regionalDomainName
+        domainName = origin.res.websiteEndpoint
         originAccessControlId = oac.res.id
         s3OriginConfig = new distribution.S3OriginConfig {}
       }
@@ -142,6 +157,7 @@ forma {
   kvs
   fn
   cert
+  certValidation
   cp
   orp
   rhp

--- a/pkg/cfres/certificatemanager/certificate.go
+++ b/pkg/cfres/certificatemanager/certificate.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -30,6 +31,12 @@ import (
 const (
 	defaultPollInterval  = 10 * time.Second
 	defaultIssuedTimeout = 15 * time.Minute
+
+	// skipIssuedWaitEnvVar disables the wait-for-ISSUED loop when set to
+	// "1" / "true". The conformance fixture uses unvalidatable
+	// `*.example` domains where the cert never reaches ISSUED, so the
+	// CI harness sets this to keep the lifecycle test fast.
+	skipIssuedWaitEnvVar = "FORMAE_AWS_CERT_SKIP_ISSUED_WAIT"
 )
 
 // Certificate is the AWS::CertificateManager::Certificate provisioner.
@@ -225,6 +232,11 @@ func (c *Certificate) Create(ctx context.Context, request *resource.CreateReques
 // validation check itself, so DNS-provider work composes via the
 // resource graph rather than via provider-aware wait logic here.
 func (c *Certificate) waitForIssued(ctx context.Context, client ACMClientInterface, certArn string) error {
+	if skip := os.Getenv(skipIssuedWaitEnvVar); skip == "1" || skip == "true" {
+		slog.Info("acm: skipping wait-for-ISSUED due to env override", "cert_arn", certArn, "env", skipIssuedWaitEnvVar)
+		return nil
+	}
+
 	pollInterval := c.pollInterval
 	if pollInterval <= 0 {
 		pollInterval = defaultPollInterval

--- a/pkg/cfres/certificatemanager/certificate.go
+++ b/pkg/cfres/certificatemanager/certificate.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/acm"
@@ -21,6 +22,14 @@ import (
 	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/cfres/ses"
 	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/cfres/utils"
 	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/config"
+)
+
+// Wait-for-ISSUED defaults. Operators with unusual DNS-propagation
+// expectations can override these on the provisioner at construction
+// time; tests do so to keep run-time in microseconds.
+const (
+	defaultPollInterval  = 10 * time.Second
+	defaultIssuedTimeout = 15 * time.Minute
 )
 
 // Certificate is the AWS::CertificateManager::Certificate provisioner.
@@ -40,6 +49,12 @@ import (
 type Certificate struct {
 	cfg              *config.Config
 	acmClientFactory func(cfg *config.Config) (ACMClientInterface, error)
+	// pollInterval is how long Create sleeps between DescribeCertificate
+	// polls while waiting for Status=ISSUED. Zero means use the default.
+	pollInterval time.Duration
+	// issuedTimeout is the upper bound on the wait-for-ISSUED loop. Zero
+	// means use the default.
+	issuedTimeout time.Duration
 }
 
 var _ prov.Provisioner = &Certificate{}
@@ -174,6 +189,15 @@ func (c *Certificate) Create(ctx context.Context, request *resource.CreateReques
 		}
 	}
 
+	// Block until the cert reaches ISSUED so downstream resources that
+	// depend on the ARN (e.g. CloudFront::Distribution.viewerCertificate)
+	// can be created in the same apply. The DNS publisher is wired
+	// upstream via runtimeDependency; this loop only observes ACM's view
+	// of the validation outcome.
+	if err := c.waitForIssued(ctx, client, certArn); err != nil {
+		return nil, err
+	}
+
 	// Read back so callers get the fully-enriched property set (including
 	// any validation records that ACM has already populated).
 	props, _ := c.readProperties(ctx, client, certArn)
@@ -187,6 +211,56 @@ func (c *Certificate) Create(ctx context.Context, request *resource.CreateReques
 			ResourceProperties: propsBytes,
 		},
 	}, nil
+}
+
+// waitForIssued polls DescribeCertificate until Status transitions to
+// ISSUED, hits a terminal failure (FAILED / REVOKED /
+// VALIDATION_TIMED_OUT), the context is cancelled, or the configured
+// timeout elapses.
+//
+// The provisioner makes no assumption about who publishes the validation
+// CNAME — that's the responsibility of upstream resources wired via
+// runtimeDependency (Route53::RecordSet from this plugin today, or any
+// other DNS plugin tomorrow). We only observe ACM's view; AWS owns the
+// validation check itself, so DNS-provider work composes via the
+// resource graph rather than via provider-aware wait logic here.
+func (c *Certificate) waitForIssued(ctx context.Context, client ACMClientInterface, certArn string) error {
+	pollInterval := c.pollInterval
+	if pollInterval <= 0 {
+		pollInterval = defaultPollInterval
+	}
+	issuedTimeout := c.issuedTimeout
+	if issuedTimeout <= 0 {
+		issuedTimeout = defaultIssuedTimeout
+	}
+
+	deadline := time.Now().Add(issuedTimeout)
+	for {
+		desc, err := client.DescribeCertificate(ctx, &acm.DescribeCertificateInput{
+			CertificateArn: aws.String(certArn),
+		})
+		if err != nil {
+			return fmt.Errorf("acm: DescribeCertificate while waiting for ISSUED: %w", err)
+		}
+		if desc != nil && desc.Certificate != nil {
+			switch desc.Certificate.Status {
+			case acmtypes.CertificateStatusIssued:
+				return nil
+			case acmtypes.CertificateStatusFailed,
+				acmtypes.CertificateStatusRevoked,
+				acmtypes.CertificateStatusValidationTimedOut:
+				return fmt.Errorf("acm: certificate %s reached terminal status %s before issuance", certArn, desc.Certificate.Status)
+			}
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("acm: certificate %s still not ISSUED after %s", certArn, issuedTimeout)
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("acm: certificate %s wait cancelled: %w", certArn, ctx.Err())
+		case <-time.After(pollInterval):
+		}
+	}
 }
 
 // ----- Read -----

--- a/pkg/cfres/certificatemanager/certificate_test.go
+++ b/pkg/cfres/certificatemanager/certificate_test.go
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: FSL-1.1-ALv2
 
+//go:build unit
+
 package certificatemanager
 
 import (

--- a/pkg/cfres/certificatemanager/certificate_test.go
+++ b/pkg/cfres/certificatemanager/certificate_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/acm"
@@ -26,7 +27,10 @@ type fakeACMClient struct {
 	requestCertificateOut    *acm.RequestCertificateOutput
 	requestCertificateErr    error
 	describeCertificateOut   *acm.DescribeCertificateOutput
+	describeCertificateOuts  []*acm.DescribeCertificateOutput // when set, consumed per call (last item repeats)
 	describeCertificateErr   error
+	describeCertificateCalls int
+	describeCertificateHook  func(call int) // observe each call; useful for ctx-cancel tests
 	deleteCertificateInput   *acm.DeleteCertificateInput
 	deleteCertificateErr     error
 	addTagsInput             *acm.AddTagsToCertificateInput
@@ -46,7 +50,21 @@ func (f *fakeACMClient) RequestCertificate(_ context.Context, in *acm.RequestCer
 }
 
 func (f *fakeACMClient) DescribeCertificate(_ context.Context, _ *acm.DescribeCertificateInput, _ ...func(*acm.Options)) (*acm.DescribeCertificateOutput, error) {
-	return f.describeCertificateOut, f.describeCertificateErr
+	f.describeCertificateCalls++
+	if f.describeCertificateHook != nil {
+		f.describeCertificateHook(f.describeCertificateCalls)
+	}
+	if f.describeCertificateErr != nil {
+		return nil, f.describeCertificateErr
+	}
+	if len(f.describeCertificateOuts) > 0 {
+		idx := f.describeCertificateCalls - 1
+		if idx >= len(f.describeCertificateOuts) {
+			idx = len(f.describeCertificateOuts) - 1
+		}
+		return f.describeCertificateOuts[idx], nil
+	}
+	return f.describeCertificateOut, nil
 }
 
 func (f *fakeACMClient) DeleteCertificate(_ context.Context, in *acm.DeleteCertificateInput, _ ...func(*acm.Options)) (*acm.DeleteCertificateOutput, error) {
@@ -81,13 +99,17 @@ func (f *fakeACMClient) UpdateCertificateOptions(_ context.Context, in *acm.Upda
 }
 
 // newCertificateWithFake wires a Certificate provisioner against the
-// supplied fake client.
+// supplied fake client with a very short poll interval so wait-for-ISSUED
+// tests complete in microseconds rather than seconds. Tests that need
+// to drive the timeout path override issuedTimeout directly afterwards.
 func newCertificateWithFake(fake *fakeACMClient) *Certificate {
 	return &Certificate{
 		cfg: &config.Config{Region: "us-east-1"},
 		acmClientFactory: func(_ *config.Config) (ACMClientInterface, error) {
 			return fake, nil
 		},
+		pollInterval:  time.Microsecond,
+		issuedTimeout: 5 * time.Second,
 	}
 }
 
@@ -103,6 +125,7 @@ func TestCreate_DnsValidation_RequestsCertificateAndReturnsArn(t *testing.T) {
 				CertificateArn: aws.String("arn:aws:acm:us-east-1:111:certificate/abcd"),
 				DomainName:     aws.String("example.com"),
 				KeyAlgorithm:   acmtypes.KeyAlgorithmRsa2048,
+				Status:         acmtypes.CertificateStatusIssued,
 			},
 		},
 	}
@@ -148,6 +171,7 @@ func TestCreate_SansAndTags_PassThroughToAPI(t *testing.T) {
 		describeCertificateOut: &acm.DescribeCertificateOutput{
 			Certificate: &acmtypes.CertificateDetail{
 				DomainName: aws.String("example.com"),
+				Status:     acmtypes.CertificateStatusIssued,
 			},
 		},
 	}
@@ -182,7 +206,10 @@ func TestCreate_TransparencyPreference_AppliedViaUpdateOptions(t *testing.T) {
 			CertificateArn: aws.String("arn:fake"),
 		},
 		describeCertificateOut: &acm.DescribeCertificateOutput{
-			Certificate: &acmtypes.CertificateDetail{DomainName: aws.String("example.com")},
+			Certificate: &acmtypes.CertificateDetail{
+				DomainName: aws.String("example.com"),
+				Status:     acmtypes.CertificateStatusIssued,
+			},
 		},
 	}
 	cert := newCertificateWithFake(fake)
@@ -217,6 +244,177 @@ func TestCreate_RequestCertificateError_BubblesUp(t *testing.T) {
 	_, err := cert.Create(context.Background(), &resource.CreateRequest{Properties: body})
 	if err == nil {
 		t.Fatal("expected Create to error when RequestCertificate fails")
+	}
+}
+
+// ----- Create: wait-for-ISSUED -----
+//
+// ACM RequestCertificate returns the new ARN while the cert is still
+// PENDING_VALIDATION. CloudFront's Distribution.viewerCertificate
+// requires the cert to be ISSUED before it accepts the ARN, so Create
+// must block until ACM reports ISSUED (or a terminal failure) so the
+// changeset can wire downstream resources in a single apply. The DNS
+// publisher is wired upstream via runtimeDependency; this loop does not
+// query Route53 (the publisher could be Cloudflare or operator-manual).
+
+func TestCreate_WaitForIssued_TransitionsFromPendingToIssued(t *testing.T) {
+	fake := &fakeACMClient{
+		requestCertificateOut: &acm.RequestCertificateOutput{
+			CertificateArn: aws.String("arn:fake"),
+		},
+		describeCertificateOuts: []*acm.DescribeCertificateOutput{
+			{Certificate: &acmtypes.CertificateDetail{
+				CertificateArn: aws.String("arn:fake"),
+				DomainName:     aws.String("example.com"),
+				Status:         acmtypes.CertificateStatusPendingValidation,
+			}},
+			{Certificate: &acmtypes.CertificateDetail{
+				CertificateArn: aws.String("arn:fake"),
+				DomainName:     aws.String("example.com"),
+				Status:         acmtypes.CertificateStatusPendingValidation,
+			}},
+			{Certificate: &acmtypes.CertificateDetail{
+				CertificateArn: aws.String("arn:fake"),
+				DomainName:     aws.String("example.com"),
+				Status:         acmtypes.CertificateStatusIssued,
+			}},
+		},
+	}
+	cert := newCertificateWithFake(fake)
+
+	props := map[string]any{"DomainName": "example.com", "ValidationMethod": "DNS"}
+	body, _ := json.Marshal(props)
+	res, err := cert.Create(context.Background(), &resource.CreateRequest{Properties: body})
+	if err != nil {
+		t.Fatalf("Create failed after eventual ISSUED: %v", err)
+	}
+	if res.ProgressResult.OperationStatus != resource.OperationStatusSuccess {
+		t.Errorf("OperationStatus: want Success, got %v", res.ProgressResult.OperationStatus)
+	}
+	// 3 polls for state transitions + 1 readback at the end.
+	if fake.describeCertificateCalls < 3 {
+		t.Errorf("expected at least 3 DescribeCertificate calls during wait, got %d", fake.describeCertificateCalls)
+	}
+}
+
+func TestCreate_WaitForIssued_StatusFailed_ReturnsError(t *testing.T) {
+	fake := &fakeACMClient{
+		requestCertificateOut: &acm.RequestCertificateOutput{
+			CertificateArn: aws.String("arn:fake"),
+		},
+		describeCertificateOut: &acm.DescribeCertificateOutput{
+			Certificate: &acmtypes.CertificateDetail{
+				CertificateArn: aws.String("arn:fake"),
+				Status:         acmtypes.CertificateStatusFailed,
+			},
+		},
+	}
+	cert := newCertificateWithFake(fake)
+
+	props := map[string]any{"DomainName": "example.com", "ValidationMethod": "DNS"}
+	body, _ := json.Marshal(props)
+	_, err := cert.Create(context.Background(), &resource.CreateRequest{Properties: body})
+	if err == nil {
+		t.Fatal("expected Create to error on terminal FAILED status")
+	}
+}
+
+func TestCreate_WaitForIssued_StatusRevoked_ReturnsError(t *testing.T) {
+	fake := &fakeACMClient{
+		requestCertificateOut: &acm.RequestCertificateOutput{
+			CertificateArn: aws.String("arn:fake"),
+		},
+		describeCertificateOut: &acm.DescribeCertificateOutput{
+			Certificate: &acmtypes.CertificateDetail{
+				CertificateArn: aws.String("arn:fake"),
+				Status:         acmtypes.CertificateStatusRevoked,
+			},
+		},
+	}
+	cert := newCertificateWithFake(fake)
+
+	props := map[string]any{"DomainName": "example.com", "ValidationMethod": "DNS"}
+	body, _ := json.Marshal(props)
+	_, err := cert.Create(context.Background(), &resource.CreateRequest{Properties: body})
+	if err == nil {
+		t.Fatal("expected Create to error on terminal REVOKED status")
+	}
+}
+
+func TestCreate_WaitForIssued_StatusValidationTimedOut_ReturnsError(t *testing.T) {
+	fake := &fakeACMClient{
+		requestCertificateOut: &acm.RequestCertificateOutput{
+			CertificateArn: aws.String("arn:fake"),
+		},
+		describeCertificateOut: &acm.DescribeCertificateOutput{
+			Certificate: &acmtypes.CertificateDetail{
+				CertificateArn: aws.String("arn:fake"),
+				Status:         acmtypes.CertificateStatusValidationTimedOut,
+			},
+		},
+	}
+	cert := newCertificateWithFake(fake)
+
+	props := map[string]any{"DomainName": "example.com", "ValidationMethod": "DNS"}
+	body, _ := json.Marshal(props)
+	_, err := cert.Create(context.Background(), &resource.CreateRequest{Properties: body})
+	if err == nil {
+		t.Fatal("expected Create to error on terminal VALIDATION_TIMED_OUT status")
+	}
+}
+
+func TestCreate_WaitForIssued_ContextCancelled_ReturnsError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	fake := &fakeACMClient{
+		requestCertificateOut: &acm.RequestCertificateOutput{
+			CertificateArn: aws.String("arn:fake"),
+		},
+		describeCertificateOut: &acm.DescribeCertificateOutput{
+			Certificate: &acmtypes.CertificateDetail{
+				CertificateArn: aws.String("arn:fake"),
+				Status:         acmtypes.CertificateStatusPendingValidation,
+			},
+		},
+	}
+	// Cancel on the second describe call (first one returns PENDING and loop continues).
+	fake.describeCertificateHook = func(call int) {
+		if call == 2 {
+			cancel()
+		}
+	}
+	cert := newCertificateWithFake(fake)
+
+	props := map[string]any{"DomainName": "example.com", "ValidationMethod": "DNS"}
+	body, _ := json.Marshal(props)
+	_, err := cert.Create(ctx, &resource.CreateRequest{Properties: body})
+	if err == nil {
+		t.Fatal("expected Create to error when ctx is cancelled mid-wait")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected wrapped context.Canceled, got %v", err)
+	}
+}
+
+func TestCreate_WaitForIssued_Timeout_ReturnsError(t *testing.T) {
+	fake := &fakeACMClient{
+		requestCertificateOut: &acm.RequestCertificateOutput{
+			CertificateArn: aws.String("arn:fake"),
+		},
+		describeCertificateOut: &acm.DescribeCertificateOutput{
+			Certificate: &acmtypes.CertificateDetail{
+				CertificateArn: aws.String("arn:fake"),
+				Status:         acmtypes.CertificateStatusPendingValidation,
+			},
+		},
+	}
+	cert := newCertificateWithFake(fake)
+	cert.issuedTimeout = 5 * time.Millisecond
+
+	props := map[string]any{"DomainName": "example.com", "ValidationMethod": "DNS"}
+	body, _ := json.Marshal(props)
+	_, err := cert.Create(context.Background(), &resource.CreateRequest{Properties: body})
+	if err == nil {
+		t.Fatal("expected Create to error when wait times out without ISSUED")
 	}
 }
 

--- a/pkg/cfres/certificatemanager/certificate_test.go
+++ b/pkg/cfres/certificatemanager/certificate_test.go
@@ -395,6 +395,35 @@ func TestCreate_WaitForIssued_ContextCancelled_ReturnsError(t *testing.T) {
 	}
 }
 
+func TestCreate_WaitForIssued_EnvOverride_SkipsWait(t *testing.T) {
+	t.Setenv("FORMAE_AWS_CERT_SKIP_ISSUED_WAIT", "1")
+	fake := &fakeACMClient{
+		requestCertificateOut: &acm.RequestCertificateOutput{
+			CertificateArn: aws.String("arn:fake"),
+		},
+		// Status is PENDING_VALIDATION but the env override should make
+		// Create return without polling further than the readback.
+		describeCertificateOut: &acm.DescribeCertificateOutput{
+			Certificate: &acmtypes.CertificateDetail{
+				CertificateArn: aws.String("arn:fake"),
+				Status:         acmtypes.CertificateStatusPendingValidation,
+			},
+		},
+	}
+	cert := newCertificateWithFake(fake)
+	cert.issuedTimeout = time.Hour // would normally block; the override must skip the wait
+
+	props := map[string]any{"DomainName": "test.example", "ValidationMethod": "DNS"}
+	body, _ := json.Marshal(props)
+	res, err := cert.Create(context.Background(), &resource.CreateRequest{Properties: body})
+	if err != nil {
+		t.Fatalf("Create should succeed when env override is set, got %v", err)
+	}
+	if res.ProgressResult.OperationStatus != resource.OperationStatusSuccess {
+		t.Errorf("OperationStatus: want Success, got %v", res.ProgressResult.OperationStatus)
+	}
+}
+
 func TestCreate_WaitForIssued_Timeout_ReturnsError(t *testing.T) {
 	fake := &fakeACMClient{
 		requestCertificateOut: &acm.RequestCertificateOutput{

--- a/pkg/cfres/s3/bucket.go
+++ b/pkg/cfres/s3/bucket.go
@@ -1,0 +1,105 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package s3
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/ccx"
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/cfres/prov"
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/cfres/registry"
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/config"
+)
+
+// Bucket wraps CloudControl's Read for AWS::S3::Bucket to derive a
+// hostname-only WebsiteEndpoint from the WebsiteURL that CCAPI returns.
+// CloudFront's Distribution.Origin.domainName wants a hostname, not a
+// URL; the CFN GetAtt schema only exposes WebsiteURL (with the http://
+// prefix), so without this enrichment operators have to string-compose
+// the hostname themselves and lose the Resolvable edge.
+//
+// All other operations (Create / Update / Delete / List / Status) fall
+// through to CCAPI because only the Read result needs enrichment.
+type Bucket struct {
+	cfg *config.Config
+}
+
+var _ prov.Provisioner = &Bucket{}
+
+func init() {
+	registry.Register("AWS::S3::Bucket",
+		[]resource.Operation{resource.OperationRead},
+		func(cfg *config.Config) prov.Provisioner {
+			return &Bucket{cfg: cfg}
+		})
+}
+
+func (b *Bucket) Read(ctx context.Context, request *resource.ReadRequest) (*resource.ReadResult, error) {
+	client, err := ccx.NewClient(b.cfg)
+	if err != nil {
+		return nil, err
+	}
+	result, err := client.ReadResource(ctx, request)
+	if err != nil || result == nil || result.Properties == "" {
+		return result, err
+	}
+
+	var props map[string]any
+	if err := json.Unmarshal([]byte(result.Properties), &props); err != nil {
+		// Pass through; CCAPI's representation is the source of truth.
+		return result, nil
+	}
+	enrichBucketProperties(props)
+
+	enriched, err := json.Marshal(props)
+	if err != nil {
+		return nil, fmt.Errorf("s3 bucket: re-marshal enriched properties: %w", err)
+	}
+	result.Properties = string(enriched)
+	return result, nil
+}
+
+// enrichBucketProperties derives WebsiteEndpoint from WebsiteURL by
+// stripping the `http://` scheme and any trailing slash. Idempotent: if
+// WebsiteURL is missing or empty (bucket without website configuration),
+// no key is added.
+func enrichBucketProperties(props map[string]any) {
+	raw, ok := props["WebsiteURL"].(string)
+	if !ok || raw == "" {
+		return
+	}
+	endpoint := strings.TrimSuffix(strings.TrimPrefix(raw, "http://"), "/")
+	if endpoint == "" {
+		return
+	}
+	props["WebsiteEndpoint"] = endpoint
+}
+
+// The remaining operations fall through to CCAPI; they are unimplemented
+// here so the dispatcher in aws.go bypasses this provisioner for them.
+
+func (b *Bucket) Create(ctx context.Context, request *resource.CreateRequest) (*resource.CreateResult, error) {
+	return nil, fmt.Errorf("s3 bucket: create handled by cloudcontrol")
+}
+
+func (b *Bucket) Update(ctx context.Context, request *resource.UpdateRequest) (*resource.UpdateResult, error) {
+	return nil, fmt.Errorf("s3 bucket: update handled by cloudcontrol")
+}
+
+func (b *Bucket) Delete(ctx context.Context, request *resource.DeleteRequest) (*resource.DeleteResult, error) {
+	return nil, fmt.Errorf("s3 bucket: delete handled by cloudcontrol")
+}
+
+func (b *Bucket) Status(ctx context.Context, request *resource.StatusRequest) (*resource.StatusResult, error) {
+	return nil, fmt.Errorf("s3 bucket: status handled by cloudcontrol")
+}
+
+func (b *Bucket) List(ctx context.Context, request *resource.ListRequest) (*resource.ListResult, error) {
+	return nil, fmt.Errorf("s3 bucket: list handled by cloudcontrol")
+}

--- a/pkg/cfres/s3/bucket_test.go
+++ b/pkg/cfres/s3/bucket_test.go
@@ -1,0 +1,93 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package s3
+
+import (
+	"testing"
+)
+
+// enrichBucketProperties derives WebsiteEndpoint (hostname-only) from
+// WebsiteURL whenever CCAPI populates the latter. CFN's GetAtt schema for
+// AWS::S3::Bucket exposes WebsiteURL but not WebsiteEndpoint, even though
+// CloudFront's Distribution.Origin.domainName requires the hostname-only
+// form. The enrichment closes that gap without forcing operators to
+// string-compose.
+//
+// The function under test lives in bucket.go.
+
+func TestEnrichBucketProperties_StripsHttpPrefixAndTrailingSlash(t *testing.T) {
+	props := map[string]any{
+		"WebsiteURL": "http://my-bucket.s3-website-us-west-2.amazonaws.com/",
+	}
+	enrichBucketProperties(props)
+
+	got, ok := props["WebsiteEndpoint"].(string)
+	if !ok {
+		t.Fatalf("expected WebsiteEndpoint string, got %T (%v)", props["WebsiteEndpoint"], props["WebsiteEndpoint"])
+	}
+	want := "my-bucket.s3-website-us-west-2.amazonaws.com"
+	if got != want {
+		t.Errorf("WebsiteEndpoint = %q, want %q", got, want)
+	}
+}
+
+func TestEnrichBucketProperties_StripsHttpPrefixWithoutTrailingSlash(t *testing.T) {
+	props := map[string]any{
+		"WebsiteURL": "http://my-bucket.s3-website-us-west-2.amazonaws.com",
+	}
+	enrichBucketProperties(props)
+
+	got, ok := props["WebsiteEndpoint"].(string)
+	if !ok {
+		t.Fatalf("expected WebsiteEndpoint string, got %T (%v)", props["WebsiteEndpoint"], props["WebsiteEndpoint"])
+	}
+	want := "my-bucket.s3-website-us-west-2.amazonaws.com"
+	if got != want {
+		t.Errorf("WebsiteEndpoint = %q, want %q", got, want)
+	}
+}
+
+func TestEnrichBucketProperties_NoWebsiteURL_NoEndpointAdded(t *testing.T) {
+	props := map[string]any{
+		"BucketName": "no-website-bucket",
+	}
+	enrichBucketProperties(props)
+
+	if _, present := props["WebsiteEndpoint"]; present {
+		t.Errorf("WebsiteEndpoint should not be added when WebsiteURL absent, got %v", props["WebsiteEndpoint"])
+	}
+}
+
+func TestEnrichBucketProperties_EmptyWebsiteURL_NoEndpointAdded(t *testing.T) {
+	props := map[string]any{
+		"WebsiteURL": "",
+	}
+	enrichBucketProperties(props)
+
+	if _, present := props["WebsiteEndpoint"]; present {
+		t.Errorf("WebsiteEndpoint should not be added when WebsiteURL is empty, got %v", props["WebsiteEndpoint"])
+	}
+}
+
+func TestEnrichBucketProperties_DualStackWebsiteURL_StripsCorrectly(t *testing.T) {
+	// Dual-stack form returned by S3 in regions that support it; structure differs
+	// (`.s3.dualstack.<region>.` instead of `.s3-website-<region>.`) but the
+	// transformation is still strip-http://-and-trailing-slash.
+	props := map[string]any{
+		"WebsiteURL": "http://my-bucket.s3.dualstack.us-east-2.amazonaws.com/",
+	}
+	enrichBucketProperties(props)
+
+	got, ok := props["WebsiteEndpoint"].(string)
+	if !ok {
+		t.Fatalf("expected WebsiteEndpoint string, got %T", props["WebsiteEndpoint"])
+	}
+	want := "my-bucket.s3.dualstack.us-east-2.amazonaws.com"
+	if got != want {
+		t.Errorf("WebsiteEndpoint = %q, want %q", got, want)
+	}
+}

--- a/schema/pkl/certificatemanager/certificate.pkl
+++ b/schema/pkl/certificatemanager/certificate.pkl
@@ -61,6 +61,12 @@ open class CertificateResolvable extends formae.Resolvable {
         property = "Id"
     }
 
+    // Capture outer `this` so the `new ses.DnsRecordListingResolvable { ... }`
+    // body below references the CertificateResolvable, not the resolvable
+    // being constructed. Without this, `this.label` resolves to the new
+    // listing's own (uninitialised) label and PKL stack-overflows.
+    local self = this
+
     /// Populated by the custom Read provisioner at
     /// pkg/cfres/certificatemanager/certificate.go from ACM's
     /// DescribeCertificate response. Each entry exposes `name`,
@@ -68,9 +74,9 @@ open class CertificateResolvable extends formae.Resolvable {
     /// and `value`. Consume the first SAN's challenge as
     /// `cert.res.validationRecords.at(0).name` etc.
     hidden validationRecords: ses.DnsRecordListingResolvable = new ses.DnsRecordListingResolvable {
-        label = this.label
-        type = this.type
-        stack = this.stack
+        label = self.label
+        type = self.type
+        stack = self.stack
         property = "ValidationRecords"
     }
 }

--- a/schema/pkl/route53/recordset.pkl
+++ b/schema/pkl/route53/recordset.pkl
@@ -117,7 +117,7 @@ open class RecordSet extends formae.Resource {
 
     @aws.FieldHint{
     }
-    type: String
+    type: String|formae.Resolvable
 
     @aws.FieldHint
     weight: Int?

--- a/schema/pkl/s3/bucket.pkl
+++ b/schema/pkl/s3/bucket.pkl
@@ -578,8 +578,22 @@ open class BucketResolvable extends formae.Resolvable {
         property = "RegionalDomainName"
     }
 
+    /// Full S3 website URL including the `http://` scheme and trailing
+    /// slash, e.g. `http://my-bucket.s3-website-us-west-2.amazonaws.com/`.
+    /// For consumers that want hostname-only (e.g. CloudFront's
+    /// Distribution.Origin.domainName), use `websiteEndpoint` instead.
     hidden websiteURL: BucketResolvable = (this) {
         property = "WebsiteURL"
+    }
+
+    /// Hostname-only form of the S3 website endpoint, e.g.
+    /// `my-bucket.s3-website-us-west-2.amazonaws.com`. Derived from
+    /// WebsiteURL by the bucket provisioner's custom Read because CFN's
+    /// GetAtt schema only exposes the full URL. Use this when wiring
+    /// the bucket into CloudFront::Distribution.Origin.domainName, which
+    /// rejects schemed URLs.
+    hidden websiteEndpoint: BucketResolvable = (this) {
+        property = "WebsiteEndpoint"
     }
 
     hidden bucketName: BucketResolvable = (this) {


### PR DESCRIPTION
## Summary

Four interrelated AWS plugin fixes that together unblock single-apply deployment of "Certificate with DNS validation + Route53 RecordSet publishing the validation CNAME + S3 website-hosted origin + CloudFront Distribution". All four were discovered empirically while building a static-site stack against the b9b7f06 CloudFront/ACM schemas.

- **`CertificateResolvable.validationRecords` self-reference** — the `new ses.DnsRecordListingResolvable { label = this.label; ... }` body's implicit `this` resolved to the listing being constructed, not the outer `CertificateResolvable`, stack-overflowing any access to `cert.res.validationRecords` at eval. Fixed by capturing the outer scope to `local self = this`.
- **`Route53::RecordSet.type` widened to `String|formae.Resolvable`** — sibling fields on the resource already accept this union; `type` was the outlier and rejected the new `cert.res.validationRecords.at(0).recordType` Resolvable.
- **`BucketResolvable.websiteEndpoint` accessor added** — CFN's GetAtt schema only exposes `WebsiteURL` (with the `http://` prefix), but CloudFront's `Distribution.Origin.domainName` rejects schemed URLs. A new partial provisioner for `AWS::S3::Bucket` derives `WebsiteEndpoint` from `WebsiteURL` by stripping the scheme + trailing slash; other ops fall through to CloudControl.
- **`Certificate.Create` now blocks until `Status=ISSUED`** — previously returned on `RequestCertificate`, leaving downstream resources (notably `Distribution.viewerCertificate`) racing against the `PENDING_VALIDATION -> ISSUED` transition and forcing a two-apply pattern. The wait is DNS-provider-agnostic: it polls only ACM's view of validation, so the publisher (Route53 today, a future cloudflare-dns plugin tomorrow, or operator-manual) stays composed via the resource graph's `runtimeDependency` edges rather than via provider-aware wait logic. Defaults to 10s poll interval and 15min upper bound; both overridable on the provisioner.

The `cloudfront-acm-smoke` example is extended to exercise the first three at pkl-eval time; the cert-wait change is covered by Go unit tests for the ISSUED transition, the three terminal failure statuses, ctx cancellation mid-wait, and timeout exhaustion.

### Conformance escape hatch

The `certificatemanager-certificate` conformance fixture uses an unvalidatable `*.example` domain, so the new wait would block the lifecycle test until the 15-minute upper bound elapsed. A `FORMAE_AWS_CERT_SKIP_ISSUED_WAIT` env var bypasses the wait when set to `1`/`true`; it is wired into the CI, Nightly, and Debug Conformance workflows. Production deployments leave it unset.