### PR TITLE
fix(cloudfront): Function.Update AWS readback + Distribution provider-default annotations

### DIFF
--- a/pkg/cfres/cloudfront/function.go
+++ b/pkg/cfres/cloudfront/function.go
@@ -99,7 +99,9 @@ func (f *Function) Update(ctx context.Context, request *resource.UpdateRequest) 
 	}
 
 	// 3. PublishFunction if AutoPublish — uses the post-update ETag,
-	//    because UpdateFunction bumped the version.
+	//    because UpdateFunction bumped the version. Track which stage
+	//    we read back from so the result reflects the user-facing code.
+	stage := cftypes.FunctionStageDevelopment
 	if autoPublish, ok := desired["AutoPublish"].(bool); ok && autoPublish {
 		if _, err := client.PublishFunction(ctx, &cloudfront.PublishFunctionInput{
 			Name:    aws.String(name),
@@ -107,6 +109,21 @@ func (f *Function) Update(ctx context.Context, request *resource.UpdateRequest) 
 		}); err != nil {
 			return nil, fmt.Errorf("cloudfront function: PublishFunction: %w", err)
 		}
+		stage = cftypes.FunctionStageLive
+	}
+
+	// 4. Read back actual AWS state and use it as ResourceProperties.
+	//    Returning DesiredProperties verbatim would mask silent
+	//    UpdateFunction failures (Success reported, function code
+	//    unchanged on AWS) — the agent's DB would diverge from reality
+	//    until the next periodic sync.
+	props, err := readFunctionProperties(ctx, client, name, stage, request.NativeID)
+	if err != nil {
+		return nil, err
+	}
+	propsBytes, err := json.Marshal(props)
+	if err != nil {
+		return nil, fmt.Errorf("cloudfront function: marshal readback: %w", err)
 	}
 
 	return &resource.UpdateResult{
@@ -114,9 +131,59 @@ func (f *Function) Update(ctx context.Context, request *resource.UpdateRequest) 
 			Operation:          resource.OperationUpdate,
 			OperationStatus:    resource.OperationStatusSuccess,
 			NativeID:           request.NativeID,
-			ResourceProperties: request.DesiredProperties,
+			ResourceProperties: propsBytes,
 		},
 	}, nil
+}
+
+// readFunctionProperties reads the function's actual state from AWS at
+// the given stage and returns a property map matching the CFN schema
+// shape. Used to populate the Update result so the agent's DB tracks
+// AWS state (not the operator's intent).
+func readFunctionProperties(ctx context.Context, client CloudFrontClientInterface, name string, stage cftypes.FunctionStage, nativeID string) (map[string]any, error) {
+	getResp, err := client.GetFunction(ctx, &cloudfront.GetFunctionInput{
+		Name:  aws.String(name),
+		Stage: stage,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cloudfront function: GetFunction(%s): %w", stage, err)
+	}
+	descResp, err := client.DescribeFunction(ctx, &cloudfront.DescribeFunctionInput{
+		Name:  aws.String(name),
+		Stage: stage,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cloudfront function: DescribeFunction(%s) for readback: %w", stage, err)
+	}
+
+	props := map[string]any{
+		"Name":         name,
+		"FunctionCode": string(getResp.FunctionCode),
+		"FunctionARN":  nativeID,
+	}
+	if descResp.FunctionSummary != nil && descResp.FunctionSummary.FunctionConfig != nil {
+		cfg := descResp.FunctionSummary.FunctionConfig
+		fc := map[string]any{}
+		if cfg.Comment != nil {
+			fc["Comment"] = *cfg.Comment
+		}
+		if cfg.Runtime != "" {
+			fc["Runtime"] = string(cfg.Runtime)
+		}
+		if cfg.KeyValueStoreAssociations != nil && len(cfg.KeyValueStoreAssociations.Items) > 0 {
+			var items []map[string]any
+			for _, kva := range cfg.KeyValueStoreAssociations.Items {
+				if kva.KeyValueStoreARN != nil {
+					items = append(items, map[string]any{"KeyValueStoreARN": *kva.KeyValueStoreARN})
+				}
+			}
+			if len(items) > 0 {
+				fc["KeyValueStoreAssociations"] = items
+			}
+		}
+		props["FunctionConfig"] = fc
+	}
+	return props, nil
 }
 
 func functionConfigFromDesired(raw any) (*cftypes.FunctionConfig, error) {

--- a/pkg/cfres/cloudfront/function_test.go
+++ b/pkg/cfres/cloudfront/function_test.go
@@ -181,3 +181,57 @@ func TestFunction_Update_PreservesNameFromDesiredProperties(t *testing.T) {
 		t.Fatalf("UpdateFunction Name wrong: %q", aws.ToString(client.updateFunctionInput.Name))
 	}
 }
+
+func TestFunction_Update_ResultReflectsPostUpdateReadbackFromAWS(t *testing.T) {
+	// The conformance harness verifies post-Update properties by reading
+	// formae's inventory, which comes from ResourceProperties returned
+	// here. If we trust DesiredProperties verbatim, a silent AWS-side
+	// failure (Update reports Success but the function code didn't
+	// actually change) is invisible to conformance. The fix: read back
+	// the actual AWS state after Update+Publish and use that as the
+	// returned ResourceProperties.
+	client := &fakeCloudFrontClient{
+		describeFunctionOut: &cloudfront.DescribeFunctionOutput{
+			ETag: aws.String("E1-before-update"),
+			FunctionSummary: &cftypes.FunctionSummary{
+				Name: aws.String("my-fn"),
+				FunctionConfig: &cftypes.FunctionConfig{
+					Runtime: cftypes.FunctionRuntimeCloudfrontJs20,
+					Comment: aws.String("old"),
+				},
+				FunctionMetadata: &cftypes.FunctionMetadata{
+					FunctionARN: aws.String("arn:aws:cloudfront::123:function/my-fn"),
+				},
+			},
+		},
+		updateFunctionOut: &cloudfront.UpdateFunctionOutput{
+			ETag: aws.String("E2-after-update"),
+		},
+		getFunctionOut: &cloudfront.GetFunctionOutput{
+			ETag:         aws.String("E2-after-update"),
+			FunctionCode: []byte("ACTUAL LIVE CODE FROM AWS"),
+		},
+	}
+	f := newFunctionForTest(client)
+
+	result, err := f.Update(context.Background(), functionUpdateRequest(true, "code we sent"))
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+
+	// We must have queried AWS for the actual function code after
+	// publishing — otherwise the agent's DB will diverge from reality
+	// and silent no-ops in UpdateFunction become invisible.
+	if client.getFunctionInput == nil {
+		t.Fatal("expected GetFunction to be called for post-update readback")
+	}
+
+	var props map[string]any
+	if err := json.Unmarshal(result.ProgressResult.ResourceProperties, &props); err != nil {
+		t.Fatalf("unmarshal result properties: %v", err)
+	}
+	if got := props["FunctionCode"]; got != "ACTUAL LIVE CODE FROM AWS" {
+		t.Errorf("ResourceProperties.FunctionCode: want AWS readback %q, got %q (provisioner is trusting DesiredProperties instead of reading back from AWS)",
+			"ACTUAL LIVE CODE FROM AWS", got)
+	}
+}

--- a/pkg/cfres/cloudfront/registration_test.go
+++ b/pkg/cfres/cloudfront/registration_test.go
@@ -1,0 +1,36 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package cloudfront
+
+import (
+	"testing"
+
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/cfres/registry"
+)
+
+// TestCustomProvisioners_AreRegisteredForUpdate guards against init()
+// ordering or build-tag mishaps that would let our Function/Distribution
+// Update overrides fall through to CCAPI silently. If this test
+// regresses, the dispatcher in aws.go won't see HasProvisioner==true and
+// CCAPI handles Update instead — which is the silent failure mode that
+// reintroduced Bug 1 post-dev.12.
+func TestCustomProvisioners_AreRegisteredForUpdate(t *testing.T) {
+	cases := []struct {
+		resourceType string
+		operation    resource.Operation
+	}{
+		{"AWS::CloudFront::Function", resource.OperationUpdate},
+		{"AWS::CloudFront::Distribution", resource.OperationUpdate},
+	}
+	for _, tc := range cases {
+		if !registry.HasProvisioner(tc.resourceType, tc.operation) {
+			t.Errorf("expected registry.HasProvisioner(%q, %v) == true; init() did not register the custom provisioner",
+				tc.resourceType, tc.operation)
+		}
+	}
+}

--- a/schema/pkl/cloudfront/distribution.pkl
+++ b/schema/pkl/cloudfront/distribution.pkl
@@ -34,25 +34,33 @@ open class DistributionConfig extends formae.SubResource {
     anycastIpListId: (String|formae.Resolvable)?
     @aws.FieldHint{outputField = "CNAMEs"}
     cnames: Listing<String>?
+    @aws.FieldHint{hasProviderDefault = true}
     cacheBehaviors: Listing<CacheBehavior>?
     comment: String?
+    @aws.FieldHint{hasProviderDefault = true}
     continuousDeploymentPolicyId: (String|formae.Resolvable)?
+    @aws.FieldHint{hasProviderDefault = true}
     customErrorResponses: Listing<CustomErrorResponse>?
     customOrigin: CustomOrigin?
     defaultCacheBehavior: DefaultCacheBehavior
     defaultRootObject: String?
     enabled: Boolean
     httpVersion: HttpVersionType?
-    @aws.FieldHint{outputField = "IPV6Enabled"}
+    @aws.FieldHint{outputField = "IPV6Enabled"; hasProviderDefault = true}
     ipV6Enabled: Boolean?
+    @aws.FieldHint{hasProviderDefault = true}
     logging: Logging?
+    @aws.FieldHint{hasProviderDefault = true}
     originGroups: OriginGroups?
     origins: Listing<Origin>?
     priceClass: PriceClassType?
+    @aws.FieldHint{hasProviderDefault = true}
     restrictions: Restrictions?
     s3Origin: S3Origin?
+    @aws.FieldHint{hasProviderDefault = true}
     staging: Boolean?
     viewerCertificate: ViewerCertificate?
+    @aws.FieldHint{hasProviderDefault = true}
     webACLId: (String|formae.Resolvable)?
 }
 
@@ -102,11 +110,14 @@ open class CustomErrorResponse extends formae.SubResource {
 open class CustomOriginConfig extends formae.SubResource {
     @aws.FieldHint{outputField = "HTTPPort"}
     httpPort: Int?
-    @aws.FieldHint{outputField = "HTTPSPort"}
+    @aws.FieldHint{outputField = "HTTPSPort"; hasProviderDefault = true}
     httpsPort: Int?
+    @aws.FieldHint{hasProviderDefault = true}
     originKeepaliveTimeout: Int?
     originProtocolPolicy: OriginProtocolPolicyType
+    @aws.FieldHint{hasProviderDefault = true}
     originReadTimeout: Int?
+    @aws.FieldHint{hasProviderDefault = true}
     originSSLProtocols: Listing<String>?
 }
 
@@ -116,12 +127,16 @@ open class DefaultCacheBehavior extends formae.SubResource {
     @aws.FieldHint{edgeKind = "runtimeDependency"}
     cachePolicyId: (String|formae.Resolvable)?
     cachedMethods: Listing<String>?
+    @aws.FieldHint{hasProviderDefault = true}
     compress: Boolean?
     defaultTTL: Number?
+    @aws.FieldHint{hasProviderDefault = true}
     fieldLevelEncryptionId: (String|formae.Resolvable)?
     forwardedValues: ForwardedValues?
     functionAssociations: Listing<FunctionAssociation>?
+    @aws.FieldHint{hasProviderDefault = true}
     grpcConfig: GrpcConfig?
+    @aws.FieldHint{hasProviderDefault = true}
     lambdaFunctionAssociations: Listing<LambdaFunctionAssociation>?
     maxTTL: Number?
     minTTL: Number?
@@ -130,9 +145,12 @@ open class DefaultCacheBehavior extends formae.SubResource {
     realtimeLogConfigArn: (String|formae.Resolvable)?
     @aws.FieldHint{edgeKind = "runtimeDependency"}
     responseHeadersPolicyId: (String|formae.Resolvable)?
+    @aws.FieldHint{hasProviderDefault = true}
     smoothStreaming: Boolean?
     targetOriginId: String
+    @aws.FieldHint{hasProviderDefault = true}
     trustedKeyGroups: Listing<String>?
+    @aws.FieldHint{hasProviderDefault = true}
     trustedSigners: Listing<String>?
     viewerProtocolPolicy: ViewerProtocolPolicyType
 }
@@ -140,8 +158,10 @@ open class DefaultCacheBehavior extends formae.SubResource {
 @aws.SubResourceHint
 open class ForwardedValues extends formae.SubResource {
     cookies: Cookies?
+    @aws.FieldHint{hasProviderDefault = true}
     headers: Listing<String>?
     queryString: Boolean
+    @aws.FieldHint{hasProviderDefault = true}
     queryStringCacheKeys: Listing<String>?
 }
 
@@ -199,15 +219,20 @@ open class Logging extends formae.SubResource {
 
 @aws.SubResourceHint
 open class Origin extends formae.SubResource {
+    @aws.FieldHint{hasProviderDefault = true}
     connectionAttempts: Int?
+    @aws.FieldHint{hasProviderDefault = true}
     connectionTimeout: Int?
     customOriginConfig: CustomOriginConfig?
     domainName: String|formae.Resolvable
     id: String|formae.Resolvable
-    @aws.FieldHint{edgeKind = "runtimeDependency"}
+    @aws.FieldHint{edgeKind = "runtimeDependency"; hasProviderDefault = true}
     originAccessControlId: (String|formae.Resolvable)?
+    @aws.FieldHint{hasProviderDefault = true}
     originCustomHeaders: Listing<OriginCustomHeader>?
+    @aws.FieldHint{hasProviderDefault = true}
     originPath: String?
+    @aws.FieldHint{hasProviderDefault = true}
     originShield: OriginShield?
     s3OriginConfig: S3OriginConfig?
     vpcOriginConfig: VpcOriginConfig?


### PR DESCRIPTION
## Summary

`Function.Update` (introduced in dev.12) called `UpdateFunction` and `PublishFunction` correctly but then returned `request.DesiredProperties` verbatim as the Update result. The conformance harness verifies post-Update state via formae's inventory (populated from that returned value), so a silent AWS-side no-op — `UpdateFunction` reports Success while the live function code stays at the prior value — is invisible to the test. The agent's DB also diverges from reality until the next periodic sync overwrites it.

The fix: after `UpdateFunction` (and `PublishFunction` when `AutoPublish=true`), call `GetFunction` + `DescribeFunction` at the appropriate stage and build the result properties from the actual AWS readback. Same shape as `certificatemanager.Certificate.Update`. If AWS didn't accept the new code, the readback returns the old code, the agent's DB tracks reality, and the conformance comparison against the update fixture fails loudly.

Also adds a registration pin test (`TestCustomProvisioners_AreRegisteredForUpdate`) that asserts `registry.HasProvisioner` returns true for `AWS::CloudFront::Function` and `AWS::CloudFront::Distribution` under `OperationUpdate` — guards against init() ordering or build-tag regressions that would silently route Updates back through CloudControl.

## Notes for review

- `Distribution.Update` still returns `DesiredProperties` verbatim — same hygiene gap, but lower priority since Bug 2 is verified working downstream. Worth a follow-up.
- The `cloudfront-function-update.pkl` fixture already mutates `functionCode` (added in #100), so this conformance run is a real end-to-end test of whether AWS gets the new code.