### PR TITLE
fix: revert cert wait-for-ISSUED, retry recoverable CCAPI errors, EFS cleanup hygiene

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,11 +185,6 @@ jobs:
           AWS_REGION: us-east-1
           FORMAE_TEST_RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
-          # The certificatemanager fixture uses an unvalidatable `*.example`
-          # domain. With the new wait-for-ISSUED behavior in Certificate.Create
-          # the cert never transitions in CI, hanging the test until timeout.
-          # Skip the wait under conformance; production deployments leave it on.
-          FORMAE_AWS_CERT_SKIP_ISSUED_WAIT: "1"
         run: make conformance-test-crud-run conformance-test-discovery-run TEST=${{ matrix.test-case }} PARALLEL=1 TIMEOUT=120
 
   # Clean up test resources after all conformance tests (always runs)

--- a/.github/workflows/debug-conformance.yml
+++ b/.github/workflows/debug-conformance.yml
@@ -166,11 +166,6 @@ jobs:
           AWS_REGION: us-east-1
           FORMAE_TEST_RUN_ID: debug-${{ github.run_id }}-${{ github.run_attempt }}
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
-          # The certificatemanager fixture uses an unvalidatable `*.example`
-          # domain. With the new wait-for-ISSUED behavior in Certificate.Create
-          # the cert never transitions in CI, hanging the test until timeout.
-          # Skip the wait under conformance; production deployments leave it on.
-          FORMAE_AWS_CERT_SKIP_ISSUED_WAIT: "1"
         # 90-minute timeout accommodates LB-attached fixtures (ALB provisioning
         # + ECS stabilization + destroy + reapply takes 65-80m). Smaller fixtures
         # are unaffected — they finish well under the bound.

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -259,11 +259,6 @@ jobs:
           AWS_REGION: us-east-1
           FORMAE_TEST_RUN_ID: nightly-main-${{ github.run_id }}
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
-          # The certificatemanager fixture uses an unvalidatable `*.example`
-          # domain. With the new wait-for-ISSUED behavior in Certificate.Create
-          # the cert never transitions in CI, hanging the test until timeout.
-          # Skip the wait under conformance; production deployments leave it on.
-          FORMAE_AWS_CERT_SKIP_ISSUED_WAIT: "1"
         run: make conformance-test-crud-run conformance-test-discovery-run TEST=${{ matrix.test-case }} PARALLEL=1 TIMEOUT=120
 
       - name: Dump formae client log on failure

--- a/pkg/ccx/client.go
+++ b/pkg/ccx/client.go
@@ -433,92 +433,91 @@ func (c *Client) StatusResource(ctx context.Context, request *resource.StatusReq
 
 	// If operation status is success, run a Read to get the latest properties.
 	// Some resources (like DynamoDB tables) may not be immediately readable after
-	// CloudControl reports the operation as successful, so we retry with backoff.
+	// CloudControl reports the operation as successful, and AWS throttling can
+	// flap during high-concurrency periods. retryRead absorbs both with
+	// exponential backoff so the agent doesn't persist a stale snapshot.
 	if operationStatus == resource.OperationStatusSuccess && result.ProgressEvent.Operation != cctypes.OperationDelete {
-		const maxReadRetries = 3
-		const retryDelay = 2 * time.Second
-
-		var readResult *resource.ReadResult
-		var readErr error
-
-		for attempt := 1; attempt <= maxReadRetries; attempt++ {
-			readResult, readErr = readFunc(ctx, &resource.ReadRequest{
-				NativeID:     identifier,
-				ResourceType: *result.ProgressEvent.TypeName,
-				TargetConfig: request.TargetConfig,
+		typeName := *result.ProgressEvent.TypeName
+		readResult, readErr := retryRead(ctx, retryOpts{}, "StatusResource:"+typeName,
+			func(ctx context.Context) (*resource.ReadResult, error) {
+				return readFunc(ctx, &resource.ReadRequest{
+					NativeID:     identifier,
+					ResourceType: typeName,
+					TargetConfig: request.TargetConfig,
+				})
 			})
 
-			if readErr != nil {
-				slog.Warn("StatusResource: Read failed after successful operation",
-					"error", readErr,
-					"identifier", identifier,
-					"resourceType", *result.ProgressEvent.TypeName,
-					"attempt", attempt,
-					"maxRetries", maxReadRetries)
-			} else if readResult != nil && readResult.ErrorCode != "" {
-				slog.Warn("StatusResource: Read returned CloudControl error",
-					"errorCode", readResult.ErrorCode,
-					"identifier", identifier,
-					"resourceType", *result.ProgressEvent.TypeName,
-					"attempt", attempt,
-					"maxRetries", maxReadRetries)
-			} else if readResult != nil && readResult.Properties != "" {
-				// Success - we have properties
-				statusResult.ProgressResult.ResourceProperties = json.RawMessage(readResult.Properties)
-				break
-			}
-
-			// If not the last attempt, wait before retrying
-			if attempt < maxReadRetries {
-				slog.Info("StatusResource: Retrying Read after delay",
-					"identifier", identifier,
-					"delay", retryDelay)
-				time.Sleep(retryDelay)
-			}
+		switch {
+		case readErr != nil:
+			slog.Error("StatusResource: Read failed after retry budget exhausted",
+				"error", readErr,
+				"identifier", identifier,
+				"resourceType", typeName)
+		case readResult != nil && readResult.ErrorCode != "":
+			slog.Error("StatusResource: Read returned CloudControl error after retry budget",
+				"errorCode", readResult.ErrorCode,
+				"identifier", identifier,
+				"resourceType", typeName)
+		case readResult != nil && readResult.Properties != "":
+			statusResult.ProgressResult.ResourceProperties = json.RawMessage(readResult.Properties)
 		}
 
-		// If we exhausted retries without getting properties, log an error
 		if statusResult.ProgressResult.ResourceProperties == nil {
 			slog.Error("StatusResource: Failed to read properties after retries",
 				"identifier", identifier,
-				"resourceType", *result.ProgressEvent.TypeName,
-				"maxRetries", maxReadRetries)
+				"resourceType", typeName)
 		}
 	}
 
 	return statusResult, nil
 }
 
-// populateResourceProperties performs a post-success Read to populate ResourceProperties
-// on a ProgressResult. This is needed when CloudControl returns synchronous Success
-// (without going through StatusResource polling, which already does its own Read).
+// populateResourceProperties performs a post-success Read to populate
+// ResourceProperties on a ProgressResult. Used when CloudControl returns
+// synchronous Success (no async polling, so StatusResource's Read loop
+// doesn't run). Wraps the call in retryRead so transient throttling
+// surfaced as ErrorCode doesn't leave the agent with a stale snapshot.
 func (c *Client) populateResourceProperties(ctx context.Context, pr *resource.ProgressResult, identifier, resourceType string) {
-	readResult, err := c.ReadResource(ctx, &resource.ReadRequest{
-		NativeID:     identifier,
-		ResourceType: resourceType,
-	})
+	readResult, err := retryRead(ctx, retryOpts{}, "populateResourceProperties:"+resourceType,
+		func(ctx context.Context) (*resource.ReadResult, error) {
+			return c.ReadResource(ctx, &resource.ReadRequest{
+				NativeID:     identifier,
+				ResourceType: resourceType,
+			})
+		})
 	if err != nil {
-		slog.Error("post-success Read failed",
+		slog.Error("post-success Read failed after retries",
 			"error", err,
 			"identifier", identifier,
 			"resourceType", resourceType)
 		return
 	}
-	if readResult.ErrorCode != "" {
-		slog.Error("post-success Read returned error",
+	if readResult != nil && readResult.ErrorCode != "" {
+		slog.Error("post-success Read returned error after retries",
 			"errorCode", readResult.ErrorCode,
 			"identifier", identifier,
 			"resourceType", resourceType)
 		return
 	}
-	if readResult.Properties != "" {
+	if readResult != nil && readResult.Properties != "" {
 		pr.ResourceProperties = json.RawMessage(readResult.Properties)
 	}
 }
 
-// ListResources lists resources using CloudControl
+// ListResources lists resources using CloudControl. Wrapped in
+// retryCallable because Discovery has no PluginOperator layer to absorb
+// transient throttling / handler-failure errors; a single 5xx in a scan
+// loop drops the resource type for the tick and the conformance test
+// wait window typically expires before the next periodic scan.
 func (c *Client) ListResources(ctx context.Context, input *cloudcontrol.ListResourcesInput) (*cloudcontrol.ListResourcesOutput, error) {
-	return c.api.ListResources(ctx, input)
+	typeName := ""
+	if input != nil && input.TypeName != nil {
+		typeName = *input.TypeName
+	}
+	return retryCallable(ctx, retryOpts{}, "ListResources:"+typeName,
+		func(ctx context.Context) (*cloudcontrol.ListResourcesOutput, error) {
+			return c.api.ListResources(ctx, input)
+		})
 }
 
 // transformSecretStringPatch transforms replace operations to add operations for SecretString

--- a/pkg/ccx/retry.go
+++ b/pkg/ccx/retry.go
@@ -1,0 +1,239 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package ccx
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"math/rand/v2"
+	"strings"
+	"time"
+
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+)
+
+// Recoverable-error retry budget for ccx-layer calls that don't benefit from
+// the PluginOperator's higher-level retry loop. The two call sites today are:
+//
+//   - StatusResource / populateResourceProperties post-success Reads. When
+//     CloudControl reports a CRUD operation as Success, we Read to enrich the
+//     result. The PluginOperator never sees the Read's ErrorCode because the
+//     CRUD status already returned Success; without retrying here the agent
+//     persists a stale snapshot.
+//
+//   - Discovery's ListResources. Discovery has no PluginOperator wrapping
+//     so a transient AWS throttle or HandlerFailureException returns directly
+//     to the scan loop, which simply drops the resource type for the tick.
+//     The next scan only runs on the periodic schedule, so the
+//     conformance-test wait window typically times out before the next
+//     attempt.
+//
+// Both surfaces need an in-process exponential-backoff loop with a budget
+// long enough to absorb AWS's typical 30-60s recovery window.
+const (
+	defaultRetryMaxAttempts = 6
+	defaultRetryBaseDelay   = 1 * time.Second
+	defaultRetryMaxDelay    = 30 * time.Second
+)
+
+// retryOpts allows callers to override the default budget for tests or for
+// call sites with different tolerance for latency.
+type retryOpts struct {
+	MaxAttempts int
+	BaseDelay   time.Duration
+	MaxDelay    time.Duration
+}
+
+func (o retryOpts) withDefaults() retryOpts {
+	if o.MaxAttempts <= 0 {
+		o.MaxAttempts = defaultRetryMaxAttempts
+	}
+	if o.BaseDelay <= 0 {
+		o.BaseDelay = defaultRetryBaseDelay
+	}
+	if o.MaxDelay <= 0 {
+		o.MaxDelay = defaultRetryMaxDelay
+	}
+	return o
+}
+
+// retryRead repeats `fn` with exponential-backoff-plus-jitter while the
+// returned ReadResult carries a recoverable CCAPI ErrorCode (or `fn`
+// returns a transient Go error). It exits on success (Properties
+// populated, ErrorCode empty), on non-recoverable failure, on context
+// cancellation, or once the attempt budget is exhausted. The last
+// observed result is returned in all exit paths so the caller can
+// inspect it.
+func retryRead(
+	ctx context.Context,
+	opts retryOpts,
+	logHint string,
+	fn func(context.Context) (*resource.ReadResult, error),
+) (*resource.ReadResult, error) {
+	opts = opts.withDefaults()
+
+	var last *resource.ReadResult
+	var lastErr error
+	for attempt := 1; attempt <= opts.MaxAttempts; attempt++ {
+		res, err := fn(ctx)
+		last = res
+		lastErr = err
+
+		switch {
+		case err != nil && !isRecoverable(err, ""):
+			return res, err
+		case err == nil && res != nil && res.ErrorCode == "" && res.Properties != "":
+			return res, nil
+		case err == nil && res != nil && res.ErrorCode != "" && !isRecoverable(nil, string(res.ErrorCode)):
+			// Non-recoverable CCAPI error code (e.g. NotFound) — surface
+			// without further retries.
+			return res, nil
+		}
+
+		if attempt == opts.MaxAttempts {
+			break
+		}
+
+		delay := backoffDelay(attempt, opts.BaseDelay, opts.MaxDelay)
+		errCode := ""
+		if res != nil {
+			errCode = string(res.ErrorCode)
+		}
+		slog.Info("ccx: retrying read on recoverable error",
+			"hint", logHint,
+			"attempt", attempt,
+			"maxAttempts", opts.MaxAttempts,
+			"delay", delay,
+			"err", err,
+			"errorCode", errCode)
+
+		select {
+		case <-ctx.Done():
+			return last, ctx.Err()
+		case <-time.After(delay):
+		}
+	}
+
+	if lastErr != nil {
+		return last, lastErr
+	}
+	return last, nil
+}
+
+// retryCallable repeats `fn` with exponential-backoff-plus-jitter while
+// the returned error matches AWS's recoverable surface (Throttling,
+// HandlerFailure, internal service errors). It exits on success, on
+// non-recoverable error, on context cancellation, or once the attempt
+// budget is exhausted. The last observed result is returned.
+func retryCallable[T any](
+	ctx context.Context,
+	opts retryOpts,
+	logHint string,
+	fn func(context.Context) (T, error),
+) (T, error) {
+	opts = opts.withDefaults()
+
+	var last T
+	var lastErr error
+	for attempt := 1; attempt <= opts.MaxAttempts; attempt++ {
+		v, err := fn(ctx)
+		last = v
+		lastErr = err
+		if err == nil {
+			return v, nil
+		}
+		if !isRecoverable(err, "") {
+			return v, err
+		}
+		if attempt == opts.MaxAttempts {
+			break
+		}
+		delay := backoffDelay(attempt, opts.BaseDelay, opts.MaxDelay)
+		slog.Info("ccx: retrying call on recoverable error",
+			"hint", logHint,
+			"attempt", attempt,
+			"maxAttempts", opts.MaxAttempts,
+			"delay", delay,
+			"err", err)
+		select {
+		case <-ctx.Done():
+			return last, ctx.Err()
+		case <-time.After(delay):
+		}
+	}
+	return last, lastErr
+}
+
+// isRecoverable returns true when either the supplied Go error or the
+// supplied CCAPI ErrorCode string indicates a transient condition that
+// should be retried at the ccx layer.
+//
+// The SDK's built-in Retryer already handles many of these for in-flight
+// requests; this layer catches the cases where the SDK exhausts its own
+// budget and surfaces the wrapped error, plus the post-Read ErrorCode
+// path (which never went through the SDK Retryer because the Read
+// itself succeeded — CCAPI just returned a typed error inside the
+// response).
+func isRecoverable(err error, errorCode string) bool {
+	if errorCode != "" {
+		switch resource.OperationErrorCode(errorCode) {
+		case resource.OperationErrorCodeThrottling,
+			resource.OperationErrorCodeNotStabilized,
+			resource.OperationErrorCodeServiceInternalError,
+			resource.OperationErrorCodeServiceTimeout,
+			resource.OperationErrorCodeNetworkFailure,
+			resource.OperationErrorCodeInternalFailure,
+			resource.OperationErrorCodeGeneralServiceException:
+			return true
+		}
+	}
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	// String-match the wrapped SDK error surface. Once the SDK's standard
+	// retryer exhausts, the error is wrapped multiple times and the
+	// underlying CCAPI typed error isn't preserved as an Is/As target.
+	msg := err.Error()
+	for _, marker := range []string{
+		"ThrottlingException",
+		"Throttling",
+		"HandlerFailureException",
+		"HandlerInternalFailureException",
+		"InternalFailure",
+		"InternalServerError",
+		"ServiceUnavailable",
+		"GeneralServiceException",
+		"RequestTimeout",
+		"exceeded maximum number of attempts",
+	} {
+		if strings.Contains(msg, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// backoffDelay returns base * 2^(attempt-1) capped at maxDelay, with up
+// to 25% jitter added to avoid thundering-herd retries from concurrent
+// matrix jobs all hitting the same recovery window.
+func backoffDelay(attempt int, base, maxDelay time.Duration) time.Duration {
+	if attempt < 1 {
+		attempt = 1
+	}
+	shift := attempt - 1
+	if shift > 30 {
+		shift = 30
+	}
+	delay := base * (1 << shift)
+	if delay > maxDelay || delay <= 0 {
+		delay = maxDelay
+	}
+	jitter := time.Duration(rand.Int64N(int64(delay) / 4))
+	return delay + jitter
+}

--- a/pkg/ccx/retry_test.go
+++ b/pkg/ccx/retry_test.go
@@ -1,0 +1,215 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package ccx
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+)
+
+// Sub-millisecond options keep the retry loop fast under test while still
+// exercising every code path (backoff loop, exhaustion, cancellation).
+func testOpts(attempts int) retryOpts {
+	return retryOpts{
+		MaxAttempts: attempts,
+		BaseDelay:   time.Microsecond,
+		MaxDelay:    time.Microsecond,
+	}
+}
+
+func TestIsRecoverable_ByErrorCode(t *testing.T) {
+	for _, code := range []resource.OperationErrorCode{
+		resource.OperationErrorCodeThrottling,
+		resource.OperationErrorCodeInternalFailure,
+		resource.OperationErrorCodeServiceInternalError,
+		resource.OperationErrorCodeServiceTimeout,
+		resource.OperationErrorCodeNetworkFailure,
+		resource.OperationErrorCodeNotStabilized,
+		resource.OperationErrorCodeGeneralServiceException,
+	} {
+		if !isRecoverable(nil, string(code)) {
+			t.Errorf("expected %s to be recoverable", code)
+		}
+	}
+	for _, code := range []resource.OperationErrorCode{
+		resource.OperationErrorCodeNotFound,
+		resource.OperationErrorCodeAccessDenied,
+		resource.OperationErrorCodeInvalidRequest,
+	} {
+		if isRecoverable(nil, string(code)) {
+			t.Errorf("expected %s to be non-recoverable", code)
+		}
+	}
+}
+
+func TestIsRecoverable_ByErrorMessage(t *testing.T) {
+	for _, msg := range []string{
+		"ThrottlingException: Rate exceeded",
+		"HandlerFailureException: Internal Failure occurred in downstream resource handler",
+		"InternalFailure",
+		"exceeded maximum number of attempts, 2",
+		"ServiceUnavailable",
+	} {
+		if !isRecoverable(errors.New(msg), "") {
+			t.Errorf("expected %q to be recoverable", msg)
+		}
+	}
+	if isRecoverable(errors.New("ResourceNotFoundException"), "") {
+		t.Error("expected NotFound message to be non-recoverable")
+	}
+	if isRecoverable(context.Canceled, "") {
+		t.Error("expected context.Canceled to be non-recoverable")
+	}
+}
+
+func TestRetryRead_SucceedsAfterTransientThrottling(t *testing.T) {
+	calls := 0
+	res, err := retryRead(context.Background(), testOpts(5), "test",
+		func(ctx context.Context) (*resource.ReadResult, error) {
+			calls++
+			if calls < 3 {
+				return &resource.ReadResult{ErrorCode: resource.OperationErrorCodeThrottling}, nil
+			}
+			return &resource.ReadResult{Properties: `{"k":"v"}`}, nil
+		})
+	if err != nil {
+		t.Fatalf("retryRead: %v", err)
+	}
+	if res == nil || res.Properties != `{"k":"v"}` {
+		t.Fatalf("expected properties on success, got %+v", res)
+	}
+	if calls != 3 {
+		t.Errorf("expected 3 calls, got %d", calls)
+	}
+}
+
+func TestRetryRead_ExhaustsBudgetOnPersistentThrottling(t *testing.T) {
+	calls := 0
+	res, err := retryRead(context.Background(), testOpts(4), "test",
+		func(ctx context.Context) (*resource.ReadResult, error) {
+			calls++
+			return &resource.ReadResult{ErrorCode: resource.OperationErrorCodeThrottling}, nil
+		})
+	if err != nil {
+		t.Fatalf("retryRead should not surface err on exhausted recoverable code, got %v", err)
+	}
+	if res == nil || res.ErrorCode != resource.OperationErrorCodeThrottling {
+		t.Errorf("expected last result with Throttling, got %+v", res)
+	}
+	if calls != 4 {
+		t.Errorf("expected 4 calls, got %d", calls)
+	}
+}
+
+func TestRetryRead_NonRecoverableExitsImmediately(t *testing.T) {
+	calls := 0
+	res, err := retryRead(context.Background(), testOpts(5), "test",
+		func(ctx context.Context) (*resource.ReadResult, error) {
+			calls++
+			return &resource.ReadResult{ErrorCode: resource.OperationErrorCodeNotFound}, nil
+		})
+	if err != nil {
+		t.Fatalf("retryRead: %v", err)
+	}
+	if res == nil || res.ErrorCode != resource.OperationErrorCodeNotFound {
+		t.Errorf("expected NotFound to be returned without retry, got %+v", res)
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 call for non-recoverable error, got %d", calls)
+	}
+}
+
+func TestRetryRead_ContextCancelExitsCleanly(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	calls := 0
+	_, err := retryRead(ctx, retryOpts{MaxAttempts: 10, BaseDelay: 50 * time.Millisecond, MaxDelay: 50 * time.Millisecond}, "test",
+		func(ctx context.Context) (*resource.ReadResult, error) {
+			calls++
+			if calls == 1 {
+				cancel()
+			}
+			return &resource.ReadResult{ErrorCode: resource.OperationErrorCodeThrottling}, nil
+		})
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+func TestRetryCallable_SucceedsAfterTransientError(t *testing.T) {
+	calls := 0
+	result, err := retryCallable(context.Background(), testOpts(5), "test",
+		func(ctx context.Context) (string, error) {
+			calls++
+			if calls < 3 {
+				return "", fmt.Errorf("ThrottlingException: Rate exceeded")
+			}
+			return "ok", nil
+		})
+	if err != nil {
+		t.Fatalf("retryCallable: %v", err)
+	}
+	if result != "ok" {
+		t.Errorf("expected ok, got %q", result)
+	}
+	if calls != 3 {
+		t.Errorf("expected 3 calls, got %d", calls)
+	}
+}
+
+func TestRetryCallable_ExhaustsOnPersistentHandlerFailure(t *testing.T) {
+	calls := 0
+	_, err := retryCallable(context.Background(), testOpts(4), "test",
+		func(ctx context.Context) (string, error) {
+			calls++
+			return "", fmt.Errorf("HandlerFailureException: Internal Failure occurred in downstream resource handler")
+		})
+	if err == nil {
+		t.Fatal("expected error after exhausted budget")
+	}
+	if calls != 4 {
+		t.Errorf("expected 4 calls, got %d", calls)
+	}
+}
+
+func TestRetryCallable_NonRecoverableErrorReturnsImmediately(t *testing.T) {
+	calls := 0
+	_, err := retryCallable(context.Background(), testOpts(5), "test",
+		func(ctx context.Context) (string, error) {
+			calls++
+			return "", fmt.Errorf("ValidationException: invalid input")
+		})
+	if err == nil {
+		t.Fatal("expected error to propagate")
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 call for non-recoverable error, got %d", calls)
+	}
+}
+
+func TestBackoffDelay_ExponentialWithJitter(t *testing.T) {
+	base := 100 * time.Millisecond
+	max := 5 * time.Second
+	last := time.Duration(0)
+	for attempt := 1; attempt <= 5; attempt++ {
+		d := backoffDelay(attempt, base, max)
+		if d < base {
+			t.Errorf("attempt %d: delay %v less than base %v", attempt, d, base)
+		}
+		if d > max+max/4 {
+			t.Errorf("attempt %d: delay %v exceeds max+jitter %v", attempt, d, max+max/4)
+		}
+		if attempt > 1 && d < last/2 {
+			t.Errorf("attempt %d: delay %v unexpectedly smaller than half of prev %v", attempt, d, last)
+		}
+		last = d
+	}
+}

--- a/pkg/cfres/certificatemanager/certificate.go
+++ b/pkg/cfres/certificatemanager/certificate.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"os"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -25,18 +24,21 @@ import (
 	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/config"
 )
 
-// Wait-for-ISSUED defaults. Operators with unusual DNS-propagation
-// expectations can override these on the provisioner at construction
-// time; tests do so to keep run-time in microseconds.
+// ACM populates DomainValidationOptions[].ResourceRecord asynchronously
+// after RequestCertificate returns — typically within a second. Create
+// briefly polls DescribeCertificate so the validation records are
+// populated in the returned resource state by the time downstream
+// consumers (e.g. a Route53::RecordSet wired to
+// cert.res.validationRecords.at(0).name) try to resolve them.
+//
+// We intentionally do NOT wait for Status=ISSUED here: ACM cannot
+// transition to ISSUED until the validation CNAME is published in DNS,
+// and the publisher is a downstream resource that cannot start until
+// this Create returns. Waiting for ISSUED inside Create deadlocks the
+// changeset.
 const (
-	defaultPollInterval  = 10 * time.Second
-	defaultIssuedTimeout = 15 * time.Minute
-
-	// skipIssuedWaitEnvVar disables the wait-for-ISSUED loop when set to
-	// "1" / "true". The conformance fixture uses unvalidatable
-	// `*.example` domains where the cert never reaches ISSUED, so the
-	// CI harness sets this to keep the lifecycle test fast.
-	skipIssuedWaitEnvVar = "FORMAE_AWS_CERT_SKIP_ISSUED_WAIT"
+	validationRecordsPollInterval = 500 * time.Millisecond
+	validationRecordsPollAttempts = 10
 )
 
 // Certificate is the AWS::CertificateManager::Certificate provisioner.
@@ -56,12 +58,13 @@ const (
 type Certificate struct {
 	cfg              *config.Config
 	acmClientFactory func(cfg *config.Config) (ACMClientInterface, error)
-	// pollInterval is how long Create sleeps between DescribeCertificate
-	// polls while waiting for Status=ISSUED. Zero means use the default.
-	pollInterval time.Duration
-	// issuedTimeout is the upper bound on the wait-for-ISSUED loop. Zero
-	// means use the default.
-	issuedTimeout time.Duration
+	// validationRecordsPollInterval is the gap between DescribeCertificate
+	// polls during the brief Create-time wait for ACM to populate
+	// DomainValidationOptions[].ResourceRecord. Zero means use the default.
+	validationRecordsPollInterval time.Duration
+	// validationRecordsPollAttempts is the upper bound on the number of
+	// polls. Zero means use the default.
+	validationRecordsPollAttempts int
 }
 
 var _ prov.Provisioner = &Certificate{}
@@ -196,18 +199,12 @@ func (c *Certificate) Create(ctx context.Context, request *resource.CreateReques
 		}
 	}
 
-	// Block until the cert reaches ISSUED so downstream resources that
-	// depend on the ARN (e.g. CloudFront::Distribution.viewerCertificate)
-	// can be created in the same apply. The DNS publisher is wired
-	// upstream via runtimeDependency; this loop only observes ACM's view
-	// of the validation outcome.
-	if err := c.waitForIssued(ctx, client, certArn); err != nil {
-		return nil, err
-	}
-
-	// Read back so callers get the fully-enriched property set (including
-	// any validation records that ACM has already populated).
-	props, _ := c.readProperties(ctx, client, certArn)
+	// Read back so callers get the fully-enriched property set, briefly
+	// polling for the validation records that ACM populates
+	// asynchronously after RequestCertificate returns. Downstream
+	// resources wired to cert.res.validationRecords expect these to be
+	// present when Create reports Success.
+	props, _ := c.readPropertiesWithValidationRecords(ctx, client, certArn)
 	propsBytes, _ := json.Marshal(props)
 
 	return &resource.CreateResult{
@@ -220,59 +217,65 @@ func (c *Certificate) Create(ctx context.Context, request *resource.CreateReques
 	}, nil
 }
 
-// waitForIssued polls DescribeCertificate until Status transitions to
-// ISSUED, hits a terminal failure (FAILED / REVOKED /
-// VALIDATION_TIMED_OUT), the context is cancelled, or the configured
-// timeout elapses.
+// readPropertiesWithValidationRecords reads the cert's properties and
+// briefly polls until DomainValidationOptions[].ResourceRecord is
+// populated for at least one domain. ACM populates these asynchronously
+// after RequestCertificate returns -- typically in well under a second
+// -- and downstream consumers wired to cert.res.validationRecords expect
+// them to be present when Create reports Success.
 //
-// The provisioner makes no assumption about who publishes the validation
-// CNAME — that's the responsibility of upstream resources wired via
-// runtimeDependency (Route53::RecordSet from this plugin today, or any
-// other DNS plugin tomorrow). We only observe ACM's view; AWS owns the
-// validation check itself, so DNS-provider work composes via the
-// resource graph rather than via provider-aware wait logic here.
-func (c *Certificate) waitForIssued(ctx context.Context, client ACMClientInterface, certArn string) error {
-	if skip := os.Getenv(skipIssuedWaitEnvVar); skip == "1" || skip == "true" {
-		slog.Info("acm: skipping wait-for-ISSUED due to env override", "cert_arn", certArn, "env", skipIssuedWaitEnvVar)
-		return nil
-	}
-
-	pollInterval := c.pollInterval
+// We do NOT wait for ACM to transition out of PENDING_VALIDATION: the
+// validation CNAME is published by a downstream resource that cannot
+// start until this Create returns, so waiting for ISSUED here would
+// deadlock the changeset.
+//
+// EMAIL-validated certs never populate ResourceRecord; the poll
+// budget caps total wait so they don't pay an unnecessary delay.
+func (c *Certificate) readPropertiesWithValidationRecords(
+	ctx context.Context,
+	client ACMClientInterface,
+	certArn string,
+) (map[string]any, error) {
+	pollInterval := c.validationRecordsPollInterval
 	if pollInterval <= 0 {
-		pollInterval = defaultPollInterval
+		pollInterval = validationRecordsPollInterval
 	}
-	issuedTimeout := c.issuedTimeout
-	if issuedTimeout <= 0 {
-		issuedTimeout = defaultIssuedTimeout
+	maxAttempts := c.validationRecordsPollAttempts
+	if maxAttempts <= 0 {
+		maxAttempts = validationRecordsPollAttempts
 	}
 
-	deadline := time.Now().Add(issuedTimeout)
-	for {
-		desc, err := client.DescribeCertificate(ctx, &acm.DescribeCertificateInput{
-			CertificateArn: aws.String(certArn),
-		})
+	var props map[string]any
+	var err error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		props, err = c.readProperties(ctx, client, certArn)
 		if err != nil {
-			return fmt.Errorf("acm: DescribeCertificate while waiting for ISSUED: %w", err)
+			return nil, err
 		}
-		if desc != nil && desc.Certificate != nil {
-			switch desc.Certificate.Status {
-			case acmtypes.CertificateStatusIssued:
-				return nil
-			case acmtypes.CertificateStatusFailed,
-				acmtypes.CertificateStatusRevoked,
-				acmtypes.CertificateStatusValidationTimedOut:
-				return fmt.Errorf("acm: certificate %s reached terminal status %s before issuance", certArn, desc.Certificate.Status)
-			}
+		if hasNonEmptyValidationRecords(props) {
+			return props, nil
 		}
-		if time.Now().After(deadline) {
-			return fmt.Errorf("acm: certificate %s still not ISSUED after %s", certArn, issuedTimeout)
+		if attempt == maxAttempts {
+			break
 		}
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("acm: certificate %s wait cancelled: %w", certArn, ctx.Err())
+			return props, nil
 		case <-time.After(pollInterval):
 		}
 	}
+	slog.Info("acm: validation records still empty after poll budget; returning current state",
+		"cert_arn", certArn,
+		"attempts", maxAttempts)
+	return props, nil
+}
+
+func hasNonEmptyValidationRecords(props map[string]any) bool {
+	records, ok := props["ValidationRecords"].([]ses.DnsRecord)
+	if !ok {
+		return false
+	}
+	return len(records) > 0
 }
 
 // ----- Read -----

--- a/pkg/cfres/certificatemanager/certificate_test.go
+++ b/pkg/cfres/certificatemanager/certificate_test.go
@@ -101,17 +101,17 @@ func (f *fakeACMClient) UpdateCertificateOptions(_ context.Context, in *acm.Upda
 }
 
 // newCertificateWithFake wires a Certificate provisioner against the
-// supplied fake client with a very short poll interval so wait-for-ISSUED
-// tests complete in microseconds rather than seconds. Tests that need
-// to drive the timeout path override issuedTimeout directly afterwards.
+// supplied fake client with a tiny validation-records poll interval so
+// the post-Create read-back returns in microseconds when records are
+// present (and finishes its budget quickly when they aren't).
 func newCertificateWithFake(fake *fakeACMClient) *Certificate {
 	return &Certificate{
 		cfg: &config.Config{Region: "us-east-1"},
 		acmClientFactory: func(_ *config.Config) (ACMClientInterface, error) {
 			return fake, nil
 		},
-		pollInterval:  time.Microsecond,
-		issuedTimeout: 5 * time.Second,
+		validationRecordsPollInterval: time.Microsecond,
+		validationRecordsPollAttempts: 3,
 	}
 }
 
@@ -127,7 +127,17 @@ func TestCreate_DnsValidation_RequestsCertificateAndReturnsArn(t *testing.T) {
 				CertificateArn: aws.String("arn:aws:acm:us-east-1:111:certificate/abcd"),
 				DomainName:     aws.String("example.com"),
 				KeyAlgorithm:   acmtypes.KeyAlgorithmRsa2048,
-				Status:         acmtypes.CertificateStatusIssued,
+				Status:         acmtypes.CertificateStatusPendingValidation,
+				DomainValidationOptions: []acmtypes.DomainValidation{
+					{
+						DomainName: aws.String("example.com"),
+						ResourceRecord: &acmtypes.ResourceRecord{
+							Name:  aws.String("_abc.example.com."),
+							Type:  acmtypes.RecordTypeCname,
+							Value: aws.String("_xyz.acm-validations.aws."),
+						},
+					},
+				},
 			},
 		},
 	}
@@ -173,7 +183,7 @@ func TestCreate_SansAndTags_PassThroughToAPI(t *testing.T) {
 		describeCertificateOut: &acm.DescribeCertificateOutput{
 			Certificate: &acmtypes.CertificateDetail{
 				DomainName: aws.String("example.com"),
-				Status:     acmtypes.CertificateStatusIssued,
+				Status:     acmtypes.CertificateStatusPendingValidation,
 			},
 		},
 	}
@@ -210,7 +220,7 @@ func TestCreate_TransparencyPreference_AppliedViaUpdateOptions(t *testing.T) {
 		describeCertificateOut: &acm.DescribeCertificateOutput{
 			Certificate: &acmtypes.CertificateDetail{
 				DomainName: aws.String("example.com"),
-				Status:     acmtypes.CertificateStatusIssued,
+				Status:     acmtypes.CertificateStatusPendingValidation,
 			},
 		},
 	}
@@ -249,17 +259,20 @@ func TestCreate_RequestCertificateError_BubblesUp(t *testing.T) {
 	}
 }
 
-// ----- Create: wait-for-ISSUED -----
+// ----- Create: validation-records readback -----
 //
-// ACM RequestCertificate returns the new ARN while the cert is still
-// PENDING_VALIDATION. CloudFront's Distribution.viewerCertificate
-// requires the cert to be ISSUED before it accepts the ARN, so Create
-// must block until ACM reports ISSUED (or a terminal failure) so the
-// changeset can wire downstream resources in a single apply. The DNS
-// publisher is wired upstream via runtimeDependency; this loop does not
-// query Route53 (the publisher could be Cloudflare or operator-manual).
+// ACM populates DomainValidationOptions[].ResourceRecord asynchronously
+// after RequestCertificate returns. Create briefly polls the readback so
+// downstream consumers wired to cert.res.validationRecords see them when
+// Create reports Success. The poll budget is small (a few hundred
+// milliseconds in production) because the ACM async window is sub-second
+// in practice; tests configure microsecond intervals.
 
-func TestCreate_WaitForIssued_TransitionsFromPendingToIssued(t *testing.T) {
+func TestCreate_ReadbackPollsForValidationRecords_RecordsAvailable(t *testing.T) {
+	// First readback returns no DomainValidationOptions yet; second
+	// returns the populated ResourceRecord. Create should keep Status as
+	// PENDING_VALIDATION (it does not wait for ISSUED) but surface the
+	// validation records to downstream consumers.
 	fake := &fakeACMClient{
 		requestCertificateOut: &acm.RequestCertificateOutput{
 			CertificateArn: aws.String("arn:fake"),
@@ -274,178 +287,74 @@ func TestCreate_WaitForIssued_TransitionsFromPendingToIssued(t *testing.T) {
 				CertificateArn: aws.String("arn:fake"),
 				DomainName:     aws.String("example.com"),
 				Status:         acmtypes.CertificateStatusPendingValidation,
+				DomainValidationOptions: []acmtypes.DomainValidation{
+					{
+						DomainName: aws.String("example.com"),
+						ResourceRecord: &acmtypes.ResourceRecord{
+							Name:  aws.String("_abc.example.com."),
+							Type:  acmtypes.RecordTypeCname,
+							Value: aws.String("_xyz.acm-validations.aws."),
+						},
+					},
+				},
 			}},
-			{Certificate: &acmtypes.CertificateDetail{
+		},
+	}
+	cert := newCertificateWithFake(fake)
+
+	props := map[string]any{"DomainName": "example.com", "ValidationMethod": "DNS"}
+	body, _ := json.Marshal(props)
+	res, err := cert.Create(context.Background(), &resource.CreateRequest{Properties: body})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if res.ProgressResult.OperationStatus != resource.OperationStatusSuccess {
+		t.Errorf("OperationStatus: want Success, got %v", res.ProgressResult.OperationStatus)
+	}
+	if fake.describeCertificateCalls < 2 {
+		t.Errorf("expected at least 2 DescribeCertificate calls (re-poll for records), got %d", fake.describeCertificateCalls)
+	}
+
+	var returnedProps map[string]any
+	if err := json.Unmarshal(res.ProgressResult.ResourceProperties, &returnedProps); err != nil {
+		t.Fatalf("unmarshal returned properties: %v", err)
+	}
+	records, ok := returnedProps["ValidationRecords"].([]any)
+	if !ok {
+		t.Fatalf("expected ValidationRecords slice in returned properties, got %T", returnedProps["ValidationRecords"])
+	}
+	if len(records) != 1 {
+		t.Errorf("ValidationRecords: want 1, got %d", len(records))
+	}
+}
+
+func TestCreate_ReadbackBudgetExhausted_ReturnsSuccessAnyway(t *testing.T) {
+	// EMAIL-validated certs never populate ResourceRecord; Create should
+	// exhaust the poll budget and still return Success so the apply
+	// proceeds.
+	fake := &fakeACMClient{
+		requestCertificateOut: &acm.RequestCertificateOutput{
+			CertificateArn: aws.String("arn:fake"),
+		},
+		describeCertificateOut: &acm.DescribeCertificateOutput{
+			Certificate: &acmtypes.CertificateDetail{
 				CertificateArn: aws.String("arn:fake"),
 				DomainName:     aws.String("example.com"),
-				Status:         acmtypes.CertificateStatusIssued,
-			}},
+				Status:         acmtypes.CertificateStatusPendingValidation,
+				// No DomainValidationOptions (e.g. EMAIL-validated path)
+			},
 		},
 	}
 	cert := newCertificateWithFake(fake)
 
-	props := map[string]any{"DomainName": "example.com", "ValidationMethod": "DNS"}
+	props := map[string]any{"DomainName": "example.com", "ValidationMethod": "EMAIL"}
 	body, _ := json.Marshal(props)
 	res, err := cert.Create(context.Background(), &resource.CreateRequest{Properties: body})
 	if err != nil {
-		t.Fatalf("Create failed after eventual ISSUED: %v", err)
+		t.Fatalf("Create should not error when validation records remain empty, got %v", err)
 	}
 	if res.ProgressResult.OperationStatus != resource.OperationStatusSuccess {
 		t.Errorf("OperationStatus: want Success, got %v", res.ProgressResult.OperationStatus)
-	}
-	// 3 polls for state transitions + 1 readback at the end.
-	if fake.describeCertificateCalls < 3 {
-		t.Errorf("expected at least 3 DescribeCertificate calls during wait, got %d", fake.describeCertificateCalls)
-	}
-}
-
-func TestCreate_WaitForIssued_StatusFailed_ReturnsError(t *testing.T) {
-	fake := &fakeACMClient{
-		requestCertificateOut: &acm.RequestCertificateOutput{
-			CertificateArn: aws.String("arn:fake"),
-		},
-		describeCertificateOut: &acm.DescribeCertificateOutput{
-			Certificate: &acmtypes.CertificateDetail{
-				CertificateArn: aws.String("arn:fake"),
-				Status:         acmtypes.CertificateStatusFailed,
-			},
-		},
-	}
-	cert := newCertificateWithFake(fake)
-
-	props := map[string]any{"DomainName": "example.com", "ValidationMethod": "DNS"}
-	body, _ := json.Marshal(props)
-	_, err := cert.Create(context.Background(), &resource.CreateRequest{Properties: body})
-	if err == nil {
-		t.Fatal("expected Create to error on terminal FAILED status")
-	}
-}
-
-func TestCreate_WaitForIssued_StatusRevoked_ReturnsError(t *testing.T) {
-	fake := &fakeACMClient{
-		requestCertificateOut: &acm.RequestCertificateOutput{
-			CertificateArn: aws.String("arn:fake"),
-		},
-		describeCertificateOut: &acm.DescribeCertificateOutput{
-			Certificate: &acmtypes.CertificateDetail{
-				CertificateArn: aws.String("arn:fake"),
-				Status:         acmtypes.CertificateStatusRevoked,
-			},
-		},
-	}
-	cert := newCertificateWithFake(fake)
-
-	props := map[string]any{"DomainName": "example.com", "ValidationMethod": "DNS"}
-	body, _ := json.Marshal(props)
-	_, err := cert.Create(context.Background(), &resource.CreateRequest{Properties: body})
-	if err == nil {
-		t.Fatal("expected Create to error on terminal REVOKED status")
-	}
-}
-
-func TestCreate_WaitForIssued_StatusValidationTimedOut_ReturnsError(t *testing.T) {
-	fake := &fakeACMClient{
-		requestCertificateOut: &acm.RequestCertificateOutput{
-			CertificateArn: aws.String("arn:fake"),
-		},
-		describeCertificateOut: &acm.DescribeCertificateOutput{
-			Certificate: &acmtypes.CertificateDetail{
-				CertificateArn: aws.String("arn:fake"),
-				Status:         acmtypes.CertificateStatusValidationTimedOut,
-			},
-		},
-	}
-	cert := newCertificateWithFake(fake)
-
-	props := map[string]any{"DomainName": "example.com", "ValidationMethod": "DNS"}
-	body, _ := json.Marshal(props)
-	_, err := cert.Create(context.Background(), &resource.CreateRequest{Properties: body})
-	if err == nil {
-		t.Fatal("expected Create to error on terminal VALIDATION_TIMED_OUT status")
-	}
-}
-
-func TestCreate_WaitForIssued_ContextCancelled_ReturnsError(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	fake := &fakeACMClient{
-		requestCertificateOut: &acm.RequestCertificateOutput{
-			CertificateArn: aws.String("arn:fake"),
-		},
-		describeCertificateOut: &acm.DescribeCertificateOutput{
-			Certificate: &acmtypes.CertificateDetail{
-				CertificateArn: aws.String("arn:fake"),
-				Status:         acmtypes.CertificateStatusPendingValidation,
-			},
-		},
-	}
-	// Cancel on the second describe call (first one returns PENDING and loop continues).
-	fake.describeCertificateHook = func(call int) {
-		if call == 2 {
-			cancel()
-		}
-	}
-	cert := newCertificateWithFake(fake)
-
-	props := map[string]any{"DomainName": "example.com", "ValidationMethod": "DNS"}
-	body, _ := json.Marshal(props)
-	_, err := cert.Create(ctx, &resource.CreateRequest{Properties: body})
-	if err == nil {
-		t.Fatal("expected Create to error when ctx is cancelled mid-wait")
-	}
-	if !errors.Is(err, context.Canceled) {
-		t.Errorf("expected wrapped context.Canceled, got %v", err)
-	}
-}
-
-func TestCreate_WaitForIssued_EnvOverride_SkipsWait(t *testing.T) {
-	t.Setenv("FORMAE_AWS_CERT_SKIP_ISSUED_WAIT", "1")
-	fake := &fakeACMClient{
-		requestCertificateOut: &acm.RequestCertificateOutput{
-			CertificateArn: aws.String("arn:fake"),
-		},
-		// Status is PENDING_VALIDATION but the env override should make
-		// Create return without polling further than the readback.
-		describeCertificateOut: &acm.DescribeCertificateOutput{
-			Certificate: &acmtypes.CertificateDetail{
-				CertificateArn: aws.String("arn:fake"),
-				Status:         acmtypes.CertificateStatusPendingValidation,
-			},
-		},
-	}
-	cert := newCertificateWithFake(fake)
-	cert.issuedTimeout = time.Hour // would normally block; the override must skip the wait
-
-	props := map[string]any{"DomainName": "test.example", "ValidationMethod": "DNS"}
-	body, _ := json.Marshal(props)
-	res, err := cert.Create(context.Background(), &resource.CreateRequest{Properties: body})
-	if err != nil {
-		t.Fatalf("Create should succeed when env override is set, got %v", err)
-	}
-	if res.ProgressResult.OperationStatus != resource.OperationStatusSuccess {
-		t.Errorf("OperationStatus: want Success, got %v", res.ProgressResult.OperationStatus)
-	}
-}
-
-func TestCreate_WaitForIssued_Timeout_ReturnsError(t *testing.T) {
-	fake := &fakeACMClient{
-		requestCertificateOut: &acm.RequestCertificateOutput{
-			CertificateArn: aws.String("arn:fake"),
-		},
-		describeCertificateOut: &acm.DescribeCertificateOutput{
-			Certificate: &acmtypes.CertificateDetail{
-				CertificateArn: aws.String("arn:fake"),
-				Status:         acmtypes.CertificateStatusPendingValidation,
-			},
-		},
-	}
-	cert := newCertificateWithFake(fake)
-	cert.issuedTimeout = 5 * time.Millisecond
-
-	props := map[string]any{"DomainName": "example.com", "ValidationMethod": "DNS"}
-	body, _ := json.Marshal(props)
-	_, err := cert.Create(context.Background(), &resource.CreateRequest{Properties: body})
-	if err == nil {
-		t.Fatal("expected Create to error when wait times out without ISSUED")
 	}
 }
 

--- a/scripts/ci/clean-environment.sh
+++ b/scripts/ci/clean-environment.sh
@@ -1089,11 +1089,30 @@ done
 # EFS Resources (regional)
 # ============================================================================
 
-# 31. Delete EFS file systems with test prefix (by Name tag)
+# 31. Delete EFS file systems that look like test orphans.
+#
+# The fixture-side label "test-fs-for-mounttarget" doesn't propagate to an
+# AWS tag, so the original Name-tag match missed every FS the
+# efs-mounttarget discovery test creates. Empirically these accumulate
+# untagged and trip the CCAPI ListResources call under conformance load
+# (the per-account elasticfilesystem rate limit hits, surfaced as
+# HandlerFailureException). Match three cases here:
+#   1. Tag-name prefix (FORMAE_PREFIX): standard formae-created FSes
+#   2. Tag-name prefix (TEST_PREFIX):   plugin-sdk fixtures with explicit tags
+#   3. Untagged with zero mount targets: conformance orphans (the discovery
+#      test creates these directly and they have no tags at all)
 echo "Cleaning EFS test file systems..."
 aws efs describe-file-systems --region "$REGION" \
-    --query "FileSystems[].{Id:FileSystemId, Tags:Tags}" --output json 2>/dev/null | \
-    jq -r '.[] | select(.Tags[]? | select(.Key == "Name" and (.Value | test("'"$FORMAE_PREFIX"'")))) | .Id' 2>/dev/null | while read -r fs_id; do
+    --query "FileSystems[].{Id:FileSystemId, Tags:Tags, MountTargets:NumberOfMountTargets}" --output json 2>/dev/null | \
+    jq -r '
+      .[] |
+      select(
+        (.Tags // []) as $tags |
+        ($tags | any(.Key == "Name" and ((.Value | test("'"$FORMAE_PREFIX"'")) or (.Value | test("'"$TEST_PREFIX"'")))))
+        or
+        ((.Tags == null or .Tags == []) and .MountTargets == 0)
+      ) | .Id
+    ' 2>/dev/null | while read -r fs_id; do
     if [[ -n "$fs_id" ]]; then
         echo "  Deleting EFS file system: $fs_id"
         # Delete mount targets first

--- a/testdata/efs-mounttarget.pkl
+++ b/testdata/efs-mounttarget.pkl
@@ -41,12 +41,17 @@ local testSg = new securitygroup.SecurityGroup {
   vpcId = testVpc.res.vpcId
 }
 
-// FileSystem dependency
+// FileSystem dependency. The Name tag mirrors the formae label so the
+// CI cleanup script catches orphans even when a test aborts before its
+// own teardown can run.
 local testFs = new filesystem.FileSystem {
   label = "test-fs-for-mounttarget"
   encrypted = true
   performanceMode = "generalPurpose"
   throughputMode = "bursting"
+  fileSystemTags = new Listing<aws.Tag> {
+    new { key = "Name"; value = "formae-plugin-sdk-test-fs-for-mounttarget-\(testRunID)" }
+  }
 }
 
 forma {


### PR DESCRIPTION
## Summary

Four interrelated fixes that get the nightly conformance suite back to consistent green and undo a structural deadlock introduced in `0.1.11-dev.10`.

### 1. Revert `Certificate.Create` wait-for-ISSUED (deadlock)

The dev.10 wait-loop deadlocks any single-apply stack that pairs the cert with a sibling Route53 RecordSet (or any DNS publisher) for validation: `cert.Create` blocks on `Status=ISSUED`, but the RecordSet that publishes the validation CNAME can't start until `cert.Create` returns. Lengthening the timeout doesn't help — the deadlock is structural, not temporal.

Restore the b9b7f06 design: `RequestCertificate` returns synchronously, the validation lifecycle is surfaced via `cert.res.validationRecords` (populated by `DescribeCertificate`). `Create` now does a brief readback poll (≤5s budget) so `DomainValidationOptions[].ResourceRecord` is populated by the time downstream consumers try to resolve it — ACM's async population window is typically sub-second. The `FORMAE_AWS_CERT_SKIP_ISSUED_WAIT` env var is also removed from the CI, Nightly, and Debug Conformance workflows.

The "Distribution.viewerCertificate needs cert ISSUED" coordination problem is real, but the right fix is a readiness signal in formae-core's Resolvable model; out of scope for this revert.

### 2. Exponential-backoff retry for recoverable CCAPI errors

Three nightly failures (`kms-key`, `iam-userpolicy`, `efs-mounttarget`) share a single root: transient AWS errors exhaust the existing tight retry budget. The post-Update Read in `StatusResource` retries 3× at 2s fixed delay — not enough for the 30-60s AWS Throttling recovery window. Discovery's `ListResources` has only the SDK's two-attempt budget and no PluginOperator wrapping.

Returning `Failure+Throttling` upward would also be wrong on the StatusCheck path: `PluginOperator` retries the original CRUD operation (not just the Read), and high-attempt exponential backoff can outrun the ResourceUpdater's `PluginOperatorMissingInAction` state timeout. Replicate the retry behavior in-plugin instead.

New `pkg/ccx/retry.go` provides `retryRead` and `retryCallable` helpers — exponential backoff with jitter, 6 attempts at 1s base capped at 30s (~60s total budget). Recoverable-error detection matches `resource.IsRecoverable` plus a fallback string-match for the SDK-wrapped surface. Applied at `StatusResource` post-Read, `populateResourceProperties`, and the `ListResources` entry point.

### 3. Broaden EFS cleanup + tag the efs-mounttarget fixture

`AWS::EFS::FileSystem` orphans have been accumulating in the test account since exactly 2026-05-27 (the max-parallel 5→10 commit): 53 untagged FSes counted today. The cleanup script's `Name`-tag prefix match never caught them because the harness-created FSes were untagged. The accumulating count compounds per-account `elasticfilesystem` rate pressure each scan, which is the trigger for the `HandlerFailureException` 500.

`clean-environment.sh` now matches `FORMAE_PREFIX` OR `TEST_PREFIX` OR (untagged AND zero mount targets) — the third clause sweeps orphans no tagged-match could reach, with the mount-target guard avoiding anything actively in use. The `efs-mounttarget` fixture also picks up a `Name` tag mirroring its formae label so future runs are catchable by the standard tag path.

A one-time manual purge of the existing 53 orphans is needed before the new cleanup path takes over.