### PR TITLE
feat(networkfirewall): add AWS Network Firewall resource support

### DIFF
--- a/pkg/cfres/cfres.go
+++ b/pkg/cfres/cfres.go
@@ -19,6 +19,7 @@ import (
 	_ "github.com/platform-engineering-labs/formae-plugin-aws/pkg/cfres/elasticloadbalancingv2"
 	_ "github.com/platform-engineering-labs/formae-plugin-aws/pkg/cfres/iam"
 	_ "github.com/platform-engineering-labs/formae-plugin-aws/pkg/cfres/lambda"
+	_ "github.com/platform-engineering-labs/formae-plugin-aws/pkg/cfres/networkfirewall"
 	_ "github.com/platform-engineering-labs/formae-plugin-aws/pkg/cfres/route53"
 	_ "github.com/platform-engineering-labs/formae-plugin-aws/pkg/cfres/s3"
 	_ "github.com/platform-engineering-labs/formae-plugin-aws/pkg/cfres/secretsmanager"

--- a/pkg/cfres/networkfirewall/firewall.go
+++ b/pkg/cfres/networkfirewall/firewall.go
@@ -1,0 +1,190 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package networkfirewall
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/ccx"
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/cfres/prov"
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/cfres/registry"
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/config"
+)
+
+const firewallType = "AWS::NetworkFirewall::Firewall"
+
+// ccxClient abstracts the CloudControl operations this reconciler delegates to,
+// so they can be mocked in unit tests. *ccx.Client satisfies this interface.
+type ccxClient interface {
+	ReadResource(ctx context.Context, request *resource.ReadRequest) (*resource.ReadResult, error)
+	StatusResource(ctx context.Context, request *resource.StatusRequest, readFunc func(context.Context, *resource.ReadRequest) (*resource.ReadResult, error)) (*resource.StatusResult, error)
+}
+
+// Firewall enriches CloudControl reads with a computed EndpointIdsByAz map and
+// gates create-success on endpoint readiness. All other operations fall through
+// to the generic CloudControl path in aws.go (only Read + CheckStatus are
+// registered).
+type Firewall struct {
+	cfg *config.Config
+	// client is injectable for testing; nil means construct a real ccx.Client.
+	client ccxClient
+}
+
+var _ prov.Provisioner = &Firewall{}
+
+func init() {
+	registry.Register(firewallType,
+		[]resource.Operation{resource.OperationRead, resource.OperationCheckStatus},
+		func(cfg *config.Config) prov.Provisioner {
+			return &Firewall{cfg: cfg}
+		})
+}
+
+func (f *Firewall) getClient() (ccxClient, error) {
+	if f.client != nil {
+		return f.client, nil
+	}
+	return ccx.NewClient(f.cfg)
+}
+
+// Read reads the firewall via CloudControl and injects a computed EndpointIdsByAz
+// object mapping availability zone -> VPC endpoint id, derived from the read-only
+// EndpointIds list (each entry "<az>:<endpoint-id>"). The native EndpointIds list
+// is left intact.
+func (f *Firewall) Read(ctx context.Context, request *resource.ReadRequest) (*resource.ReadResult, error) {
+	client, err := f.getClient()
+	if err != nil {
+		return nil, fmt.Errorf("creating cloudcontrol client: %w", err)
+	}
+
+	result, err := client.ReadResource(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+	if result.ErrorCode != "" {
+		return result, nil
+	}
+
+	var props map[string]any
+	if err = json.Unmarshal([]byte(result.Properties), &props); err != nil {
+		return nil, fmt.Errorf("unmarshal firewall properties: %w", err)
+	}
+
+	props["EndpointIdsByAz"] = endpointIdsByAz(props)
+
+	out, err := json.Marshal(props)
+	if err != nil {
+		return nil, fmt.Errorf("marshal enriched firewall properties: %w", err)
+	}
+	result.Properties = string(out)
+	return result, nil
+}
+
+// endpointIdsByAz converts the read-only EndpointIds list (["<az>:<endpoint-id>"])
+// into a map keyed by availability zone. Malformed entries (missing the colon, or
+// an empty az/endpoint) are skipped.
+func endpointIdsByAz(props map[string]any) map[string]string {
+	byAz := map[string]string{}
+	raw, ok := props["EndpointIds"].([]any)
+	if !ok {
+		return byAz
+	}
+	for _, e := range raw {
+		s, ok := e.(string)
+		if !ok {
+			continue
+		}
+		az, endpoint, found := strings.Cut(s, ":")
+		if !found || az == "" || endpoint == "" {
+			continue
+		}
+		byAz[az] = endpoint
+	}
+	return byAz
+}
+
+// The remaining Provisioner methods are unreachable: only Read and CheckStatus are
+// registered, so Create/Update/Delete/List always route to CloudControl in aws.go.
+func (f *Firewall) Create(_ context.Context, _ *resource.CreateRequest) (*resource.CreateResult, error) {
+	return nil, fmt.Errorf("create not implemented - cloudcontrol handles this")
+}
+
+func (f *Firewall) Update(_ context.Context, _ *resource.UpdateRequest) (*resource.UpdateResult, error) {
+	return nil, fmt.Errorf("update not implemented - cloudcontrol handles this")
+}
+
+func (f *Firewall) Delete(_ context.Context, _ *resource.DeleteRequest) (*resource.DeleteResult, error) {
+	return nil, fmt.Errorf("delete not implemented - cloudcontrol handles this")
+}
+
+func (f *Firewall) List(_ context.Context, _ *resource.ListRequest) (*resource.ListResult, error) {
+	return nil, fmt.Errorf("list not implemented - cloudcontrol handles this")
+}
+
+// Status drives the CloudControl create/update status check, but withholds
+// Success until the firewall's per-AZ VPC endpoints are populated. Core
+// ResolveCache treats a property that is missing after a successful Read as a
+// terminal resolve failure (not a retry), so reporting Success before
+// EndpointIdsByAz is populated would make dependent routes fail late and
+// terminally. Returning InProgress keeps the operator polling instead.
+func (f *Firewall) Status(ctx context.Context, request *resource.StatusRequest) (*resource.StatusResult, error) {
+	client, err := f.getClient()
+	if err != nil {
+		return nil, fmt.Errorf("creating cloudcontrol client: %w", err)
+	}
+
+	result, err := client.StatusResource(ctx, request, f.Read)
+	if err != nil {
+		return nil, err
+	}
+	if result == nil || result.ProgressResult == nil {
+		return result, nil
+	}
+
+	pr := result.ProgressResult
+	if pr.OperationStatus != resource.OperationStatusSuccess {
+		return result, nil
+	}
+	// Only create/update success carries (and needs) populated endpoints. Delete
+	// success has no ResourceProperties (ccx does not read deleted resources), so
+	// gating it would flip a finished delete back to InProgress and poll until
+	// timeout. Pass non-create/update success through unchanged.
+	if pr.Operation != resource.OperationCreate && pr.Operation != resource.OperationUpdate {
+		return result, nil
+	}
+	if endpointsPopulated(pr.ResourceProperties) {
+		return result, nil
+	}
+
+	return &resource.StatusResult{
+		ProgressResult: &resource.ProgressResult{
+			Operation:       pr.Operation,
+			OperationStatus: resource.OperationStatusInProgress,
+			RequestID:       request.RequestID,
+			NativeID:        request.NativeID,
+			StatusMessage:   "waiting for firewall VPC endpoints to be assigned",
+		},
+	}, nil
+}
+
+// endpointsPopulated reports whether the enriched properties carry at least one
+// per-AZ endpoint id.
+func endpointsPopulated(properties json.RawMessage) bool {
+	if len(properties) == 0 {
+		return false
+	}
+	var p struct {
+		EndpointIdsByAz map[string]string `json:"EndpointIdsByAz"`
+	}
+	if err := json.Unmarshal(properties, &p); err != nil {
+		return false
+	}
+	return len(p.EndpointIdsByAz) > 0
+}

--- a/pkg/cfres/networkfirewall/firewall_mock_test.go
+++ b/pkg/cfres/networkfirewall/firewall_mock_test.go
@@ -1,0 +1,34 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package networkfirewall
+
+import (
+	"context"
+
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+	"github.com/stretchr/testify/mock"
+)
+
+type mockCCXClient struct {
+	mock.Mock
+}
+
+func (m *mockCCXClient) ReadResource(ctx context.Context, request *resource.ReadRequest) (*resource.ReadResult, error) {
+	args := m.Called(ctx, request)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*resource.ReadResult), args.Error(1)
+}
+
+func (m *mockCCXClient) StatusResource(ctx context.Context, request *resource.StatusRequest, readFunc func(context.Context, *resource.ReadRequest) (*resource.ReadResult, error)) (*resource.StatusResult, error) {
+	args := m.Called(ctx, request, readFunc)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*resource.StatusResult), args.Error(1)
+}

--- a/pkg/cfres/networkfirewall/firewall_test.go
+++ b/pkg/cfres/networkfirewall/firewall_test.go
@@ -1,0 +1,252 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package networkfirewall
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/config"
+)
+
+const fwArn = "arn:aws:network-firewall:us-east-1:123456789012:firewall/test-fw"
+
+func fwPropsJSON(t *testing.T, endpointIds []string) string {
+	t.Helper()
+	props := map[string]any{
+		"FirewallName":      "test-fw",
+		"FirewallArn":       fwArn,
+		"FirewallId":        "11111111-2222-3333-4444-555555555555",
+		"VpcId":             "vpc-0abc",
+		"FirewallPolicyArn": "arn:aws:network-firewall:us-east-1:123456789012:firewall-policy/test-pol",
+	}
+	if endpointIds != nil {
+		ids := make([]any, len(endpointIds))
+		for i, e := range endpointIds {
+			ids[i] = e
+		}
+		props["EndpointIds"] = ids
+	}
+	b, err := json.Marshal(props)
+	require.NoError(t, err)
+	return string(b)
+}
+
+func newFirewallWithMock(c *mockCCXClient) *Firewall {
+	return &Firewall{cfg: &config.Config{Region: "us-east-1"}, client: c}
+}
+
+func readEndpointIdsByAz(t *testing.T, properties string) map[string]string {
+	t.Helper()
+	var p struct {
+		EndpointIdsByAz map[string]string `json:"EndpointIdsByAz"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(properties), &p))
+	return p.EndpointIdsByAz
+}
+
+func TestFirewall_Read_FlattensMultipleAZs(t *testing.T) {
+	c := &mockCCXClient{}
+	c.On("ReadResource", mock.Anything, mock.Anything).Return(&resource.ReadResult{
+		ResourceType: firewallType,
+		Properties:   fwPropsJSON(t, []string{"us-east-1a:vpce-aaa", "us-east-1b:vpce-bbb"}),
+	}, nil)
+	fw := newFirewallWithMock(c)
+
+	res, err := fw.Read(context.Background(), &resource.ReadRequest{NativeID: fwArn, ResourceType: firewallType})
+
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"us-east-1a": "vpce-aaa", "us-east-1b": "vpce-bbb"}, readEndpointIdsByAz(t, res.Properties))
+}
+
+func TestFirewall_Read_SingleAZ(t *testing.T) {
+	c := &mockCCXClient{}
+	c.On("ReadResource", mock.Anything, mock.Anything).Return(&resource.ReadResult{
+		ResourceType: firewallType,
+		Properties:   fwPropsJSON(t, []string{"eu-west-1a:vpce-zzz"}),
+	}, nil)
+	fw := newFirewallWithMock(c)
+
+	res, err := fw.Read(context.Background(), &resource.ReadRequest{NativeID: fwArn, ResourceType: firewallType})
+
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"eu-west-1a": "vpce-zzz"}, readEndpointIdsByAz(t, res.Properties))
+}
+
+func TestFirewall_Read_EmptyEndpointIds(t *testing.T) {
+	c := &mockCCXClient{}
+	c.On("ReadResource", mock.Anything, mock.Anything).Return(&resource.ReadResult{
+		ResourceType: firewallType,
+		Properties:   fwPropsJSON(t, []string{}),
+	}, nil)
+	fw := newFirewallWithMock(c)
+
+	res, err := fw.Read(context.Background(), &resource.ReadRequest{NativeID: fwArn, ResourceType: firewallType})
+
+	require.NoError(t, err)
+	assert.Empty(t, readEndpointIdsByAz(t, res.Properties))
+}
+
+func TestFirewall_Read_NoEndpointIdsKey(t *testing.T) {
+	c := &mockCCXClient{}
+	c.On("ReadResource", mock.Anything, mock.Anything).Return(&resource.ReadResult{
+		ResourceType: firewallType,
+		Properties:   fwPropsJSON(t, nil),
+	}, nil)
+	fw := newFirewallWithMock(c)
+
+	res, err := fw.Read(context.Background(), &resource.ReadRequest{NativeID: fwArn, ResourceType: firewallType})
+
+	require.NoError(t, err)
+	assert.Empty(t, readEndpointIdsByAz(t, res.Properties))
+}
+
+func TestFirewall_Read_MalformedEntrySkipped(t *testing.T) {
+	c := &mockCCXClient{}
+	c.On("ReadResource", mock.Anything, mock.Anything).Return(&resource.ReadResult{
+		ResourceType: firewallType,
+		Properties:   fwPropsJSON(t, []string{"no-colon-here", "us-east-1a:vpce-aaa", ":vpce-nobad", "us-east-1b:"}),
+	}, nil)
+	fw := newFirewallWithMock(c)
+
+	res, err := fw.Read(context.Background(), &resource.ReadRequest{NativeID: fwArn, ResourceType: firewallType})
+
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"us-east-1a": "vpce-aaa"}, readEndpointIdsByAz(t, res.Properties))
+}
+
+func TestFirewall_Read_NativeEndpointIdsPreserved(t *testing.T) {
+	c := &mockCCXClient{}
+	c.On("ReadResource", mock.Anything, mock.Anything).Return(&resource.ReadResult{
+		ResourceType: firewallType,
+		Properties:   fwPropsJSON(t, []string{"us-east-1a:vpce-aaa"}),
+	}, nil)
+	fw := newFirewallWithMock(c)
+
+	res, err := fw.Read(context.Background(), &resource.ReadRequest{NativeID: fwArn, ResourceType: firewallType})
+
+	require.NoError(t, err)
+	var p map[string]any
+	require.NoError(t, json.Unmarshal([]byte(res.Properties), &p))
+	assert.Contains(t, p, "EndpointIds")
+}
+
+func TestFirewall_Read_ErrorCodePassthrough(t *testing.T) {
+	c := &mockCCXClient{}
+	c.On("ReadResource", mock.Anything, mock.Anything).Return(&resource.ReadResult{
+		ResourceType: firewallType,
+		ErrorCode:    resource.OperationErrorCodeNotFound,
+	}, nil)
+	fw := newFirewallWithMock(c)
+
+	res, err := fw.Read(context.Background(), &resource.ReadRequest{NativeID: fwArn, ResourceType: firewallType})
+
+	require.NoError(t, err)
+	assert.Equal(t, resource.OperationErrorCodeNotFound, res.ErrorCode)
+}
+
+func TestFirewall_Read_ReaderError(t *testing.T) {
+	c := &mockCCXClient{}
+	c.On("ReadResource", mock.Anything, mock.Anything).Return(nil, errors.New("boom"))
+	fw := newFirewallWithMock(c)
+
+	_, err := fw.Read(context.Background(), &resource.ReadRequest{NativeID: fwArn, ResourceType: firewallType})
+
+	require.Error(t, err)
+}
+
+func statusResultWith(status resource.OperationStatus, props string) *resource.StatusResult {
+	return statusResultForOp(resource.OperationCreate, status, props)
+}
+
+func statusResultForOp(op resource.Operation, status resource.OperationStatus, props string) *resource.StatusResult {
+	pr := &resource.ProgressResult{
+		Operation:       op,
+		OperationStatus: status,
+		RequestID:       "req-1",
+		NativeID:        fwArn,
+	}
+	if props != "" {
+		pr.ResourceProperties = json.RawMessage(props)
+	}
+	return &resource.StatusResult{ProgressResult: pr}
+}
+
+func TestFirewall_Status_InProgressPassthrough(t *testing.T) {
+	c := &mockCCXClient{}
+	c.On("StatusResource", mock.Anything, mock.Anything, mock.Anything).
+		Return(statusResultWith(resource.OperationStatusInProgress, ""), nil)
+	fw := newFirewallWithMock(c)
+
+	res, err := fw.Status(context.Background(), &resource.StatusRequest{RequestID: "req-1", NativeID: fwArn, ResourceType: firewallType})
+
+	require.NoError(t, err)
+	assert.Equal(t, resource.OperationStatusInProgress, res.ProgressResult.OperationStatus)
+}
+
+func TestFirewall_Status_SuccessButEmptyEndpoints_StaysInProgress(t *testing.T) {
+	c := &mockCCXClient{}
+	props := fwPropsJSON(t, []string{})
+	c.On("StatusResource", mock.Anything, mock.Anything, mock.Anything).
+		Return(statusResultWith(resource.OperationStatusSuccess, props), nil)
+	fw := newFirewallWithMock(c)
+
+	res, err := fw.Status(context.Background(), &resource.StatusRequest{RequestID: "req-1", NativeID: fwArn, ResourceType: firewallType})
+
+	require.NoError(t, err)
+	assert.Equal(t, resource.OperationStatusInProgress, res.ProgressResult.OperationStatus)
+	assert.Equal(t, "req-1", res.ProgressResult.RequestID)
+	assert.Equal(t, fwArn, res.ProgressResult.NativeID)
+}
+
+func TestFirewall_Status_SuccessWithEndpoints(t *testing.T) {
+	c := &mockCCXClient{}
+	props := `{"FirewallArn":"` + fwArn + `","EndpointIdsByAz":{"us-east-1a":"vpce-aaa"}}`
+	c.On("StatusResource", mock.Anything, mock.Anything, mock.Anything).
+		Return(statusResultWith(resource.OperationStatusSuccess, props), nil)
+	fw := newFirewallWithMock(c)
+
+	res, err := fw.Status(context.Background(), &resource.StatusRequest{RequestID: "req-1", NativeID: fwArn, ResourceType: firewallType})
+
+	require.NoError(t, err)
+	assert.Equal(t, resource.OperationStatusSuccess, res.ProgressResult.OperationStatus)
+}
+
+func TestFirewall_Status_DeleteSuccessPassthrough(t *testing.T) {
+	// A completed delete returns Success with no ResourceProperties (ccx does not
+	// read deleted resources). The endpoint-readiness gate must NOT apply to
+	// deletes, otherwise a finished delete is flipped back to InProgress and polls
+	// until timeout.
+	c := &mockCCXClient{}
+	c.On("StatusResource", mock.Anything, mock.Anything, mock.Anything).
+		Return(statusResultForOp(resource.OperationDelete, resource.OperationStatusSuccess, ""), nil)
+	fw := newFirewallWithMock(c)
+
+	res, err := fw.Status(context.Background(), &resource.StatusRequest{RequestID: "req-1", NativeID: fwArn, ResourceType: firewallType})
+
+	require.NoError(t, err)
+	assert.Equal(t, resource.OperationStatusSuccess, res.ProgressResult.OperationStatus)
+}
+
+func TestFirewall_Status_FailurePassthrough(t *testing.T) {
+	c := &mockCCXClient{}
+	c.On("StatusResource", mock.Anything, mock.Anything, mock.Anything).
+		Return(statusResultWith(resource.OperationStatusFailure, ""), nil)
+	fw := newFirewallWithMock(c)
+
+	res, err := fw.Status(context.Background(), &resource.StatusRequest{RequestID: "req-1", NativeID: fwArn, ResourceType: firewallType})
+
+	require.NoError(t, err)
+	assert.Equal(t, resource.OperationStatusFailure, res.ProgressResult.OperationStatus)
+}

--- a/schema/pkl/networkfirewall/firewall.pkl
+++ b/schema/pkl/networkfirewall/firewall.pkl
@@ -14,6 +14,7 @@ const type = "AWS::NetworkFirewall::Firewall"
 @aws.SubResourceHint
 open class SubnetMapping extends formae.SubResource {
     subnetId: String|formae.Resolvable
+    @aws.FieldHint{hasProviderDefault = true}
     iPAddressType: String?
 }
 
@@ -61,13 +62,13 @@ open class Firewall extends formae.Resource {
     @aws.FieldHint
     subnetMappings: Listing<SubnetMapping>
 
-    @aws.FieldHint
+    @aws.FieldHint{hasProviderDefault = true}
     deleteProtection: Boolean?
 
-    @aws.FieldHint
+    @aws.FieldHint{hasProviderDefault = true}
     subnetChangeProtection: Boolean?
 
-    @aws.FieldHint
+    @aws.FieldHint{hasProviderDefault = true}
     firewallPolicyChangeProtection: Boolean?
 
     @aws.FieldHint

--- a/schema/pkl/networkfirewall/firewall.pkl
+++ b/schema/pkl/networkfirewall/firewall.pkl
@@ -1,0 +1,92 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+module aws.networkfirewall.firewall
+
+import "@formae/formae.pkl"
+import "../aws.pkl"
+
+const type = "AWS::NetworkFirewall::Firewall"
+
+@aws.SubResourceHint
+open class SubnetMapping extends formae.SubResource {
+    subnetId: String|formae.Resolvable
+    iPAddressType: String?
+}
+
+open class FirewallResolvable extends formae.Resolvable {
+    local _self = this
+
+    hidden type = module.type
+
+    hidden id: FirewallResolvable = (this) {
+        property = "FirewallArn"
+    }
+    hidden arn: FirewallResolvable = (this) {
+        property = "FirewallArn"
+    }
+    hidden firewallId: FirewallResolvable = (this) {
+        property = "FirewallId"
+    }
+
+    /// Per-AZ VPC endpoint IDs computed by AWS for this firewall.
+    /// Use at() to access an individual endpoint by availability zone:
+    ///   firewall.res.endpointIds.at("us-east-1a")
+    hidden endpointIds: formae.MappingResolvable = new formae.MappingResolvable {
+        label = _self.label
+        type = _self.type
+        stack = _self.stack
+        property = "EndpointIdsByAz"
+    }
+}
+
+@aws.ResourceHint {
+    type = module.type
+    identifier = "FirewallArn"
+}
+open class Firewall extends formae.Resource {
+
+    @aws.FieldHint{createOnly = true}
+    firewallName: String
+
+    @aws.FieldHint
+    firewallPolicyArn: String|formae.Resolvable
+
+    @aws.FieldHint{createOnly = true}
+    vpcId: String|formae.Resolvable
+
+    @aws.FieldHint
+    subnetMappings: Listing<SubnetMapping>
+
+    @aws.FieldHint
+    deleteProtection: Boolean?
+
+    @aws.FieldHint
+    subnetChangeProtection: Boolean?
+
+    @aws.FieldHint
+    firewallPolicyChangeProtection: Boolean?
+
+    @aws.FieldHint
+    description: String?
+
+    /// Per-AZ VPC endpoint IDs computed by AWS, keyed by availability zone.
+    @aws.FieldHint{hasProviderDefault = true}
+    endpointIdsByAz: Mapping<String, String>?
+
+    @aws.FieldHint {
+        updateMethod = "EntitySet"
+        indexField = "Key"
+    }
+    tags: Listing<aws.Tag>?
+
+    local parent = this
+
+    hidden res: FirewallResolvable = new {
+        label = parent.label
+        stack = parent.stack?.label
+    }
+}

--- a/schema/pkl/networkfirewall/firewallpolicy.pkl
+++ b/schema/pkl/networkfirewall/firewallpolicy.pkl
@@ -1,0 +1,83 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+module aws.networkfirewall.firewallpolicy
+
+import "@formae/formae.pkl"
+import "../aws.pkl"
+
+const type = "AWS::NetworkFirewall::FirewallPolicy"
+
+@aws.SubResourceHint
+open class StatefulRuleGroupReference extends formae.SubResource {
+    resourceArn: String|formae.Resolvable
+    priority: Int?
+}
+
+@aws.SubResourceHint
+open class StatelessRuleGroupReference extends formae.SubResource {
+    resourceArn: String|formae.Resolvable
+    priority: Int
+}
+
+@aws.SubResourceHint
+open class StatefulEngineOptions extends formae.SubResource {
+    ruleOrder: String?
+    streamExceptionPolicy: String?
+}
+
+@aws.SubResourceHint
+open class FirewallPolicyData extends formae.SubResource {
+    statelessDefaultActions: Listing<String>
+    statelessFragmentDefaultActions: Listing<String>
+    statefulDefaultActions: Listing<String>?
+    statefulRuleGroupReferences: Listing<StatefulRuleGroupReference>?
+    statelessRuleGroupReferences: Listing<StatelessRuleGroupReference>?
+    statefulEngineOptions: StatefulEngineOptions?
+}
+
+open class FirewallPolicyResolvable extends formae.Resolvable {
+    hidden type = module.type
+
+    hidden id: FirewallPolicyResolvable = (this) {
+        property = "FirewallPolicyArn"
+    }
+    hidden arn: FirewallPolicyResolvable = (this) {
+        property = "FirewallPolicyArn"
+    }
+    hidden firewallPolicyId: FirewallPolicyResolvable = (this) {
+        property = "FirewallPolicyId"
+    }
+}
+
+@aws.ResourceHint {
+    type = module.type
+    identifier = "FirewallPolicyArn"
+}
+open class FirewallPolicy extends formae.Resource {
+
+    @aws.FieldHint{createOnly = true}
+    firewallPolicyName: String
+
+    @aws.FieldHint
+    description: String?
+
+    @aws.FieldHint
+    firewallPolicy: FirewallPolicyData
+
+    @aws.FieldHint {
+        updateMethod = "EntitySet"
+        indexField = "Key"
+    }
+    tags: Listing<aws.Tag>?
+
+    local parent = this
+
+    hidden res: FirewallPolicyResolvable = new {
+        label = parent.label
+        stack = parent.stack?.label
+    }
+}

--- a/schema/pkl/networkfirewall/loggingconfiguration.pkl
+++ b/schema/pkl/networkfirewall/loggingconfiguration.pkl
@@ -1,0 +1,37 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+module aws.networkfirewall.loggingconfiguration
+
+import "@formae/formae.pkl"
+import "../aws.pkl"
+
+const type = "AWS::NetworkFirewall::LoggingConfiguration"
+
+@aws.SubResourceHint
+open class LogDestinationConfig extends formae.SubResource {
+    logType: String
+    logDestinationType: String
+    logDestination: Mapping<String, String|formae.Resolvable>
+}
+
+@aws.SubResourceHint
+open class LoggingConfigurationData extends formae.SubResource {
+    logDestinationConfigs: Listing<LogDestinationConfig>
+}
+
+@aws.ResourceHint {
+    type = module.type
+    identifier = "FirewallArn"
+}
+open class LoggingConfiguration extends formae.Resource {
+
+    @aws.FieldHint{createOnly = true}
+    firewallArn: String|formae.Resolvable
+
+    @aws.FieldHint
+    loggingConfiguration: LoggingConfigurationData
+}

--- a/schema/pkl/networkfirewall/rulegroup.pkl
+++ b/schema/pkl/networkfirewall/rulegroup.pkl
@@ -1,0 +1,95 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+module aws.networkfirewall.rulegroup
+
+import "@formae/formae.pkl"
+import "../aws.pkl"
+
+const type = "AWS::NetworkFirewall::RuleGroup"
+
+@aws.SubResourceHint
+open class IPSet extends formae.SubResource {
+    definition: Listing<String>?
+}
+
+@aws.SubResourceHint
+open class RuleVariables extends formae.SubResource {
+    ipSets: Mapping<String, IPSet>?
+}
+
+@aws.SubResourceHint
+open class RulesSourceList extends formae.SubResource {
+    targets: Listing<String>
+    targetTypes: Listing<String>
+    generatedRulesType: String
+}
+
+@aws.SubResourceHint
+open class RulesSource extends formae.SubResource {
+    rulesSourceList: RulesSourceList?
+}
+
+@aws.SubResourceHint
+open class StatefulRuleOptions extends formae.SubResource {
+    ruleOrder: String?
+}
+
+@aws.SubResourceHint
+open class RuleGroupData extends formae.SubResource {
+    ruleVariables: RuleVariables?
+    rulesSource: RulesSource
+    statefulRuleOptions: StatefulRuleOptions?
+}
+
+open class RuleGroupResolvable extends formae.Resolvable {
+    hidden type = module.type
+
+    hidden id: RuleGroupResolvable = (this) {
+        property = "RuleGroupArn"
+    }
+    hidden arn: RuleGroupResolvable = (this) {
+        property = "RuleGroupArn"
+    }
+    hidden ruleGroupId: RuleGroupResolvable = (this) {
+        property = "RuleGroupId"
+    }
+}
+
+@aws.ResourceHint {
+    type = module.type
+    identifier = "RuleGroupArn"
+}
+open class RuleGroup extends formae.Resource {
+
+    @aws.FieldHint{createOnly = true}
+    ruleGroupName: String
+
+    @aws.FieldHint{createOnly = true}
+    type: String
+
+    @aws.FieldHint{createOnly = true}
+    capacity: Int
+
+    @aws.FieldHint
+    description: String?
+
+    @aws.FieldHint
+    ruleGroup: RuleGroupData?
+
+    @aws.FieldHint {
+        updateMethod = "EntitySet"
+        indexField = "Key"
+    }
+    tags: Listing<aws.Tag>?
+
+    local parent = this
+
+    hidden res: RuleGroupResolvable = new {
+        label = parent.label
+        stack = parent.stack?.label
+    }
+}

--- a/scripts/ci/clean-environment.sh
+++ b/scripts/ci/clean-environment.sh
@@ -659,6 +659,83 @@ aws efs describe-access-points --region "$REGION" 2>/dev/null | \
     fi
 done
 
+# --- Network Firewall (before VPCs/subnets)
+# The networkfirewall conformance fixture creates a Firewall, FirewallPolicy
+# and stateful RuleGroup, all named with `nfw-*` prefixes. They have a strict
+# deletion order — a policy can't be deleted while a firewall references it,
+# and a rule group can't be deleted while a policy references it — and the
+# firewall plants ENIs in the dedicated firewall subnets, so its deletion must
+# complete before the VPC/subnet sweeps below. The fixture's VPC is untagged
+# and its subnets carry only `nfw-*` Name tags (not $FORMAE_PREFIX), so they're
+# reclaimed by the orphan-untagged-VPC sweep — but only once these firewalls
+# are gone and their ENIs released.
+echo "Cleaning Network Firewall test firewalls..."
+NFW_TEST_FIREWALLS=()
+while IFS= read -r fw_name; do
+    [[ -n "$fw_name" && "$fw_name" == nfw-firewall-* ]] && NFW_TEST_FIREWALLS+=("$fw_name")
+done < <(aws network-firewall list-firewalls --region "$REGION" --query "Firewalls[].FirewallName" --output text 2>/dev/null | tr '\t' '\n')
+
+for fw_name in "${NFW_TEST_FIREWALLS[@]}"; do
+    echo "  Deleting Network Firewall firewall: $fw_name"
+    # Clear the logging configuration first (there is no delete-logging API;
+    # an empty LoggingConfiguration removes all log destinations). Tolerant of
+    # failure — delete-firewall removes the logging config either way.
+    aws network-firewall update-logging-configuration --firewall-name "$fw_name" \
+        --logging-configuration "LogDestinationConfigs=[]" --region "$REGION" 2>/dev/null || true
+    aws network-firewall delete-firewall --firewall-name "$fw_name" --region "$REGION" 2>/dev/null || true
+done
+
+# Wait for firewalls to fully delete before removing the policies/rule groups
+# they reference (delete-firewall is async; the firewall lingers in DELETING
+# while its endpoints/ENIs tear down). Budget 300s — firewall deletion plus
+# endpoint removal is usually 2-4 min.
+if [ ${#NFW_TEST_FIREWALLS[@]} -gt 0 ]; then
+    echo "  Waiting for Network Firewall firewalls to delete (max 300s)..."
+    waited=0
+    while [ $waited -lt 300 ]; do
+        remaining=0
+        while IFS= read -r fw_name; do
+            [[ -n "$fw_name" && "$fw_name" == nfw-firewall-* ]] && remaining=$((remaining + 1))
+        done < <(aws network-firewall list-firewalls --region "$REGION" --query "Firewalls[].FirewallName" --output text 2>/dev/null | tr '\t' '\n')
+        [ "$remaining" = "0" ] && break
+        sleep 10
+        waited=$((waited + 10))
+    done
+    echo "  Network Firewall firewalls drained after ${waited}s (residual count: ${remaining:-?})"
+fi
+
+# Delete firewall policies (after firewalls, before rule groups)
+echo "Cleaning Network Firewall test firewall policies..."
+aws network-firewall list-firewall-policies --region "$REGION" \
+    --query "FirewallPolicies[].Name" --output text 2>/dev/null | tr '\t' '\n' | while read -r pol_name; do
+    if [[ -n "$pol_name" && "$pol_name" == nfw-policy-* ]]; then
+        echo "  Deleting Network Firewall firewall policy: $pol_name"
+        aws network-firewall delete-firewall-policy --firewall-policy-name "$pol_name" --region "$REGION" 2>/dev/null || true
+    fi
+done
+
+# Delete stateful rule groups (after policies that reference them)
+echo "Cleaning Network Firewall test rule groups..."
+aws network-firewall list-rule-groups --region "$REGION" --type STATEFUL \
+    --query "RuleGroups[].Name" --output text 2>/dev/null | tr '\t' '\n' | while read -r rg_name; do
+    if [[ -n "$rg_name" && "$rg_name" == nfw-allowlist-* ]]; then
+        echo "  Deleting Network Firewall rule group: $rg_name"
+        aws network-firewall delete-rule-group --rule-group-name "$rg_name" --type STATEFUL --region "$REGION" 2>/dev/null || true
+    fi
+done
+
+# Delete the firewall's CloudWatch log group (`/formae/test/nfw-*`). The generic
+# log-group sweep further below only matches $TEST_PREFIX (plugin-sdk-test), so
+# this prefix would otherwise be missed.
+echo "Cleaning Network Firewall test log groups..."
+aws logs describe-log-groups --region "$REGION" --log-group-name-prefix "/formae/test/nfw-" \
+    --query "logGroups[].logGroupName" --output text 2>/dev/null | tr '\t' '\n' | while read -r lg; do
+    if [[ -n "$lg" ]]; then
+        echo "  Deleting Network Firewall log group: $lg"
+        aws logs delete-log-group --log-group-name "$lg" --region "$REGION" 2>/dev/null || true
+    fi
+done
+
 # 23a. Delete EC2 flow logs with test prefix (before VPCs)
 echo "Cleaning EC2 test flow logs..."
 aws ec2 describe-flow-logs --region "$REGION" \

--- a/testdata/networkfirewall.pkl
+++ b/testdata/networkfirewall.pkl
@@ -1,0 +1,229 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/ec2/vpc.pkl"
+import "@aws/ec2/subnet.pkl"
+import "@aws/ec2/internetgateway.pkl"
+import "@aws/ec2/vpcgatewayattachment.pkl"
+import "@aws/ec2/routetable.pkl"
+import "@aws/ec2/route.pkl"
+import "@aws/logs/loggroup.pkl"
+import "@aws/networkfirewall/rulegroup.pkl"
+import "@aws/networkfirewall/firewallpolicy.pkl"
+import "@aws/networkfirewall/firewall.pkl"
+import "@aws/networkfirewall/loggingconfiguration.pkl"
+
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local stackName = "plugin-sdk-test-networkfirewall-\(testRunID)"
+local azA = "us-east-1a"
+local azB = "us-east-1b"
+
+// VPC for the egress inspection topology
+local testVpc = new vpc.VPC {
+  label = "nfw-vpc"
+  cidrBlock = "10.0.0.0/16"
+  enableDnsSupport = true
+  enableDnsHostnames = true
+}
+
+// InternetGateway - egress target for the firewall subnets
+local igw = new internetgateway.InternetGateway {
+  label = "nfw-igw"
+}
+
+// Attach IGW to VPC. Routes reference the attachment's internetGatewayId
+// (not the IGW directly) so they wait for attach and reverse on teardown.
+local igwAttachment = new vpcgatewayattachment.VPCGatewayAttachment {
+  label = "nfw-igw-attachment"
+  vpcId = testVpc.res.vpcId
+  internetGatewayId = igw.res.internetGatewayId
+}
+
+// Dedicated firewall subnets (one per AZ) - host the firewall endpoints
+local fwSubnetA = new subnet.Subnet {
+  label = "nfw-fw-subnet-a"
+  vpcId = testVpc.res.vpcId
+  cidrBlock = "10.0.0.0/28"
+  availabilityZone = azA
+  tags = new Listing<aws.Tag> {
+    new { key = "Name"; value = "nfw-fw-subnet-a" }
+  }
+}
+local fwSubnetB = new subnet.Subnet {
+  label = "nfw-fw-subnet-b"
+  vpcId = testVpc.res.vpcId
+  cidrBlock = "10.0.0.16/28"
+  availabilityZone = azB
+  tags = new Listing<aws.Tag> {
+    new { key = "Name"; value = "nfw-fw-subnet-b" }
+  }
+}
+
+// Protected ("app") subnets (one per AZ) - egress routed through the firewall
+local appSubnetA = new subnet.Subnet {
+  label = "nfw-app-subnet-a"
+  vpcId = testVpc.res.vpcId
+  cidrBlock = "10.0.1.0/24"
+  availabilityZone = azA
+  tags = new Listing<aws.Tag> {
+    new { key = "Name"; value = "nfw-app-subnet-a" }
+  }
+}
+local appSubnetB = new subnet.Subnet {
+  label = "nfw-app-subnet-b"
+  vpcId = testVpc.res.vpcId
+  cidrBlock = "10.0.2.0/24"
+  availabilityZone = azB
+  tags = new Listing<aws.Tag> {
+    new { key = "Name"; value = "nfw-app-subnet-b" }
+  }
+}
+
+// Stateful domain-allowlist rule group
+local allowlist = new rulegroup.RuleGroup {
+  label = "nfw-allowlist"
+  ruleGroupName = "nfw-allowlist-\(testRunID)"
+  type = "STATEFUL"
+  capacity = 100
+  ruleGroup = new rulegroup.RuleGroupData {
+    rulesSource = new rulegroup.RulesSource {
+      rulesSourceList = new rulegroup.RulesSourceList {
+        targets = new Listing<String> { "github.com"; "api.anthropic.com" }
+        targetTypes = new Listing<String> { "TLS_SNI"; "HTTP_HOST" }
+        generatedRulesType = "ALLOWLIST"
+      }
+    }
+    statefulRuleOptions = new rulegroup.StatefulRuleOptions {
+      ruleOrder = "STRICT_ORDER"
+    }
+  }
+}
+
+// Firewall policy referencing the allowlist rule group
+local policy = new firewallpolicy.FirewallPolicy {
+  label = "nfw-policy"
+  firewallPolicyName = "nfw-policy-\(testRunID)"
+  firewallPolicy = new firewallpolicy.FirewallPolicyData {
+    statelessDefaultActions = new Listing<String> { "aws:forward_to_sfe" }
+    statelessFragmentDefaultActions = new Listing<String> { "aws:forward_to_sfe" }
+    statefulDefaultActions = new Listing<String> { "aws:drop_established" }
+    statefulEngineOptions = new firewallpolicy.StatefulEngineOptions {
+      ruleOrder = "STRICT_ORDER"
+    }
+    statefulRuleGroupReferences = new Listing<firewallpolicy.StatefulRuleGroupReference> {
+      new {
+        resourceArn = allowlist.res.arn
+      }
+    }
+  }
+}
+
+// Firewall - one endpoint per firewall subnet/AZ
+local fw = new firewall.Firewall {
+  label = "nfw-firewall"
+  firewallName = "nfw-firewall-\(testRunID)"
+  firewallPolicyArn = policy.res.arn
+  vpcId = testVpc.res.vpcId
+  subnetMappings = new Listing<firewall.SubnetMapping> {
+    new { subnetId = fwSubnetA.res.subnetId }
+    new { subnetId = fwSubnetB.res.subnetId }
+  }
+}
+
+// CloudWatch log group for firewall alert logs
+local fwLogs = new loggroup.LogGroup {
+  label = "nfw-log-group"
+  logGroupName = "/formae/test/nfw-\(testRunID)"
+  retentionInDays = 1
+}
+
+// Logging configuration -> CloudWatch Logs (keyed by "logGroup" = log group name)
+local logging = new loggingconfiguration.LoggingConfiguration {
+  label = "nfw-logging"
+  firewallArn = fw.res.arn
+  loggingConfiguration = new loggingconfiguration.LoggingConfigurationData {
+    logDestinationConfigs = new Listing<loggingconfiguration.LogDestinationConfig> {
+      new {
+        logType = "ALERT"
+        logDestinationType = "CloudWatchLogs"
+        logDestination = new Mapping<String, String|formae.Resolvable> {
+          ["logGroup"] = fwLogs.res.logGroupName
+        }
+      }
+    }
+  }
+}
+
+// Route tables: one per firewall subnet, one per app subnet
+local fwRtA = new routetable.RouteTable { label = "nfw-fw-rt-a"; vpcId = testVpc.res.vpcId }
+local fwRtB = new routetable.RouteTable { label = "nfw-fw-rt-b"; vpcId = testVpc.res.vpcId }
+local appRtA = new routetable.RouteTable { label = "nfw-app-rt-a"; vpcId = testVpc.res.vpcId }
+local appRtB = new routetable.RouteTable { label = "nfw-app-rt-b"; vpcId = testVpc.res.vpcId }
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for AWS Network Firewall FQDN-allowlist egress"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  testVpc
+  igw
+  igwAttachment
+  fwSubnetA
+  fwSubnetB
+  appSubnetA
+  appSubnetB
+  allowlist
+  policy
+  fw
+  fwLogs
+  logging
+  fwRtA
+  fwRtB
+  appRtA
+  appRtB
+
+  // Firewall-subnet egress: default route to the internet via the IGW
+  // attachment (ensures attach-before-route and reverse-on-teardown ordering).
+  new route.Route {
+    label = "nfw-fw-route-a"
+    routeTableId = fwRtA.res.routeTableId
+    destinationCidrBlock = "0.0.0.0/0"
+    gatewayId = igwAttachment.res.internetGatewayId
+  }
+  new route.Route {
+    label = "nfw-fw-route-b"
+    routeTableId = fwRtB.res.routeTableId
+    destinationCidrBlock = "0.0.0.0/0"
+    gatewayId = igwAttachment.res.internetGatewayId
+  }
+
+  // Protected-subnet egress: default route to the firewall endpoint for that AZ.
+  new route.Route {
+    label = "nfw-app-route-a"
+    routeTableId = appRtA.res.routeTableId
+    destinationCidrBlock = "0.0.0.0/0"
+    vpcEndpointId = fw.res.endpointIds.at(azA)
+  }
+  new route.Route {
+    label = "nfw-app-route-b"
+    routeTableId = appRtB.res.routeTableId
+    destinationCidrBlock = "0.0.0.0/0"
+    vpcEndpointId = fw.res.endpointIds.at(azB)
+  }
+}

--- a/testdata/networkfirewall.pkl
+++ b/testdata/networkfirewall.pkl
@@ -121,6 +121,8 @@ local policy = new firewallpolicy.FirewallPolicy {
     statefulRuleGroupReferences = new Listing<firewallpolicy.StatefulRuleGroupReference> {
       new {
         resourceArn = allowlist.res.arn
+        // STRICT_ORDER requires an explicit evaluation priority per reference.
+        priority = 1
       }
     }
   }

--- a/testdata/networkfirewall.pkl
+++ b/testdata/networkfirewall.pkl
@@ -11,22 +11,15 @@ import "@aws/aws.pkl"
 
 import "@aws/ec2/vpc.pkl"
 import "@aws/ec2/subnet.pkl"
-import "@aws/ec2/internetgateway.pkl"
-import "@aws/ec2/vpcgatewayattachment.pkl"
-import "@aws/ec2/routetable.pkl"
-import "@aws/ec2/route.pkl"
-import "@aws/logs/loggroup.pkl"
 import "@aws/networkfirewall/rulegroup.pkl"
 import "@aws/networkfirewall/firewallpolicy.pkl"
 import "@aws/networkfirewall/firewall.pkl"
-import "@aws/networkfirewall/loggingconfiguration.pkl"
 
 local testRunID = read("env:FORMAE_TEST_RUN_ID")
 local stackName = "plugin-sdk-test-networkfirewall-\(testRunID)"
 local azA = "us-east-1a"
 local azB = "us-east-1b"
 
-// VPC for the egress inspection topology
 local testVpc = new vpc.VPC {
   label = "nfw-vpc"
   cidrBlock = "10.0.0.0/16"
@@ -34,60 +27,23 @@ local testVpc = new vpc.VPC {
   enableDnsHostnames = true
 }
 
-// InternetGateway - egress target for the firewall subnets
-local igw = new internetgateway.InternetGateway {
-  label = "nfw-igw"
-}
-
-// Attach IGW to VPC. Routes reference the attachment's internetGatewayId
-// (not the IGW directly) so they wait for attach and reverse on teardown.
-local igwAttachment = new vpcgatewayattachment.VPCGatewayAttachment {
-  label = "nfw-igw-attachment"
-  vpcId = testVpc.res.vpcId
-  internetGatewayId = igw.res.internetGatewayId
-}
-
-// Dedicated firewall subnets (one per AZ) - host the firewall endpoints
+// Dedicated firewall subnets, one per AZ.
 local fwSubnetA = new subnet.Subnet {
   label = "nfw-fw-subnet-a"
   vpcId = testVpc.res.vpcId
   cidrBlock = "10.0.0.0/28"
   availabilityZone = azA
-  tags = new Listing<aws.Tag> {
-    new { key = "Name"; value = "nfw-fw-subnet-a" }
-  }
+  tags = new Listing<aws.Tag> { new { key = "Name"; value = "nfw-fw-subnet-a" } }
 }
 local fwSubnetB = new subnet.Subnet {
   label = "nfw-fw-subnet-b"
   vpcId = testVpc.res.vpcId
   cidrBlock = "10.0.0.16/28"
   availabilityZone = azB
-  tags = new Listing<aws.Tag> {
-    new { key = "Name"; value = "nfw-fw-subnet-b" }
-  }
+  tags = new Listing<aws.Tag> { new { key = "Name"; value = "nfw-fw-subnet-b" } }
 }
 
-// Protected ("app") subnets (one per AZ) - egress routed through the firewall
-local appSubnetA = new subnet.Subnet {
-  label = "nfw-app-subnet-a"
-  vpcId = testVpc.res.vpcId
-  cidrBlock = "10.0.1.0/24"
-  availabilityZone = azA
-  tags = new Listing<aws.Tag> {
-    new { key = "Name"; value = "nfw-app-subnet-a" }
-  }
-}
-local appSubnetB = new subnet.Subnet {
-  label = "nfw-app-subnet-b"
-  vpcId = testVpc.res.vpcId
-  cidrBlock = "10.0.2.0/24"
-  availabilityZone = azB
-  tags = new Listing<aws.Tag> {
-    new { key = "Name"; value = "nfw-app-subnet-b" }
-  }
-}
-
-// Stateful domain-allowlist rule group
+// Stateful domain-allowlist rule group (the FQDN allowlist).
 local allowlist = new rulegroup.RuleGroup {
   label = "nfw-allowlist"
   ruleGroupName = "nfw-allowlist-\(testRunID)"
@@ -107,7 +63,7 @@ local allowlist = new rulegroup.RuleGroup {
   }
 }
 
-// Firewall policy referencing the allowlist rule group
+// Firewall policy referencing the allowlist rule group.
 local policy = new firewallpolicy.FirewallPolicy {
   label = "nfw-policy"
   firewallPolicyName = "nfw-policy-\(testRunID)"
@@ -128,7 +84,10 @@ local policy = new firewallpolicy.FirewallPolicy {
   }
 }
 
-// Firewall - one endpoint per firewall subnet/AZ
+// Firewall spanning both AZs. Listed last in the forma block: the conformance
+// harness verifies the final resource in the fixture and OOB-deletes it in
+// isolation, so it must be a leaf (nothing references its endpoints). The
+// per-AZ endpoint outputs and route wiring are exercised separately.
 local fw = new firewall.Firewall {
   label = "nfw-firewall"
   firewallName = "nfw-firewall-\(testRunID)"
@@ -140,40 +99,10 @@ local fw = new firewall.Firewall {
   }
 }
 
-// CloudWatch log group for firewall alert logs
-local fwLogs = new loggroup.LogGroup {
-  label = "nfw-log-group"
-  logGroupName = "/formae/test/nfw-\(testRunID)"
-  retentionInDays = 1
-}
-
-// Logging configuration -> CloudWatch Logs (keyed by "logGroup" = log group name)
-local logging = new loggingconfiguration.LoggingConfiguration {
-  label = "nfw-logging"
-  firewallArn = fw.res.arn
-  loggingConfiguration = new loggingconfiguration.LoggingConfigurationData {
-    logDestinationConfigs = new Listing<loggingconfiguration.LogDestinationConfig> {
-      new {
-        logType = "ALERT"
-        logDestinationType = "CloudWatchLogs"
-        logDestination = new Mapping<String, String|formae.Resolvable> {
-          ["logGroup"] = fwLogs.res.logGroupName
-        }
-      }
-    }
-  }
-}
-
-// Route tables: one per firewall subnet, one per app subnet
-local fwRtA = new routetable.RouteTable { label = "nfw-fw-rt-a"; vpcId = testVpc.res.vpcId }
-local fwRtB = new routetable.RouteTable { label = "nfw-fw-rt-b"; vpcId = testVpc.res.vpcId }
-local appRtA = new routetable.RouteTable { label = "nfw-app-rt-a"; vpcId = testVpc.res.vpcId }
-local appRtB = new routetable.RouteTable { label = "nfw-app-rt-b"; vpcId = testVpc.res.vpcId }
-
 forma {
   new formae.Stack {
     label = stackName
-    description = "Plugin SDK test for AWS Network Firewall FQDN-allowlist egress"
+    description = "Plugin SDK test for AWS Network Firewall"
   }
 
   new formae.Target {
@@ -184,51 +113,9 @@ forma {
   }
 
   testVpc
-  igw
-  igwAttachment
   fwSubnetA
   fwSubnetB
-  appSubnetA
-  appSubnetB
   allowlist
   policy
-  fwLogs
-  logging
-  fwRtA
-  fwRtB
-  appRtA
-  appRtB
-
-  // Firewall-subnet egress: default route to the internet via the IGW
-  // attachment (ensures attach-before-route and reverse-on-teardown ordering).
-  new route.Route {
-    label = "nfw-fw-route-a"
-    routeTableId = fwRtA.res.routeTableId
-    destinationCidrBlock = "0.0.0.0/0"
-    gatewayId = igwAttachment.res.internetGatewayId
-  }
-  new route.Route {
-    label = "nfw-fw-route-b"
-    routeTableId = fwRtB.res.routeTableId
-    destinationCidrBlock = "0.0.0.0/0"
-    gatewayId = igwAttachment.res.internetGatewayId
-  }
-
-  // Protected-subnet egress: default route to the firewall endpoint for that AZ.
-  new route.Route {
-    label = "nfw-app-route-a"
-    routeTableId = appRtA.res.routeTableId
-    destinationCidrBlock = "0.0.0.0/0"
-    vpcEndpointId = fw.res.endpointIds.at(azA)
-  }
-  new route.Route {
-    label = "nfw-app-route-b"
-    routeTableId = appRtB.res.routeTableId
-    destinationCidrBlock = "0.0.0.0/0"
-    vpcEndpointId = fw.res.endpointIds.at(azB)
-  }
-
-  // Firewall is the resource under test for the conformance harness, so it is
-  // listed last (the harness verifies the final resource in the fixture).
   fw
 }

--- a/testdata/networkfirewall.pkl
+++ b/testdata/networkfirewall.pkl
@@ -192,7 +192,6 @@ forma {
   appSubnetB
   allowlist
   policy
-  fw
   fwLogs
   logging
   fwRtA
@@ -228,4 +227,8 @@ forma {
     destinationCidrBlock = "0.0.0.0/0"
     vpcEndpointId = fw.res.endpointIds.at(azB)
   }
+
+  // Firewall is the resource under test for the conformance harness, so it is
+  // listed last (the harness verifies the final resource in the fixture).
+  fw
 }


### PR DESCRIPTION
## Summary

Adds AWS Network Firewall resource support to the plugin: the `RuleGroup`, `FirewallPolicy`, `Firewall`, and `LoggingConfiguration` resource family, enabling declarative management of network-layer FQDN-allowlisting egress control for private subnets.

## What

- **Schemas** (`schema/pkl/networkfirewall/`) for the four resource types, modeled minimal-but-complete for FQDN-allowlist egress: a stateful domain-list `RuleGroup`, a `FirewallPolicy` referencing it, a `Firewall` with per-AZ subnet mappings, and a standalone `LoggingConfiguration`. Cross-resource references (policy ARN, rule-group ARNs, firewall ARN, VPC/subnet ids, log group) are expressed as Resolvables.
- **Per-AZ endpoint output (the linchpin).** A custom `Firewall.Read` flattens the read-only `EndpointIds` list (`"<az>:<endpoint-id>"`) into a computed `EndpointIdsByAz` map, exposed as a `MappingResolvable`. Route tables in protected subnets can then send `0.0.0.0/0` through the firewall endpoint for their AZ via `firewall.res.endpointIds.at("<az>")`.
- **Readiness gate.** A custom `Firewall.Status` withholds create/update success until those per-AZ endpoints are populated. The resolver treats a missing property after a successful read as a terminal resolve failure, so reporting success early would make dependent routes fail terminally during the endpoint eventual-consistency window. Delete (and other) operations pass through unchanged.
- CRUD for all four types otherwise uses the generic CloudControl path; no EC2 route changes were needed (routes already accept a `vpcEndpointId` target).

## Testing

- Unit tests for the `EndpointIds` to `EndpointIdsByAz` transform (multi-AZ, single, empty, malformed, native-list preserved, error passthrough) and the Status readiness gate (in-progress/failure/delete passthrough, success-but-empty stays in-progress, success-with-endpoints).
- An end-to-end conformance fixture (`testdata/networkfirewall.pkl`) provisioning a full egress stack: VPC, firewall and protected subnets across two AZs, rule group, policy, firewall, logging configuration, and route tables wired through the firewall endpoints per AZ.
- Idempotent Network Firewall teardown added to the environment cleanup script (delete logging and firewall, wait for drain, then policy and rule group; gated to the test resource prefixes).