### PR TITLE
fix(cloudfront): full payloads on Function/Distribution Update + cert validation Name normalization

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/platform-engineering-labs/formae-plugin-aws
 go 1.26.0
 
 require (
-	github.com/aws/aws-sdk-go-v2 v1.41.11
+	github.com/aws/aws-sdk-go-v2 v1.41.12
 	github.com/aws/aws-sdk-go-v2/config v1.32.16
 	github.com/aws/aws-sdk-go-v2/service/acm v1.39.4
 	github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.29.14
@@ -20,7 +20,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sesv2 v1.60.4
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.23
 	github.com/aws/aws-sdk-go-v2/service/sts v1.42.0
-	github.com/aws/smithy-go v1.27.0
+	github.com/aws/smithy-go v1.27.1
 	github.com/google/uuid v1.6.0
 	github.com/platform-engineering-labs/formae/pkg/model v0.1.25-0.20260528030337-9ae690b3715c
 	github.com/platform-engineering-labs/formae/pkg/plugin v0.2.3-0.20260528030337-9ae690b3715c
@@ -37,9 +37,10 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.15 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.22 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.10 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.27 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.27 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.28 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.28 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.24 // indirect
+	github.com/aws/aws-sdk-go-v2/service/cloudfront v1.65.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.12 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.22 // indirect
@@ -52,6 +53,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/ebitengine/purego v0.9.1 // indirect
+	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/asdine/storm v2.1.2+incompatible h1:dczuIkyqwY2LrtXPz8ixMrU/OFgZp71kb
 github.com/asdine/storm v2.1.2+incompatible/go.mod h1:RarYDc9hq1UPLImuiXK3BIWPJLdIygvV3PsInK0FbVQ=
 github.com/aws/aws-sdk-go-v2 v1.41.11 h1:9PRf7jyTMEUM6fuNRAJa2mO/skJfrF50rENJwf2LXqw=
 github.com/aws/aws-sdk-go-v2 v1.41.11/go.mod h1:iiUX27gOXRuYaoeUVXhUpPwjJHzISfPAjjcuhUbLSVs=
+github.com/aws/aws-sdk-go-v2 v1.41.12 h1:DIKX2c31ekm9RA2D9FBj1EWXx++9AdAqRw+e78Tq2Ck=
+github.com/aws/aws-sdk-go-v2 v1.41.12/go.mod h1:27+ACypSLljLAEKsCYOmrjKh83vuTRkuAe9Uv/3A4bg=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.9 h1:adBsCIIpLbLmYnkQU+nAChU5yhVTvu5PerROm+/Kq2A=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.9/go.mod h1:uOYhgfgThm/ZyAuJGNQ5YgNyOlYfqnGpTHXvk3cpykg=
 github.com/aws/aws-sdk-go-v2/config v1.32.16 h1:Q0iQ7quUgJP0F/SCRTieScnaMdXr9h/2+wze1u3cNeM=
@@ -26,14 +28,20 @@ github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.10 h1:2KCL4TmeiNvpP
 github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.10/go.mod h1:KwaiUFVO7pG8Z9F5bMGvvrRibdSDaAu8HtlKGKkjZSA=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.27 h1:8sPbKi1/KRHwl5oR3qN9mUXestCeHuaRutxylnr/eVY=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.27/go.mod h1:QV9IVIopJ1dpQUno0f9VYDUwOEjj8u0iEJ4JiZVre3Y=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.28 h1:Xf2j7NdVcUKomlZ4iihOP4AZ3Fzlr8h4yKpXeP+OFPg=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.28/go.mod h1:O8cDo1dW63jU7ki//kRe1z+tLGcpnD1jrouitsQddDw=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.27 h1:9d8AoASQY9UwrOSmiJ7uSM0MGUPFhnenwSvpaFfat2c=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.27/go.mod h1:x0rldpsnUQaQIs4Rh+Vwm9Z/0vI6BxadGtsgJfZFb8s=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.28 h1:KqIfN9kpkKkcBqBbNpNGTIrXO6ExTUvFKvXkC+YAzVo=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.28/go.mod h1:uxtQiKvLtNS4iXVsH2McVD/ls8FKN/uUhe1hGxPjrw0=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.24 h1:OQqn11BtaYv1WLUowvcA30MpzIu8Ti4pcLPIIyoKZrA=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.24/go.mod h1:X5ZJyfwVrWA96GzPmUCWFQaEARPR7gCrpq2E92PJwAE=
 github.com/aws/aws-sdk-go-v2/service/acm v1.39.4 h1:2P7p/kNLozilMJfF5SNfKCAslLZFtLmr7RjDHVni024=
 github.com/aws/aws-sdk-go-v2/service/acm v1.39.4/go.mod h1:xQtZpSJWrvS9GKpvmxLqZU98QbBAsXxjd4ZHH0U42Qk=
 github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.29.14 h1:ImtrKaec9pN/hz2rCS0IiVUBGKjxS9ZFM3MHNVoZTiY=
 github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.29.14/go.mod h1:7lrvANo4D0kDvxGrcKXEocfULnurpaYBiPRf17ri2lU=
+github.com/aws/aws-sdk-go-v2/service/cloudfront v1.65.1 h1:UXPRXa3HLrJolDM098DfXgLJrbB086+Zip3M+4Dy1WI=
+github.com/aws/aws-sdk-go-v2/service/cloudfront v1.65.1/go.mod h1:Uu2kNhTTM1ZrJcIL3FDLlzaHwOZUugiMmL8K8ibBbvo=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.299.0 h1:qTozRFl2YFFU2HJGl7ZAywlRQvBnAN591gbAFT5bE0s=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.299.0/go.mod h1:E1pnYwWFZ8N3REmeN9Fe/Zipbpps4HJj8DQGNnLUMYc=
 github.com/aws/aws-sdk-go-v2/service/ecs v1.77.0 h1:g3RYQmK6uRU5kOuwDthemuiiTbmwyGd8Wzf+k7cYWtk=
@@ -76,6 +84,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.42.0 h1:ks8KBcZPh3PYISr5dAiXCM5/Thcu
 github.com/aws/aws-sdk-go-v2/service/sts v1.42.0/go.mod h1:pFw33T0WLvXU3rw1WBkpMlkgIn54eCB5FYLhjDc9Foo=
 github.com/aws/smithy-go v1.27.0 h1:ZoFioDKJxkSIW2otF9T0aPtNlUwhdVCcuZh/rzH9Hus=
 github.com/aws/smithy-go v1.27.0/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
+github.com/aws/smithy-go v1.27.1 h1:4T340VFndXtADGF52gYa1POyL7s9E4Z1OeZ1hCscIw8=
+github.com/aws/smithy-go v1.27.1/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
@@ -86,6 +96,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/ebitengine/purego v0.9.1 h1:a/k2f2HQU3Pi399RPW1MOaZyhKJL9w/xFpKAg4q1s0A=
 github.com/ebitengine/purego v0.9.1/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
+github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjTM0wiaDU=
+github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/pkg/cfres/certificatemanager/certificate.go
+++ b/pkg/cfres/certificatemanager/certificate.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -421,6 +422,11 @@ func normalizeKeyAlgorithmForCFN(s string) string {
 // into the ses.DnsRecord shape that CertificateResolvable.validationRecords expects.
 // Records may be empty if the cert uses EMAIL validation or is too new for ACM
 // to have populated the CNAMEs yet.
+//
+// Trailing dots are stripped from Name to match Route53::RecordSet's Read
+// normalization. Without that, a downstream Route53::RecordSet that
+// resolves cert.res.validationRecords.at(0).name sees a perpetual diff
+// against its own readback and gets delete+recreate'd on every reconcile.
 func validationRecordsFromCert(cert *acmtypes.CertificateDetail) []ses.DnsRecord {
 	var records []ses.DnsRecord
 	for _, opt := range cert.DomainValidationOptions {
@@ -430,7 +436,7 @@ func validationRecordsFromCert(cert *acmtypes.CertificateDetail) []ses.DnsRecord
 		}
 		records = append(records, ses.DnsRecord{
 			Type:           string(rr.Type),
-			Name:           *rr.Name,
+			Name:           strings.TrimSuffix(*rr.Name, "."),
 			Values:         []string{*rr.Value},
 			RecommendedTtl: 300,
 		})

--- a/pkg/cfres/certificatemanager/certificate_test.go
+++ b/pkg/cfres/certificatemanager/certificate_test.go
@@ -403,6 +403,18 @@ func TestRead_PopulatesValidationRecords(t *testing.T) {
 	if len(records) != 1 {
 		t.Errorf("ValidationRecords: want 1, got %d", len(records))
 	}
+	// Trailing dot must be stripped: ACM returns `_abc.example.com.` but
+	// Route53::RecordSet's Read strips trailing dots from Name. Without
+	// matching that normalization, downstream RecordSet consumers see a
+	// fresh diff on every reconcile and delete+create the validation
+	// CNAME unnecessarily.
+	rec0, ok := records[0].(map[string]any)
+	if !ok {
+		t.Fatalf("ValidationRecords[0] not a map: %T", records[0])
+	}
+	if got := rec0["Name"]; got != "_abc.example.com" {
+		t.Errorf("ValidationRecords[0].Name: want %q (no trailing dot), got %q", "_abc.example.com", got)
+	}
 }
 
 func TestRead_PopulatesValidationMethodFromDomainValidationOption(t *testing.T) {

--- a/pkg/cfres/cfres.go
+++ b/pkg/cfres/cfres.go
@@ -12,6 +12,7 @@ import (
 
 	_ "github.com/platform-engineering-labs/formae-plugin-aws/pkg/cfres/apigateway"
 	_ "github.com/platform-engineering-labs/formae-plugin-aws/pkg/cfres/certificatemanager"
+	_ "github.com/platform-engineering-labs/formae-plugin-aws/pkg/cfres/cloudfront"
 	_ "github.com/platform-engineering-labs/formae-plugin-aws/pkg/cfres/ec2"
 	_ "github.com/platform-engineering-labs/formae-plugin-aws/pkg/cfres/ecs"
 	_ "github.com/platform-engineering-labs/formae-plugin-aws/pkg/cfres/elasticbeanstalk"

--- a/pkg/cfres/cloudfront/cloudfrontclient.go
+++ b/pkg/cfres/cloudfront/cloudfrontclient.go
@@ -1,0 +1,33 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package cloudfront
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/cloudfront"
+)
+
+// CloudFrontClientInterface is the narrow surface of the CloudFront SDK
+// client used by formae-plugin-aws. Defined explicitly (rather than
+// aliased from the SDK) so unit tests can mock just the methods we
+// actually call.
+//
+// Reads / mutations on Distribution and Function go through this
+// interface; CCAPI handles Create/Delete/Read/List/Status for these
+// types via the fall-through path in aws.go.
+type CloudFrontClientInterface interface {
+	GetDistributionConfig(ctx context.Context, params *cloudfront.GetDistributionConfigInput, optFns ...func(*cloudfront.Options)) (*cloudfront.GetDistributionConfigOutput, error)
+	UpdateDistribution(ctx context.Context, params *cloudfront.UpdateDistributionInput, optFns ...func(*cloudfront.Options)) (*cloudfront.UpdateDistributionOutput, error)
+	GetDistribution(ctx context.Context, params *cloudfront.GetDistributionInput, optFns ...func(*cloudfront.Options)) (*cloudfront.GetDistributionOutput, error)
+	ListTagsForResource(ctx context.Context, params *cloudfront.ListTagsForResourceInput, optFns ...func(*cloudfront.Options)) (*cloudfront.ListTagsForResourceOutput, error)
+	TagResource(ctx context.Context, params *cloudfront.TagResourceInput, optFns ...func(*cloudfront.Options)) (*cloudfront.TagResourceOutput, error)
+	UntagResource(ctx context.Context, params *cloudfront.UntagResourceInput, optFns ...func(*cloudfront.Options)) (*cloudfront.UntagResourceOutput, error)
+
+	DescribeFunction(ctx context.Context, params *cloudfront.DescribeFunctionInput, optFns ...func(*cloudfront.Options)) (*cloudfront.DescribeFunctionOutput, error)
+	UpdateFunction(ctx context.Context, params *cloudfront.UpdateFunctionInput, optFns ...func(*cloudfront.Options)) (*cloudfront.UpdateFunctionOutput, error)
+	PublishFunction(ctx context.Context, params *cloudfront.PublishFunctionInput, optFns ...func(*cloudfront.Options)) (*cloudfront.PublishFunctionOutput, error)
+	GetFunction(ctx context.Context, params *cloudfront.GetFunctionInput, optFns ...func(*cloudfront.Options)) (*cloudfront.GetFunctionOutput, error)
+}

--- a/pkg/cfres/cloudfront/distribution.go
+++ b/pkg/cfres/cloudfront/distribution.go
@@ -1,0 +1,329 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package cloudfront
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudfront"
+	cftypes "github.com/aws/aws-sdk-go-v2/service/cloudfront/types"
+	jsonpatch "github.com/evanphx/json-patch/v5"
+
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/cfres/prov"
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/cfres/registry"
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/config"
+)
+
+// Distribution is the AWS::CloudFront::Distribution provisioner. We
+// only take over Update; Create/Read/Delete/List/Status fall through to
+// CCAPI.
+//
+// CloudFront's UpdateDistribution API requires the FULL DistributionConfig
+// payload on every call: fields not in the payload are reset to defaults,
+// and ViewerCertificate enforces an "exactly one of [AcmCertificateArn,
+// CloudFrontDefaultCertificate, IamCertificateId]" rule that hard-fails
+// when CCAPI sends a diff-only payload (e.g. just a Comment change).
+//
+// We fetch the live DistributionConfig + ETag, apply the operator's
+// JSON Patch on top of it, and submit the merged payload via the
+// CloudFront SDK directly. Tags are handled separately via
+// TagResource/UntagResource on the distribution ARN.
+type Distribution struct {
+	cfg                     *config.Config
+	cloudFrontClientFactory func(cfg *config.Config) (CloudFrontClientInterface, error)
+}
+
+var _ prov.Provisioner = &Distribution{}
+
+func init() {
+	registry.Register("AWS::CloudFront::Distribution",
+		[]resource.Operation{resource.OperationUpdate},
+		func(cfg *config.Config) prov.Provisioner {
+			return &Distribution{
+				cfg:                     cfg,
+				cloudFrontClientFactory: defaultCloudFrontClientFactory,
+			}
+		})
+}
+
+func defaultCloudFrontClientFactory(cfg *config.Config) (CloudFrontClientInterface, error) {
+	awsCfg, err := cfg.ToAwsConfig(context.Background())
+	if err != nil {
+		return nil, fmt.Errorf("cloudfront: build AWS config: %w", err)
+	}
+	return cloudfront.NewFromConfig(awsCfg), nil
+}
+
+// ----- Update -----
+
+func (d *Distribution) Update(ctx context.Context, request *resource.UpdateRequest) (*resource.UpdateResult, error) {
+	client, err := d.cloudFrontClientFactory(d.cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	// 1. Fetch live DistributionConfig and ETag.
+	liveResp, err := client.GetDistributionConfig(ctx, &cloudfront.GetDistributionConfigInput{
+		Id: aws.String(request.NativeID),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cloudfront: GetDistributionConfig: %w", err)
+	}
+	if liveResp == nil || liveResp.DistributionConfig == nil || liveResp.ETag == nil {
+		return nil, fmt.Errorf("cloudfront: GetDistributionConfig returned empty body for %s", request.NativeID)
+	}
+
+	// 2. Merge desired-state diff onto live config.
+	mergedCfg, err := mergeDistributionConfig(liveResp.DistributionConfig, request.PatchDocument, request.DesiredProperties)
+	if err != nil {
+		return nil, err
+	}
+
+	// 3. Submit UpdateDistribution with captured ETag.
+	if _, err := client.UpdateDistribution(ctx, &cloudfront.UpdateDistributionInput{
+		Id:                 aws.String(request.NativeID),
+		IfMatch:            liveResp.ETag,
+		DistributionConfig: mergedCfg,
+	}); err != nil {
+		return nil, fmt.Errorf("cloudfront: UpdateDistribution: %w", err)
+	}
+
+	// 4. Sync tags (TagResource / UntagResource).
+	if err := d.syncDistributionTags(ctx, client, request); err != nil {
+		return nil, err
+	}
+
+	// 5. Build the response. We don't re-read here; the immediate caller
+	//    only needs Success + the desired properties echoed back. The
+	//    background sync will refresh from AWS shortly.
+	return &resource.UpdateResult{
+		ProgressResult: &resource.ProgressResult{
+			Operation:          resource.OperationUpdate,
+			OperationStatus:    resource.OperationStatusSuccess,
+			NativeID:           request.NativeID,
+			ResourceProperties: request.DesiredProperties,
+		},
+	}, nil
+}
+
+// mergeDistributionConfig applies the operator's JSON Patch onto the
+// live DistributionConfig and returns the merged config as the SDK
+// type. The envelope wraps the live config under a "DistributionConfig"
+// key so patch paths like "/DistributionConfig/Comment" resolve
+// correctly.
+//
+// When no PatchDocument is provided we fall back to the DesiredProperties
+// snapshot — this is the path the synchronizer takes if it ever invokes
+// Update without a precomputed diff.
+func mergeDistributionConfig(liveCfg *cftypes.DistributionConfig, patchDoc *string, desired json.RawMessage) (*cftypes.DistributionConfig, error) {
+	liveJSON, err := json.Marshal(liveCfg)
+	if err != nil {
+		return nil, fmt.Errorf("cloudfront: marshal live DistributionConfig: %w", err)
+	}
+
+	envelope := map[string]json.RawMessage{"DistributionConfig": liveJSON}
+	envelopeJSON, err := json.Marshal(envelope)
+	if err != nil {
+		return nil, fmt.Errorf("cloudfront: marshal envelope: %w", err)
+	}
+
+	if patchDoc != nil && *patchDoc != "" {
+		filtered, ferr := filterPatchToDistributionConfig(*patchDoc)
+		if ferr != nil {
+			return nil, ferr
+		}
+		if len(filtered) > 0 {
+			patch, perr := jsonpatch.DecodePatch(filtered)
+			if perr != nil {
+				return nil, fmt.Errorf("cloudfront: decode patch: %w", perr)
+			}
+			envelopeJSON, perr = patch.Apply(envelopeJSON)
+			if perr != nil {
+				return nil, fmt.Errorf("cloudfront: apply patch: %w", perr)
+			}
+		}
+	} else if len(desired) > 0 {
+		// No patch — overlay DesiredProperties.DistributionConfig if present.
+		var desiredProps map[string]json.RawMessage
+		if uerr := json.Unmarshal(desired, &desiredProps); uerr == nil {
+			if cfgRaw, ok := desiredProps["DistributionConfig"]; ok && len(cfgRaw) > 0 {
+				envelope["DistributionConfig"] = cfgRaw
+				envelopeJSON, _ = json.Marshal(envelope)
+			}
+		}
+	}
+
+	var merged struct {
+		DistributionConfig json.RawMessage `json:"DistributionConfig"`
+	}
+	if err := json.Unmarshal(envelopeJSON, &merged); err != nil {
+		return nil, fmt.Errorf("cloudfront: unmarshal merged envelope: %w", err)
+	}
+
+	var mergedCfg cftypes.DistributionConfig
+	if err := json.Unmarshal(merged.DistributionConfig, &mergedCfg); err != nil {
+		return nil, fmt.Errorf("cloudfront: unmarshal merged DistributionConfig: %w", err)
+	}
+	return &mergedCfg, nil
+}
+
+// filterPatchToDistributionConfig drops any patch ops that don't target
+// /DistributionConfig (e.g. /Tags/... is handled separately).
+func filterPatchToDistributionConfig(patchDoc string) ([]byte, error) {
+	var ops []map[string]any
+	if err := json.Unmarshal([]byte(patchDoc), &ops); err != nil {
+		return nil, fmt.Errorf("cloudfront: parse patch: %w", err)
+	}
+	filtered := make([]map[string]any, 0, len(ops))
+	for _, op := range ops {
+		path, _ := op["path"].(string)
+		if len(path) >= len("/DistributionConfig") && path[:len("/DistributionConfig")] == "/DistributionConfig" {
+			filtered = append(filtered, op)
+		}
+	}
+	if len(filtered) == 0 {
+		return nil, nil
+	}
+	out, err := json.Marshal(filtered)
+	if err != nil {
+		return nil, fmt.Errorf("cloudfront: marshal filtered patch: %w", err)
+	}
+	return out, nil
+}
+
+// syncDistributionTags diffs prior vs desired tags and issues
+// TagResource / UntagResource as needed. The distribution ARN is
+// resolved via GetDistribution if not present in the desired properties.
+func (d *Distribution) syncDistributionTags(ctx context.Context, client CloudFrontClientInterface, request *resource.UpdateRequest) error {
+	priorTags := tagSetFromProperties(request.PriorProperties)
+	desiredTags := tagSetFromProperties(request.DesiredProperties)
+
+	toAdd, toRemove := diffTagSets(priorTags, desiredTags)
+	if len(toAdd) == 0 && len(toRemove) == 0 {
+		return nil
+	}
+
+	arn, err := resolveDistributionARN(ctx, client, request)
+	if err != nil {
+		return err
+	}
+
+	if len(toRemove) > 0 {
+		keys := make([]string, 0, len(toRemove))
+		for _, t := range toRemove {
+			keys = append(keys, *t.Key)
+		}
+		sort.Strings(keys)
+		if _, err := client.UntagResource(ctx, &cloudfront.UntagResourceInput{
+			Resource: aws.String(arn),
+			TagKeys:  &cftypes.TagKeys{Items: keys},
+		}); err != nil {
+			return fmt.Errorf("cloudfront: UntagResource: %w", err)
+		}
+	}
+	if len(toAdd) > 0 {
+		sort.Slice(toAdd, func(i, j int) bool {
+			return aws.ToString(toAdd[i].Key) < aws.ToString(toAdd[j].Key)
+		})
+		if _, err := client.TagResource(ctx, &cloudfront.TagResourceInput{
+			Resource: aws.String(arn),
+			Tags:     &cftypes.Tags{Items: toAdd},
+		}); err != nil {
+			return fmt.Errorf("cloudfront: TagResource: %w", err)
+		}
+	}
+	return nil
+}
+
+func resolveDistributionARN(ctx context.Context, client CloudFrontClientInterface, request *resource.UpdateRequest) (string, error) {
+	var desired map[string]any
+	if len(request.DesiredProperties) > 0 {
+		_ = json.Unmarshal(request.DesiredProperties, &desired)
+	}
+	if arn, ok := desired["Arn"].(string); ok && arn != "" {
+		return arn, nil
+	}
+	// Fall back to GetDistribution.
+	resp, err := client.GetDistribution(ctx, &cloudfront.GetDistributionInput{Id: aws.String(request.NativeID)})
+	if err != nil {
+		return "", fmt.Errorf("cloudfront: GetDistribution for ARN lookup: %w", err)
+	}
+	if resp == nil || resp.Distribution == nil || resp.Distribution.ARN == nil {
+		return "", fmt.Errorf("cloudfront: distribution %s has no ARN", request.NativeID)
+	}
+	return *resp.Distribution.ARN, nil
+}
+
+// tagSetFromProperties parses a "Tags" array-of-{Key,Value} property
+// into a key->value map.
+func tagSetFromProperties(raw json.RawMessage) map[string]string {
+	out := map[string]string{}
+	if len(raw) == 0 {
+		return out
+	}
+	var props map[string]any
+	if err := json.Unmarshal(raw, &props); err != nil {
+		return out
+	}
+	tags, ok := props["Tags"].([]any)
+	if !ok {
+		return out
+	}
+	for _, r := range tags {
+		m, ok := r.(map[string]any)
+		if !ok {
+			continue
+		}
+		k, _ := m["Key"].(string)
+		if k == "" {
+			continue
+		}
+		v, _ := m["Value"].(string)
+		out[k] = v
+	}
+	return out
+}
+
+func diffTagSets(prior, desired map[string]string) (toAdd []cftypes.Tag, toRemove []cftypes.Tag) {
+	for k, dv := range desired {
+		pv, present := prior[k]
+		if !present || pv != dv {
+			toAdd = append(toAdd, cftypes.Tag{Key: aws.String(k), Value: aws.String(dv)})
+		}
+	}
+	for k, pv := range prior {
+		if _, present := desired[k]; !present {
+			toRemove = append(toRemove, cftypes.Tag{Key: aws.String(k), Value: aws.String(pv)})
+		}
+	}
+	return toAdd, toRemove
+}
+
+// ----- Unused operations (CCAPI handles them) -----
+
+func (d *Distribution) Create(_ context.Context, _ *resource.CreateRequest) (*resource.CreateResult, error) {
+	return nil, fmt.Errorf("cloudfront distribution: create handled by cloudcontrol")
+}
+
+func (d *Distribution) Read(_ context.Context, _ *resource.ReadRequest) (*resource.ReadResult, error) {
+	return nil, fmt.Errorf("cloudfront distribution: read handled by cloudcontrol")
+}
+
+func (d *Distribution) Delete(_ context.Context, _ *resource.DeleteRequest) (*resource.DeleteResult, error) {
+	return nil, fmt.Errorf("cloudfront distribution: delete handled by cloudcontrol")
+}
+
+func (d *Distribution) Status(_ context.Context, _ *resource.StatusRequest) (*resource.StatusResult, error) {
+	return nil, fmt.Errorf("cloudfront distribution: status handled by cloudcontrol")
+}
+
+func (d *Distribution) List(_ context.Context, _ *resource.ListRequest) (*resource.ListResult, error) {
+	return nil, fmt.Errorf("cloudfront distribution: list handled by cloudcontrol")
+}

--- a/pkg/cfres/cloudfront/distribution_test.go
+++ b/pkg/cfres/cloudfront/distribution_test.go
@@ -1,0 +1,408 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package cloudfront
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudfront"
+	cftypes "github.com/aws/aws-sdk-go-v2/service/cloudfront/types"
+
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/config"
+)
+
+// ----- fake CloudFront client -----
+
+type fakeCloudFrontClient struct {
+	getDistributionConfigInput  *cloudfront.GetDistributionConfigInput
+	getDistributionConfigOut    *cloudfront.GetDistributionConfigOutput
+	getDistributionConfigErr    error
+	updateDistributionInput     *cloudfront.UpdateDistributionInput
+	updateDistributionOut       *cloudfront.UpdateDistributionOutput
+	updateDistributionErr       error
+	getDistributionInput        *cloudfront.GetDistributionInput
+	getDistributionOut          *cloudfront.GetDistributionOutput
+	listTagsForResourceInput    *cloudfront.ListTagsForResourceInput
+	listTagsForResourceOut      *cloudfront.ListTagsForResourceOutput
+	tagResourceInput            *cloudfront.TagResourceInput
+	untagResourceInput          *cloudfront.UntagResourceInput
+
+	describeFunctionInput  *cloudfront.DescribeFunctionInput
+	describeFunctionOut    *cloudfront.DescribeFunctionOutput
+	describeFunctionErr    error
+	updateFunctionInput    *cloudfront.UpdateFunctionInput
+	updateFunctionOut      *cloudfront.UpdateFunctionOutput
+	updateFunctionErr      error
+	publishFunctionInput   *cloudfront.PublishFunctionInput
+	publishFunctionOut     *cloudfront.PublishFunctionOutput
+	publishFunctionErr     error
+	getFunctionInput       *cloudfront.GetFunctionInput
+	getFunctionOut         *cloudfront.GetFunctionOutput
+}
+
+func (f *fakeCloudFrontClient) GetDistributionConfig(_ context.Context, in *cloudfront.GetDistributionConfigInput, _ ...func(*cloudfront.Options)) (*cloudfront.GetDistributionConfigOutput, error) {
+	f.getDistributionConfigInput = in
+	if f.getDistributionConfigErr != nil {
+		return nil, f.getDistributionConfigErr
+	}
+	return f.getDistributionConfigOut, nil
+}
+
+func (f *fakeCloudFrontClient) UpdateDistribution(_ context.Context, in *cloudfront.UpdateDistributionInput, _ ...func(*cloudfront.Options)) (*cloudfront.UpdateDistributionOutput, error) {
+	f.updateDistributionInput = in
+	if f.updateDistributionErr != nil {
+		return nil, f.updateDistributionErr
+	}
+	if f.updateDistributionOut != nil {
+		return f.updateDistributionOut, nil
+	}
+	return &cloudfront.UpdateDistributionOutput{}, nil
+}
+
+func (f *fakeCloudFrontClient) GetDistribution(_ context.Context, in *cloudfront.GetDistributionInput, _ ...func(*cloudfront.Options)) (*cloudfront.GetDistributionOutput, error) {
+	f.getDistributionInput = in
+	if f.getDistributionOut != nil {
+		return f.getDistributionOut, nil
+	}
+	return &cloudfront.GetDistributionOutput{Distribution: &cftypes.Distribution{ARN: aws.String("arn:aws:cloudfront::123:distribution/E1ABCDE")}}, nil
+}
+
+func (f *fakeCloudFrontClient) ListTagsForResource(_ context.Context, in *cloudfront.ListTagsForResourceInput, _ ...func(*cloudfront.Options)) (*cloudfront.ListTagsForResourceOutput, error) {
+	f.listTagsForResourceInput = in
+	if f.listTagsForResourceOut != nil {
+		return f.listTagsForResourceOut, nil
+	}
+	return &cloudfront.ListTagsForResourceOutput{Tags: &cftypes.Tags{}}, nil
+}
+
+func (f *fakeCloudFrontClient) TagResource(_ context.Context, in *cloudfront.TagResourceInput, _ ...func(*cloudfront.Options)) (*cloudfront.TagResourceOutput, error) {
+	f.tagResourceInput = in
+	return &cloudfront.TagResourceOutput{}, nil
+}
+
+func (f *fakeCloudFrontClient) UntagResource(_ context.Context, in *cloudfront.UntagResourceInput, _ ...func(*cloudfront.Options)) (*cloudfront.UntagResourceOutput, error) {
+	f.untagResourceInput = in
+	return &cloudfront.UntagResourceOutput{}, nil
+}
+
+func (f *fakeCloudFrontClient) DescribeFunction(_ context.Context, in *cloudfront.DescribeFunctionInput, _ ...func(*cloudfront.Options)) (*cloudfront.DescribeFunctionOutput, error) {
+	f.describeFunctionInput = in
+	if f.describeFunctionErr != nil {
+		return nil, f.describeFunctionErr
+	}
+	return f.describeFunctionOut, nil
+}
+
+func (f *fakeCloudFrontClient) UpdateFunction(_ context.Context, in *cloudfront.UpdateFunctionInput, _ ...func(*cloudfront.Options)) (*cloudfront.UpdateFunctionOutput, error) {
+	f.updateFunctionInput = in
+	if f.updateFunctionErr != nil {
+		return nil, f.updateFunctionErr
+	}
+	if f.updateFunctionOut != nil {
+		return f.updateFunctionOut, nil
+	}
+	return &cloudfront.UpdateFunctionOutput{ETag: aws.String("ETAG-AFTER-UPDATE")}, nil
+}
+
+func (f *fakeCloudFrontClient) PublishFunction(_ context.Context, in *cloudfront.PublishFunctionInput, _ ...func(*cloudfront.Options)) (*cloudfront.PublishFunctionOutput, error) {
+	f.publishFunctionInput = in
+	if f.publishFunctionErr != nil {
+		return nil, f.publishFunctionErr
+	}
+	return f.publishFunctionOut, nil
+}
+
+func (f *fakeCloudFrontClient) GetFunction(_ context.Context, in *cloudfront.GetFunctionInput, _ ...func(*cloudfront.Options)) (*cloudfront.GetFunctionOutput, error) {
+	f.getFunctionInput = in
+	if f.getFunctionOut != nil {
+		return f.getFunctionOut, nil
+	}
+	return &cloudfront.GetFunctionOutput{}, nil
+}
+
+// ----- helpers -----
+
+func newDistributionForTest(client CloudFrontClientInterface) *Distribution {
+	return &Distribution{
+		cfg: &config.Config{},
+		cloudFrontClientFactory: func(_ *config.Config) (CloudFrontClientInterface, error) {
+			return client, nil
+		},
+	}
+}
+
+func liveDistributionConfig() *cftypes.DistributionConfig {
+	return &cftypes.DistributionConfig{
+		CallerReference: aws.String("caller-ref-original"),
+		Comment:         aws.String("original comment"),
+		Enabled:         aws.Bool(true),
+		Origins: &cftypes.Origins{
+			Quantity: aws.Int32(1),
+			Items: []cftypes.Origin{
+				{
+					Id:         aws.String("origin-1"),
+					DomainName: aws.String("origin.example.com"),
+				},
+			},
+		},
+		DefaultCacheBehavior: &cftypes.DefaultCacheBehavior{
+			TargetOriginId:       aws.String("origin-1"),
+			ViewerProtocolPolicy: cftypes.ViewerProtocolPolicyRedirectToHttps,
+		},
+		ViewerCertificate: &cftypes.ViewerCertificate{
+			ACMCertificateArn: aws.String("arn:aws:acm:us-east-1:123:certificate/abc"),
+			SSLSupportMethod:  cftypes.SSLSupportMethodSniOnly,
+		},
+	}
+}
+
+// ----- tests -----
+
+func TestDistribution_Update_FetchesLiveConfigAndCapturesETag(t *testing.T) {
+	client := &fakeCloudFrontClient{
+		getDistributionConfigOut: &cloudfront.GetDistributionConfigOutput{
+			DistributionConfig: liveDistributionConfig(),
+			ETag:               aws.String("E2QWRUHAPOMQZL"),
+		},
+	}
+	d := newDistributionForTest(client)
+
+	desired := map[string]any{
+		"Id": "E1ABCDE",
+		"DistributionConfig": map[string]any{
+			"CallerReference": "caller-ref-original",
+			"Comment":         "updated comment",
+			"Enabled":         true,
+			"Origins": map[string]any{
+				"Quantity": float64(1),
+				"Items":    []any{map[string]any{"Id": "origin-1", "DomainName": "origin.example.com"}},
+			},
+			"DefaultCacheBehavior": map[string]any{
+				"TargetOriginId":       "origin-1",
+				"ViewerProtocolPolicy": "redirect-to-https",
+			},
+			"ViewerCertificate": map[string]any{
+				"AcmCertificateArn": "arn:aws:acm:us-east-1:123:certificate/abc",
+				"SslSupportMethod":  "sni-only",
+			},
+		},
+	}
+	desiredBytes, _ := json.Marshal(desired)
+
+	prior := map[string]any{
+		"Id": "E1ABCDE",
+		"DistributionConfig": map[string]any{
+			"CallerReference": "caller-ref-original",
+			"Comment":         "original comment",
+		},
+	}
+	priorBytes, _ := json.Marshal(prior)
+
+	patch := `[{"op":"replace","path":"/DistributionConfig/Comment","value":"updated comment"}]`
+
+	_, err := d.Update(context.Background(), &resource.UpdateRequest{
+		NativeID:          "E1ABCDE",
+		ResourceType:      "AWS::CloudFront::Distribution",
+		PriorProperties:   priorBytes,
+		DesiredProperties: desiredBytes,
+		PatchDocument:     &patch,
+	})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+
+	if client.getDistributionConfigInput == nil {
+		t.Fatal("expected GetDistributionConfig to be called")
+	}
+	if aws.ToString(client.getDistributionConfigInput.Id) != "E1ABCDE" {
+		t.Fatalf("GetDistributionConfig called with wrong Id: %q", aws.ToString(client.getDistributionConfigInput.Id))
+	}
+
+	if client.updateDistributionInput == nil {
+		t.Fatal("expected UpdateDistribution to be called")
+	}
+	if aws.ToString(client.updateDistributionInput.IfMatch) != "E2QWRUHAPOMQZL" {
+		t.Fatalf("UpdateDistribution called with wrong IfMatch: %q", aws.ToString(client.updateDistributionInput.IfMatch))
+	}
+	if aws.ToString(client.updateDistributionInput.Id) != "E1ABCDE" {
+		t.Fatalf("UpdateDistribution called with wrong Id: %q", aws.ToString(client.updateDistributionInput.Id))
+	}
+}
+
+func TestDistribution_Update_AppliesPatchOntoLiveConfigPreservingRequiredFields(t *testing.T) {
+	// The bug: CCAPI sends only the diff'd field (e.g. Comment), CloudFront
+	// then complains that ViewerCertificate is missing the required ACM ARN.
+	// Our fix: start from the live config so all required fields are present,
+	// then overlay only the operator's actual change.
+	client := &fakeCloudFrontClient{
+		getDistributionConfigOut: &cloudfront.GetDistributionConfigOutput{
+			DistributionConfig: liveDistributionConfig(),
+			ETag:               aws.String("E2QWRUHAPOMQZL"),
+		},
+	}
+	d := newDistributionForTest(client)
+
+	patch := `[{"op":"replace","path":"/DistributionConfig/Comment","value":"updated comment"}]`
+	desired, _ := json.Marshal(map[string]any{
+		"Id": "E1ABCDE",
+		"DistributionConfig": map[string]any{
+			"Comment": "updated comment",
+		},
+	})
+
+	_, err := d.Update(context.Background(), &resource.UpdateRequest{
+		NativeID:          "E1ABCDE",
+		ResourceType:      "AWS::CloudFront::Distribution",
+		DesiredProperties: desired,
+		PatchDocument:     &patch,
+	})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+
+	if client.updateDistributionInput == nil || client.updateDistributionInput.DistributionConfig == nil {
+		t.Fatal("expected UpdateDistribution to be called with a non-nil DistributionConfig")
+	}
+	cfg := client.updateDistributionInput.DistributionConfig
+
+	// The operator's change made it through:
+	if aws.ToString(cfg.Comment) != "updated comment" {
+		t.Errorf("Comment not updated: got %q, want %q", aws.ToString(cfg.Comment), "updated comment")
+	}
+	// Fields not in the patch survive from live state (this is the bug fix):
+	if cfg.ViewerCertificate == nil || aws.ToString(cfg.ViewerCertificate.ACMCertificateArn) != "arn:aws:acm:us-east-1:123:certificate/abc" {
+		t.Errorf("ViewerCertificate.ACMCertificateArn lost during merge: %+v", cfg.ViewerCertificate)
+	}
+	if cfg.DefaultCacheBehavior == nil || aws.ToString(cfg.DefaultCacheBehavior.TargetOriginId) != "origin-1" {
+		t.Errorf("DefaultCacheBehavior lost during merge: %+v", cfg.DefaultCacheBehavior)
+	}
+	if cfg.Origins == nil || len(cfg.Origins.Items) != 1 || aws.ToString(cfg.Origins.Items[0].Id) != "origin-1" {
+		t.Errorf("Origins lost during merge: %+v", cfg.Origins)
+	}
+	if aws.ToString(cfg.CallerReference) != "caller-ref-original" {
+		t.Errorf("CallerReference lost during merge: got %q", aws.ToString(cfg.CallerReference))
+	}
+}
+
+func TestDistribution_Update_AppliesNestedPatchOps(t *testing.T) {
+	client := &fakeCloudFrontClient{
+		getDistributionConfigOut: &cloudfront.GetDistributionConfigOutput{
+			DistributionConfig: liveDistributionConfig(),
+			ETag:               aws.String("ETAG"),
+		},
+	}
+	d := newDistributionForTest(client)
+
+	// Operator swaps the origin's DomainName.
+	patch := `[{"op":"replace","path":"/DistributionConfig/Origins/Items/0/DomainName","value":"new-origin.example.com"}]`
+	desired, _ := json.Marshal(map[string]any{"Id": "E1ABCDE"})
+
+	_, err := d.Update(context.Background(), &resource.UpdateRequest{
+		NativeID:          "E1ABCDE",
+		ResourceType:      "AWS::CloudFront::Distribution",
+		DesiredProperties: desired,
+		PatchDocument:     &patch,
+	})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	cfg := client.updateDistributionInput.DistributionConfig
+	if cfg.Origins == nil || len(cfg.Origins.Items) != 1 {
+		t.Fatalf("expected 1 origin, got %d", len(cfg.Origins.Items))
+	}
+	if aws.ToString(cfg.Origins.Items[0].DomainName) != "new-origin.example.com" {
+		t.Errorf("nested patch not applied: DomainName=%q", aws.ToString(cfg.Origins.Items[0].DomainName))
+	}
+}
+
+func TestDistribution_Update_ReportsErrorWhenGetFails(t *testing.T) {
+	client := &fakeCloudFrontClient{
+		getDistributionConfigErr: errors.New("GetDistributionConfig failed"),
+	}
+	d := newDistributionForTest(client)
+	desired, _ := json.Marshal(map[string]any{"Id": "E1ABCDE"})
+	_, err := d.Update(context.Background(), &resource.UpdateRequest{
+		NativeID:          "E1ABCDE",
+		ResourceType:      "AWS::CloudFront::Distribution",
+		DesiredProperties: desired,
+	})
+	if err == nil {
+		t.Fatal("expected error when GetDistributionConfig fails")
+	}
+}
+
+func TestDistribution_Update_HandlesTagAddAndRemove(t *testing.T) {
+	client := &fakeCloudFrontClient{
+		getDistributionConfigOut: &cloudfront.GetDistributionConfigOutput{
+			DistributionConfig: liveDistributionConfig(),
+			ETag:               aws.String("ETAG"),
+		},
+	}
+	d := newDistributionForTest(client)
+
+	prior, _ := json.Marshal(map[string]any{
+		"Id": "E1ABCDE",
+		"Tags": []any{
+			map[string]any{"Key": "Env", "Value": "staging"},
+			map[string]any{"Key": "Owner", "Value": "alice"},
+		},
+	})
+	desired, _ := json.Marshal(map[string]any{
+		"Id":  "E1ABCDE",
+		"Arn": "arn:aws:cloudfront::123:distribution/E1ABCDE",
+		"Tags": []any{
+			map[string]any{"Key": "Env", "Value": "prod"},   // changed
+			map[string]any{"Key": "Team", "Value": "infra"}, // added; Owner removed
+		},
+	})
+
+	_, err := d.Update(context.Background(), &resource.UpdateRequest{
+		NativeID:          "E1ABCDE",
+		ResourceType:      "AWS::CloudFront::Distribution",
+		PriorProperties:   prior,
+		DesiredProperties: desired,
+	})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+
+	if client.tagResourceInput == nil {
+		t.Fatal("expected TagResource to be called (for changed+added tags)")
+	}
+	// Env changed AND Team added → 2 tags in the add payload
+	gotTags := map[string]string{}
+	if client.tagResourceInput.Tags != nil {
+		for _, t := range client.tagResourceInput.Tags.Items {
+			gotTags[aws.ToString(t.Key)] = aws.ToString(t.Value)
+		}
+	}
+	if gotTags["Env"] != "prod" || gotTags["Team"] != "infra" {
+		t.Errorf("TagResource called with wrong tags: %+v", gotTags)
+	}
+
+	if client.untagResourceInput == nil {
+		t.Fatal("expected UntagResource to be called (for removed Owner tag)")
+	}
+	var removedKeys []string
+	if client.untagResourceInput.TagKeys != nil {
+		removedKeys = client.untagResourceInput.TagKeys.Items
+	}
+	foundOwner := false
+	for _, k := range removedKeys {
+		if k == "Owner" {
+			foundOwner = true
+		}
+	}
+	if !foundOwner {
+		t.Errorf("UntagResource didn't include Owner: %v", removedKeys)
+	}
+}

--- a/pkg/cfres/cloudfront/function.go
+++ b/pkg/cfres/cloudfront/function.go
@@ -1,0 +1,203 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package cloudfront
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudfront"
+	cftypes "github.com/aws/aws-sdk-go-v2/service/cloudfront/types"
+
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/cfres/prov"
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/cfres/registry"
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/config"
+)
+
+// Function is the AWS::CloudFront::Function provisioner. We only take
+// over Update; Create/Read/Delete/List/Status fall through to CCAPI.
+//
+// CCAPI's generic Update for AWS::CloudFront::Function silently drops
+// FunctionCode: the Update call reports Success after ~44s but neither
+// AWS nor the agent's DB reflects the new code. We replace it with a
+// direct SDK call: DescribeFunction (capture ETag) -> UpdateFunction
+// (with FunctionCode + IfMatch) -> PublishFunction (if AutoPublish).
+type Function struct {
+	cfg                     *config.Config
+	cloudFrontClientFactory func(cfg *config.Config) (CloudFrontClientInterface, error)
+}
+
+var _ prov.Provisioner = &Function{}
+
+func init() {
+	registry.Register("AWS::CloudFront::Function",
+		[]resource.Operation{resource.OperationUpdate},
+		func(cfg *config.Config) prov.Provisioner {
+			return &Function{
+				cfg:                     cfg,
+				cloudFrontClientFactory: defaultCloudFrontClientFactory,
+			}
+		})
+}
+
+func (f *Function) Update(ctx context.Context, request *resource.UpdateRequest) (*resource.UpdateResult, error) {
+	client, err := f.cloudFrontClientFactory(f.cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	var desired map[string]any
+	if len(request.DesiredProperties) > 0 {
+		if err := json.Unmarshal(request.DesiredProperties, &desired); err != nil {
+			return nil, fmt.Errorf("cloudfront function: parse desired properties: %w", err)
+		}
+	}
+
+	name, _ := desired["Name"].(string)
+	if name == "" {
+		return nil, fmt.Errorf("cloudfront function: Name missing from desired properties")
+	}
+
+	// 1. DescribeFunction (DEVELOPMENT stage) for the current ETag.
+	descResp, err := client.DescribeFunction(ctx, &cloudfront.DescribeFunctionInput{
+		Name: aws.String(name),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cloudfront function: DescribeFunction: %w", err)
+	}
+	if descResp == nil || descResp.ETag == nil {
+		return nil, fmt.Errorf("cloudfront function: DescribeFunction returned no ETag for %s", name)
+	}
+
+	functionCode, _ := desired["FunctionCode"].(string)
+	if functionCode == "" {
+		return nil, fmt.Errorf("cloudfront function: FunctionCode missing from desired properties")
+	}
+
+	functionConfig, err := functionConfigFromDesired(desired["FunctionConfig"])
+	if err != nil {
+		return nil, err
+	}
+
+	// 2. UpdateFunction with new code + config + IfMatch.
+	updResp, err := client.UpdateFunction(ctx, &cloudfront.UpdateFunctionInput{
+		Name:           aws.String(name),
+		IfMatch:        descResp.ETag,
+		FunctionCode:   []byte(functionCode),
+		FunctionConfig: functionConfig,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cloudfront function: UpdateFunction: %w", err)
+	}
+	if updResp == nil || updResp.ETag == nil {
+		return nil, fmt.Errorf("cloudfront function: UpdateFunction returned no ETag for %s", name)
+	}
+
+	// 3. PublishFunction if AutoPublish — uses the post-update ETag,
+	//    because UpdateFunction bumped the version.
+	if autoPublish, ok := desired["AutoPublish"].(bool); ok && autoPublish {
+		if _, err := client.PublishFunction(ctx, &cloudfront.PublishFunctionInput{
+			Name:    aws.String(name),
+			IfMatch: updResp.ETag,
+		}); err != nil {
+			return nil, fmt.Errorf("cloudfront function: PublishFunction: %w", err)
+		}
+	}
+
+	return &resource.UpdateResult{
+		ProgressResult: &resource.ProgressResult{
+			Operation:          resource.OperationUpdate,
+			OperationStatus:    resource.OperationStatusSuccess,
+			NativeID:           request.NativeID,
+			ResourceProperties: request.DesiredProperties,
+		},
+	}, nil
+}
+
+func functionConfigFromDesired(raw any) (*cftypes.FunctionConfig, error) {
+	m, ok := raw.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("cloudfront function: FunctionConfig missing or wrong type")
+	}
+	cfg := &cftypes.FunctionConfig{}
+	if c, ok := m["Comment"].(string); ok {
+		cfg.Comment = aws.String(c)
+	}
+	if r, ok := m["Runtime"].(string); ok {
+		cfg.Runtime = cftypes.FunctionRuntime(r)
+	}
+	if assocsRaw, ok := m["KeyValueStoreAssociations"]; ok {
+		assocs := keyValueStoreAssociationsFromDesired(assocsRaw)
+		if assocs != nil {
+			cfg.KeyValueStoreAssociations = assocs
+		}
+	}
+	if cfg.Comment == nil || cfg.Runtime == "" {
+		return nil, fmt.Errorf("cloudfront function: FunctionConfig requires Comment and Runtime")
+	}
+	return cfg, nil
+}
+
+func keyValueStoreAssociationsFromDesired(raw any) *cftypes.KeyValueStoreAssociations {
+	items, ok := raw.([]any)
+	if !ok || len(items) == 0 {
+		// Also accept the wrapped {Items, Quantity} form CCAPI may produce.
+		if wrap, ok := raw.(map[string]any); ok {
+			if its, ok := wrap["Items"].([]any); ok {
+				items = its
+			}
+		}
+		if len(items) == 0 {
+			return nil
+		}
+	}
+	var out []cftypes.KeyValueStoreAssociation
+	for _, it := range items {
+		m, ok := it.(map[string]any)
+		if !ok {
+			continue
+		}
+		arn, _ := m["KeyValueStoreARN"].(string)
+		if arn == "" {
+			continue
+		}
+		out = append(out, cftypes.KeyValueStoreAssociation{
+			KeyValueStoreARN: aws.String(arn),
+		})
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	q := int32(len(out))
+	return &cftypes.KeyValueStoreAssociations{
+		Items:    out,
+		Quantity: &q,
+	}
+}
+
+// ----- Unused operations (CCAPI handles them) -----
+
+func (f *Function) Create(_ context.Context, _ *resource.CreateRequest) (*resource.CreateResult, error) {
+	return nil, fmt.Errorf("cloudfront function: create handled by cloudcontrol")
+}
+
+func (f *Function) Read(_ context.Context, _ *resource.ReadRequest) (*resource.ReadResult, error) {
+	return nil, fmt.Errorf("cloudfront function: read handled by cloudcontrol")
+}
+
+func (f *Function) Delete(_ context.Context, _ *resource.DeleteRequest) (*resource.DeleteResult, error) {
+	return nil, fmt.Errorf("cloudfront function: delete handled by cloudcontrol")
+}
+
+func (f *Function) Status(_ context.Context, _ *resource.StatusRequest) (*resource.StatusResult, error) {
+	return nil, fmt.Errorf("cloudfront function: status handled by cloudcontrol")
+}
+
+func (f *Function) List(_ context.Context, _ *resource.ListRequest) (*resource.ListResult, error) {
+	return nil, fmt.Errorf("cloudfront function: list handled by cloudcontrol")
+}

--- a/pkg/cfres/cloudfront/function_test.go
+++ b/pkg/cfres/cloudfront/function_test.go
@@ -1,0 +1,183 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package cloudfront
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudfront"
+	cftypes "github.com/aws/aws-sdk-go-v2/service/cloudfront/types"
+
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/config"
+)
+
+func newFunctionForTest(client CloudFrontClientInterface) *Function {
+	return &Function{
+		cfg: &config.Config{},
+		cloudFrontClientFactory: func(_ *config.Config) (CloudFrontClientInterface, error) {
+			return client, nil
+		},
+	}
+}
+
+func functionUpdateRequest(autoPublish bool, code string) *resource.UpdateRequest {
+	desired, _ := json.Marshal(map[string]any{
+		"Name":         "my-fn",
+		"FunctionARN":  "arn:aws:cloudfront::123:function/my-fn",
+		"AutoPublish":  autoPublish,
+		"FunctionCode": code,
+		"FunctionConfig": map[string]any{
+			"Comment": "updated",
+			"Runtime": "cloudfront-js-2.0",
+		},
+	})
+	return &resource.UpdateRequest{
+		NativeID:          "arn:aws:cloudfront::123:function/my-fn",
+		ResourceType:      "AWS::CloudFront::Function",
+		DesiredProperties: desired,
+	}
+}
+
+func TestFunction_Update_SendsFunctionCodeWithIfMatchETag(t *testing.T) {
+	// The bug: a previous Function.Update reported Success but the live
+	// functionCode never changed. The provisioner must (a) include the
+	// new FunctionCode in the UpdateFunction payload and (b) forward the
+	// ETag captured from DescribeFunction as IfMatch.
+	client := &fakeCloudFrontClient{
+		describeFunctionOut: &cloudfront.DescribeFunctionOutput{
+			ETag: aws.String("ETAG-DEVELOPMENT-1"),
+			FunctionSummary: &cftypes.FunctionSummary{
+				Name: aws.String("my-fn"),
+				FunctionConfig: &cftypes.FunctionConfig{
+					Comment: aws.String("old"),
+					Runtime: cftypes.FunctionRuntimeCloudfrontJs20,
+				},
+			},
+		},
+	}
+	f := newFunctionForTest(client)
+
+	_, err := f.Update(context.Background(), functionUpdateRequest(true, "function handler(e) { return e.request; } // v2"))
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if client.describeFunctionInput == nil {
+		t.Fatal("expected DescribeFunction to be called")
+	}
+	if aws.ToString(client.describeFunctionInput.Name) != "my-fn" {
+		t.Fatalf("DescribeFunction called with wrong Name: %q", aws.ToString(client.describeFunctionInput.Name))
+	}
+	if client.updateFunctionInput == nil {
+		t.Fatal("expected UpdateFunction to be called")
+	}
+	if aws.ToString(client.updateFunctionInput.IfMatch) != "ETAG-DEVELOPMENT-1" {
+		t.Fatalf("UpdateFunction IfMatch wrong: %q", aws.ToString(client.updateFunctionInput.IfMatch))
+	}
+	if string(client.updateFunctionInput.FunctionCode) != "function handler(e) { return e.request; } // v2" {
+		t.Fatalf("UpdateFunction FunctionCode wrong: %q", string(client.updateFunctionInput.FunctionCode))
+	}
+	if client.updateFunctionInput.FunctionConfig == nil ||
+		aws.ToString(client.updateFunctionInput.FunctionConfig.Comment) != "updated" ||
+		client.updateFunctionInput.FunctionConfig.Runtime != cftypes.FunctionRuntimeCloudfrontJs20 {
+		t.Fatalf("UpdateFunction FunctionConfig wrong: %+v", client.updateFunctionInput.FunctionConfig)
+	}
+}
+
+func TestFunction_Update_PublishesWhenAutoPublishTrue(t *testing.T) {
+	client := &fakeCloudFrontClient{
+		describeFunctionOut: &cloudfront.DescribeFunctionOutput{
+			ETag: aws.String("ETAG-DEVELOPMENT-1"),
+			FunctionSummary: &cftypes.FunctionSummary{
+				Name: aws.String("my-fn"),
+				FunctionConfig: &cftypes.FunctionConfig{
+					Comment: aws.String("c"),
+					Runtime: cftypes.FunctionRuntimeCloudfrontJs20,
+				},
+			},
+		},
+	}
+	f := newFunctionForTest(client)
+
+	_, err := f.Update(context.Background(), functionUpdateRequest(true, "new code"))
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if client.publishFunctionInput == nil {
+		t.Fatal("expected PublishFunction to be called when AutoPublish=true")
+	}
+	// PublishFunction must use the ETag from UpdateFunction's response, not
+	// the original DescribeFunction ETag (Update bumps the version).
+	if aws.ToString(client.publishFunctionInput.IfMatch) != "ETAG-AFTER-UPDATE" {
+		t.Fatalf("PublishFunction IfMatch wrong: got %q, want ETAG-AFTER-UPDATE", aws.ToString(client.publishFunctionInput.IfMatch))
+	}
+	if aws.ToString(client.publishFunctionInput.Name) != "my-fn" {
+		t.Fatalf("PublishFunction Name wrong: %q", aws.ToString(client.publishFunctionInput.Name))
+	}
+}
+
+func TestFunction_Update_SkipsPublishWhenAutoPublishFalse(t *testing.T) {
+	client := &fakeCloudFrontClient{
+		describeFunctionOut: &cloudfront.DescribeFunctionOutput{
+			ETag: aws.String("ETAG-DEVELOPMENT-1"),
+			FunctionSummary: &cftypes.FunctionSummary{
+				Name: aws.String("my-fn"),
+				FunctionConfig: &cftypes.FunctionConfig{
+					Comment: aws.String("c"),
+					Runtime: cftypes.FunctionRuntimeCloudfrontJs20,
+				},
+			},
+		},
+	}
+	f := newFunctionForTest(client)
+
+	_, err := f.Update(context.Background(), functionUpdateRequest(false, "new code"))
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if client.publishFunctionInput != nil {
+		t.Fatal("expected PublishFunction NOT to be called when AutoPublish=false")
+	}
+}
+
+func TestFunction_Update_ReportsErrorWhenDescribeFails(t *testing.T) {
+	client := &fakeCloudFrontClient{
+		describeFunctionErr: errors.New("DescribeFunction failed"),
+	}
+	f := newFunctionForTest(client)
+	_, err := f.Update(context.Background(), functionUpdateRequest(true, "code"))
+	if err == nil {
+		t.Fatal("expected error when DescribeFunction fails")
+	}
+}
+
+func TestFunction_Update_PreservesNameFromDesiredProperties(t *testing.T) {
+	// NativeID is the ARN; the schema's identifier is FunctionARN, but the
+	// UpdateFunction SDK call takes Name. The provisioner should extract
+	// Name from DesiredProperties.Name (the createOnly field).
+	client := &fakeCloudFrontClient{
+		describeFunctionOut: &cloudfront.DescribeFunctionOutput{
+			ETag: aws.String("E1"),
+			FunctionSummary: &cftypes.FunctionSummary{
+				Name:           aws.String("my-fn"),
+				FunctionConfig: &cftypes.FunctionConfig{Runtime: cftypes.FunctionRuntimeCloudfrontJs20, Comment: aws.String("c")},
+			},
+		},
+	}
+	f := newFunctionForTest(client)
+	_, err := f.Update(context.Background(), functionUpdateRequest(false, "code"))
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if aws.ToString(client.updateFunctionInput.Name) != "my-fn" {
+		t.Fatalf("UpdateFunction Name wrong: %q", aws.ToString(client.updateFunctionInput.Name))
+	}
+}

--- a/testdata/cloudfront-function-update.pkl
+++ b/testdata/cloudfront-function-update.pkl
@@ -31,7 +31,7 @@ forma {
     label = "plugin-sdk-test-fn"
     name = "formae-plugin-sdk-test-fn-\(testRunID)"
     autoPublish = true
-    functionCode = "function handler(event) { return event.request; }"
+    functionCode = "function handler(event) { event.request.headers['x-formae-test'] = { value: 'updated' }; return event.request; }"
     functionConfig = new cffn.FunctionConfig {
       runtime = "cloudfront-js-2.0"
       comment = "Plugin SDK test Function — updated comment"


### PR DESCRIPTION
## Summary

Three independent fixes for the CloudFront/ACM/Route53 resources shipped in `0.1.11`. All surfaced when re-applying a real "S3 + CloudFront + ACM cert + Route53 validation" stack against the new agent.

### `AWS::CloudFront::Function.Update` silently dropped `functionCode`

CloudControl's generic Update path didn't include `functionCode` in the payload, so `UpdateFunction` reported Success while the live code (DEVELOPMENT and LIVE stages) stayed at the prior value. New custom provisioner handles Update directly via the CloudFront SDK:

- `DescribeFunction` -> capture ETag
- `UpdateFunction` with the new `FunctionCode` + `FunctionConfig` + `IfMatch`
- `PublishFunction` when `autoPublish=true`, using the post-update ETag (UpdateFunction bumps the version, so the original DescribeFunction ETag is stale by the time we publish)

### `AWS::CloudFront::Distribution.Update` failed with 400 "Exactly one of [AcmCertificateArn, ...]"

`UpdateDistribution` requires the full `DistributionConfig` on every call — fields not in the payload get reset to defaults, and the ViewerCertificate union rejects any payload that doesn't carry one of the cert-source fields. CloudControl's diff-only patch payload omitted `ViewerCertificate.AcmCertificateArn` whenever the diff didn't touch it, so any Update on a distribution with a managed cert hard-failed.

New custom provisioner:

- `GetDistributionConfig` -> capture live config + ETag
- Apply the operator's JSON Patch (filtered to `/DistributionConfig/*` ops) on top of the live config
- `UpdateDistribution` with the merged config + `IfMatch`
- Tags sync via `TagResource` / `UntagResource` on the distribution ARN (separate from `DistributionConfig`)

Both Function and Distribution use a narrow `CloudFrontClientInterface` for DI, mirroring the `ACMClientInterface` pattern from `certificatemanager`. CRUD operations other than Update fall through to CloudControl.

### `AWS::Route53::RecordSet` for cert validation got delete+create on every reconcile

ACM returns DNS validation Names with a trailing dot (`_abc.example.com.`); `RecordSet.Read` strips trailing dots from `Name`. So a `Route53::RecordSet` fed by `cert.res.validationRecords.at(0).name` saw a perpetual diff against its own readback and was delete+recreate'd every apply (~80s of unnecessary churn, plus a brief window where the validation CNAME didn't exist). Fix: strip the trailing dot in `validationRecordsFromCert` so the cert resolvable produces values that match Route53's normalization.

## Conformance coverage

`testdata/cloudfront-function-update.pkl` now mutates `functionCode` (previously only changed `functionConfig.comment`), so the silent-drop regression is exercised in the existing CloudFront Function conformance test.

No `cloudfront-distribution.pkl` conformance fixture is added in this PR — `AWS::CloudFront::Distribution` is `discoverable=false, extractable=false` and a Distribution Create takes 5–15 min, so a full conformance fixture would need ~30+ min for the create/update/destroy cycle. The unit tests cover the merge semantics; field validation will happen against a real distribution before tagging.

## Dependencies

Adds `github.com/aws/aws-sdk-go-v2/service/cloudfront` and `github.com/evanphx/json-patch/v5`.