### PR TITLE
fix(route53): normalize alias target DNSName trailing dot

### DIFF
--- a/pkg/cfres/route53/record_set.go
+++ b/pkg/cfres/route53/record_set.go
@@ -157,25 +157,9 @@ func (r RecordSet) Create(ctx context.Context, request *resource.CreateRequest) 
 
 	var aliasTarget *types.AliasTarget
 	if aliasTargetRaw, hasAlias := properties["AliasTarget"].(map[string]any); hasAlias {
-		dnsName, err := utils.GetStringProperty(aliasTargetRaw, "DNSName")
+		aliasTarget, err = buildAliasTarget(aliasTargetRaw)
 		if err != nil {
-			return nil, fmt.Errorf("invalid AliasTarget DNSName: %w", err)
-		}
-
-		hostedZoneID, err := utils.GetStringProperty(aliasTargetRaw, "HostedZoneId")
-		if err != nil {
-			return nil, fmt.Errorf("invalid AliasTarget HostedZoneId: %w", err)
-		}
-
-		evaluateTargetHealth := false
-		if evalHealth, ok := aliasTargetRaw["EvaluateTargetHealth"].(bool); ok {
-			evaluateTargetHealth = evalHealth
-		}
-
-		aliasTarget = &types.AliasTarget{
-			DNSName:              aws.String(dnsName),
-			HostedZoneId:         aws.String(hostedZoneID),
-			EvaluateTargetHealth: evaluateTargetHealth,
+			return nil, err
 		}
 	}
 
@@ -294,36 +278,18 @@ func (r RecordSet) Update(ctx context.Context, request *resource.UpdateRequest) 
 	// Handle prior AliasTarget
 	var priorAliasTarget *types.AliasTarget
 	if priorAliasTargetRaw, hasAlias := priorProperties["AliasTarget"].(map[string]any); hasAlias {
-		dnsName, err := utils.GetStringProperty(priorAliasTargetRaw, "DNSName")
+		priorAliasTarget, err = buildAliasTarget(priorAliasTargetRaw)
 		if err != nil {
-			return nil, fmt.Errorf("invalid prior AliasTarget DNSName: %w", err)
-		}
-		hostedZoneID, err := utils.GetStringProperty(priorAliasTargetRaw, "HostedZoneId")
-		if err != nil {
-			return nil, fmt.Errorf("invalid prior AliasTarget HostedZoneId: %w", err)
-		}
-		priorAliasTarget = &types.AliasTarget{
-			DNSName:              aws.String(dnsName),
-			HostedZoneId:         aws.String(hostedZoneID),
-			EvaluateTargetHealth: false,
+			return nil, fmt.Errorf("prior %w", err)
 		}
 	}
 
 	// Handle desired AliasTarget
 	var desiredAliasTarget *types.AliasTarget
 	if desiredAliasTargetRaw, hasAlias := desiredProperties["AliasTarget"].(map[string]any); hasAlias {
-		dnsName, err := utils.GetStringProperty(desiredAliasTargetRaw, "DNSName")
+		desiredAliasTarget, err = buildAliasTarget(desiredAliasTargetRaw)
 		if err != nil {
-			return nil, fmt.Errorf("invalid desired AliasTarget DNSName: %w", err)
-		}
-		hostedZoneID, err := utils.GetStringProperty(desiredAliasTargetRaw, "HostedZoneId")
-		if err != nil {
-			return nil, fmt.Errorf("invalid desired AliasTarget HostedZoneId: %w", err)
-		}
-		desiredAliasTarget = &types.AliasTarget{
-			DNSName:              aws.String(dnsName),
-			HostedZoneId:         aws.String(hostedZoneID),
-			EvaluateTargetHealth: false,
+			return nil, fmt.Errorf("desired %w", err)
 		}
 	}
 
@@ -461,14 +427,13 @@ func (r RecordSet) Delete(ctx context.Context, request *resource.DeleteRequest) 
 
 	// Handle AliasTarget if present
 	if meta.AliasTarget != nil {
-		dnsName := meta.AliasTarget.DNSName
-		if !strings.HasSuffix(dnsName, ".") {
-			dnsName = dnsName + "."
-		}
-		rrs.AliasTarget = &types.AliasTarget{
-			DNSName:              aws.String(dnsName),
-			HostedZoneId:         aws.String(meta.AliasTarget.HostedZoneID),
-			EvaluateTargetHealth: meta.AliasTarget.EvaluateTargetHealth,
+		rrs.AliasTarget, err = buildAliasTarget(map[string]any{
+			"DNSName":              meta.AliasTarget.DNSName,
+			"HostedZoneId":         meta.AliasTarget.HostedZoneID,
+			"EvaluateTargetHealth": meta.AliasTarget.EvaluateTargetHealth,
+		})
+		if err != nil {
+			return nil, err
 		}
 	} else {
 		rrs.TTL = aws.Int64(meta.TTL)
@@ -606,28 +571,7 @@ func (r RecordSet) Read(ctx context.Context, request *resource.ReadRequest) (*re
 	}
 
 	// Build properties map
-	props := map[string]any{
-		"HostedZoneId": hostedZoneID,
-		"Name":         strings.TrimSuffix(name, "."), // remove trailing dot
-		"Type":         recordType,
-	}
-
-	if found.AliasTarget != nil {
-		props["AliasTarget"] = map[string]any{
-			"DNSName":              aws.ToString(found.AliasTarget.DNSName),
-			"HostedZoneId":         aws.ToString(found.AliasTarget.HostedZoneId),
-			"EvaluateTargetHealth": found.AliasTarget.EvaluateTargetHealth,
-		}
-	} else {
-		records := make([]string, 0, len(found.ResourceRecords))
-		for _, rr := range found.ResourceRecords {
-			records = append(records, aws.ToString(rr.Value))
-		}
-		props["ResourceRecords"] = records
-		if found.TTL != nil {
-			props["TTL"] = *found.TTL
-		}
-	}
+	props := buildReadProperties(found, hostedZoneID, name, recordType)
 
 	// Marshal back to JSON
 	propBytes, err := json.Marshal(props)
@@ -670,6 +614,66 @@ func (r *RecordSet) List(ctx context.Context, request *resource.ListRequest) (*r
 		NativeIDs:     nativeIDs,
 		NextPageToken: res.NextRecordName,
 	}, nil
+}
+
+// buildAliasTarget constructs an AWS AliasTarget from declared properties.
+// Outbound normalization mirrors Read's inbound stripping: Route53 stores DNS
+// names with a trailing dot, so it is restored here for change requests — a
+// delete-by-value (used by Update and Delete) is rejected unless the alias
+// DNSName matches Route53's canonical (dotted) form.
+func buildAliasTarget(raw map[string]any) (*types.AliasTarget, error) {
+	dnsName, err := utils.GetStringProperty(raw, "DNSName")
+	if err != nil {
+		return nil, fmt.Errorf("invalid AliasTarget DNSName: %w", err)
+	}
+	hostedZoneID, err := utils.GetStringProperty(raw, "HostedZoneId")
+	if err != nil {
+		return nil, fmt.Errorf("invalid AliasTarget HostedZoneId: %w", err)
+	}
+	if !strings.HasSuffix(dnsName, ".") {
+		dnsName += "."
+	}
+	evaluateTargetHealth := false
+	if v, ok := raw["EvaluateTargetHealth"].(bool); ok {
+		evaluateTargetHealth = v
+	}
+	return &types.AliasTarget{
+		DNSName:              aws.String(dnsName),
+		HostedZoneId:         aws.String(hostedZoneID),
+		EvaluateTargetHealth: evaluateTargetHealth,
+	}, nil
+}
+
+// buildReadProperties maps an AWS ResourceRecordSet into the formae property
+// map returned by Read.
+func buildReadProperties(found *types.ResourceRecordSet, hostedZoneID, name, recordType string) map[string]any {
+	props := map[string]any{
+		"HostedZoneId": hostedZoneID,
+		"Name":         strings.TrimSuffix(name, "."), // remove trailing dot
+		"Type":         recordType,
+	}
+
+	if found.AliasTarget != nil {
+		props["AliasTarget"] = map[string]any{
+			// AWS canonicalizes the alias target DNSName with a trailing dot;
+			// strip it so it matches the stored (no-dot) desired state and an
+			// unchanged ALIAS reconciles as a no-op.
+			"DNSName":              strings.TrimSuffix(aws.ToString(found.AliasTarget.DNSName), "."),
+			"HostedZoneId":         aws.ToString(found.AliasTarget.HostedZoneId),
+			"EvaluateTargetHealth": found.AliasTarget.EvaluateTargetHealth,
+		}
+	} else {
+		records := make([]string, 0, len(found.ResourceRecords))
+		for _, rr := range found.ResourceRecords {
+			records = append(records, aws.ToString(rr.Value))
+		}
+		props["ResourceRecords"] = records
+		if found.TTL != nil {
+			props["TTL"] = *found.TTL
+		}
+	}
+
+	return props
 }
 
 func nativeID(hostedZoneID, name, recordType string) string {

--- a/pkg/cfres/route53/record_set_unit_test.go
+++ b/pkg/cfres/route53/record_set_unit_test.go
@@ -1,0 +1,70 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package route53
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/route53/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// AWS Route53 canonicalizes DNS names with a trailing dot. Formae stores them
+// without one (Name is already stripped on read), so the alias target DNSName
+// must be stripped the same way — otherwise an unchanged ALIAS record shows
+// phantom drift on every reconcile and a fresh create loops on read-back.
+func TestBuildReadProperties_StripsAliasTargetTrailingDot(t *testing.T) {
+	found := &types.ResourceRecordSet{
+		Name: aws.String("formae-agent.platform.engineering."),
+		Type: types.RRTypeA,
+		AliasTarget: &types.AliasTarget{
+			DNSName:              aws.String("formae-agent-bridge-1460787171.us-west-2.elb.amazonaws.com."),
+			HostedZoneId:         aws.String("Z1H1FL5HABSF5"),
+			EvaluateTargetHealth: true,
+		},
+	}
+
+	props := buildReadProperties(found, "Z9999999", "formae-agent.platform.engineering.", "A")
+
+	alias, ok := props["AliasTarget"].(map[string]any)
+	require.True(t, ok, "AliasTarget should be present in read properties")
+	assert.Equal(t, "formae-agent-bridge-1460787171.us-west-2.elb.amazonaws.com", alias["DNSName"],
+		"alias DNSName should have its trailing dot stripped to match stored state")
+}
+
+// When building an AWS AliasTarget from stored (no-dot) state to send back to
+// Route53, the trailing dot must be restored. The Update path deletes the prior
+// record by value, and Route53 rejects the delete unless the alias DNSName
+// matches its canonical (dotted) form — the "values provided do not match the
+// current values" failure.
+func TestBuildAliasTarget_AddsTrailingDot(t *testing.T) {
+	raw := map[string]any{
+		"DNSName":              "formae-agent-bridge-1460787171.us-west-2.elb.amazonaws.com",
+		"HostedZoneId":         "Z1H1FL5HABSF5",
+		"EvaluateTargetHealth": true,
+	}
+
+	target, err := buildAliasTarget(raw)
+	require.NoError(t, err)
+	require.NotNil(t, target)
+	assert.Equal(t, "formae-agent-bridge-1460787171.us-west-2.elb.amazonaws.com.", aws.ToString(target.DNSName),
+		"outbound alias DNSName should carry the canonical trailing dot")
+}
+
+// EvaluateTargetHealth must be carried through from the declared properties, not
+// hardcoded — otherwise an update silently flips a `true` setting to `false`.
+func TestBuildAliasTarget_HonorsEvaluateTargetHealth(t *testing.T) {
+	target, err := buildAliasTarget(map[string]any{
+		"DNSName":              "example.elb.amazonaws.com.",
+		"HostedZoneId":         "Z1H1FL5HABSF5",
+		"EvaluateTargetHealth": true,
+	})
+	require.NoError(t, err)
+	assert.True(t, target.EvaluateTargetHealth, "EvaluateTargetHealth should reflect the declared value")
+}

--- a/testdata/route53-recordset-alias-update.pkl
+++ b/testdata/route53-recordset-alias-update.pkl
@@ -1,0 +1,118 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/ec2/vpc.pkl"
+import "@aws/ec2/subnet.pkl"
+import "@aws/ec2/securitygroup.pkl"
+import "@aws/elasticloadbalancingv2/loadbalancer.pkl"
+import "@aws/route53/hostedzone.pkl"
+import "@aws/route53/recordset.pkl"
+
+// Read the test run ID from environment variable set by the test harness
+// This ensures consistent naming within a test run but unique names between runs
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local stackName = "plugin-sdk-test-route53-recordset-alias-\(testRunID)"
+local domainName = "sdk-alias-\(testRunID).test-formae.io"
+
+// Minimal VPC + two multi-AZ subnets + security group so we can stand up an
+// internal ALB to alias at. An internal ALB needs two subnets in different AZs
+// and a security group, but no internet routing or listener to get a DNSName.
+local testVpc = new vpc.VPC {
+  label = "test-vpc-for-r53-alias"
+  cidrBlock = "10.232.0.0/16"
+  enableDnsSupport = true
+}
+
+local testSubnetA = new subnet.Subnet {
+  label = "test-subnet-a-for-r53-alias"
+  vpcId = testVpc.res.vpcId
+  cidrBlock = "10.232.1.0/24"
+  availabilityZone = "us-east-1a"
+}
+
+local testSubnetB = new subnet.Subnet {
+  label = "test-subnet-b-for-r53-alias"
+  vpcId = testVpc.res.vpcId
+  cidrBlock = "10.232.2.0/24"
+  availabilityZone = "us-east-1b"
+}
+
+local albSG = new securitygroup.SecurityGroup {
+  label = "test-alb-sg-for-r53-alias"
+  groupDescription = "SG for internal ALB used as Route53 ALIAS target"
+  groupName = "formae-sdk-test-r53-alias-sg-\(testRunID)"
+  vpcId = testVpc.res.vpcId
+}
+
+// Internal ALB across the two subnets. AWS stores its DNSName with a trailing
+// dot in the alias target; this fixture exercises that round-trip.
+local testALB = new loadbalancer.LoadBalancer {
+  label = "test-alb-for-r53-alias"
+  name = "formae-sdk-r53alias-\(testRunID)"
+  scheme = "internal"
+  type = "application"
+  subnets {
+    testSubnetA.res.subnetId
+    testSubnetB.res.subnetId
+  }
+  securityGroups {
+    albSG.res.groupId
+  }
+}
+
+// HostedZone the ALIAS record lives in.
+local hz = new hostedzone.HostedZone {
+  label = "test-hosted-zone-for-r53-alias"
+  name = domainName
+  hostedZoneConfig = new hostedzone.HostedZoneConfig {
+    comment = "SDK test hosted zone for Route53 ALIAS RecordSet tests"
+  }
+}
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for Route53 A-ALIAS RecordSet to an ALB (update: flip evaluateTargetHealth)"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  // ALB target infrastructure
+  testVpc
+  testSubnetA
+  testSubnetB
+  albSG
+  testALB
+
+  // HostedZone required for RecordSet
+  hz
+
+  // A-ALIAS RecordSet under test (declared last so the conformance harness
+  // treats it as the resource under test). Aliases at the ALB's DNSName, which
+  // AWS canonicalizes with a trailing dot — the round-trip that must reconcile
+  // as a no-op rather than producing phantom drift.
+  new recordset.RecordSet {
+    label = "plugin-sdk-test-recordset-alias"
+    hostedZoneId = hz.res.id
+    name = "app.\(domainName)"
+    type = "A"
+    aliasTarget = new recordset.AliasTarget {
+      dnsName = testALB.res.dnsName
+      hostedZoneId = testALB.res.canonicalHostedZoneID
+      evaluateTargetHealth = false
+    }
+  }
+}

--- a/testdata/route53-recordset-alias.pkl
+++ b/testdata/route53-recordset-alias.pkl
@@ -1,0 +1,118 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/ec2/vpc.pkl"
+import "@aws/ec2/subnet.pkl"
+import "@aws/ec2/securitygroup.pkl"
+import "@aws/elasticloadbalancingv2/loadbalancer.pkl"
+import "@aws/route53/hostedzone.pkl"
+import "@aws/route53/recordset.pkl"
+
+// Read the test run ID from environment variable set by the test harness
+// This ensures consistent naming within a test run but unique names between runs
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local stackName = "plugin-sdk-test-route53-recordset-alias-\(testRunID)"
+local domainName = "sdk-alias-\(testRunID).test-formae.io"
+
+// Minimal VPC + two multi-AZ subnets + security group so we can stand up an
+// internal ALB to alias at. An internal ALB needs two subnets in different AZs
+// and a security group, but no internet routing or listener to get a DNSName.
+local testVpc = new vpc.VPC {
+  label = "test-vpc-for-r53-alias"
+  cidrBlock = "10.232.0.0/16"
+  enableDnsSupport = true
+}
+
+local testSubnetA = new subnet.Subnet {
+  label = "test-subnet-a-for-r53-alias"
+  vpcId = testVpc.res.vpcId
+  cidrBlock = "10.232.1.0/24"
+  availabilityZone = "us-east-1a"
+}
+
+local testSubnetB = new subnet.Subnet {
+  label = "test-subnet-b-for-r53-alias"
+  vpcId = testVpc.res.vpcId
+  cidrBlock = "10.232.2.0/24"
+  availabilityZone = "us-east-1b"
+}
+
+local albSG = new securitygroup.SecurityGroup {
+  label = "test-alb-sg-for-r53-alias"
+  groupDescription = "SG for internal ALB used as Route53 ALIAS target"
+  groupName = "formae-sdk-test-r53-alias-sg-\(testRunID)"
+  vpcId = testVpc.res.vpcId
+}
+
+// Internal ALB across the two subnets. AWS stores its DNSName with a trailing
+// dot in the alias target; this fixture exercises that round-trip.
+local testALB = new loadbalancer.LoadBalancer {
+  label = "test-alb-for-r53-alias"
+  name = "formae-sdk-r53alias-\(testRunID)"
+  scheme = "internal"
+  type = "application"
+  subnets {
+    testSubnetA.res.subnetId
+    testSubnetB.res.subnetId
+  }
+  securityGroups {
+    albSG.res.groupId
+  }
+}
+
+// HostedZone the ALIAS record lives in.
+local hz = new hostedzone.HostedZone {
+  label = "test-hosted-zone-for-r53-alias"
+  name = domainName
+  hostedZoneConfig = new hostedzone.HostedZoneConfig {
+    comment = "SDK test hosted zone for Route53 ALIAS RecordSet tests"
+  }
+}
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for Route53 A-ALIAS RecordSet to an ALB"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  // ALB target infrastructure
+  testVpc
+  testSubnetA
+  testSubnetB
+  albSG
+  testALB
+
+  // HostedZone required for RecordSet
+  hz
+
+  // A-ALIAS RecordSet under test (declared last so the conformance harness
+  // treats it as the resource under test). Aliases at the ALB's DNSName, which
+  // AWS canonicalizes with a trailing dot — the round-trip that must reconcile
+  // as a no-op rather than producing phantom drift.
+  new recordset.RecordSet {
+    label = "plugin-sdk-test-recordset-alias"
+    hostedZoneId = hz.res.id
+    name = "app.\(domainName)"
+    type = "A"
+    aliasTarget = new recordset.AliasTarget {
+      dnsName = testALB.res.dnsName
+      hostedZoneId = testALB.res.canonicalHostedZoneID
+      evaluateTargetHealth = true
+    }
+  }
+}


### PR DESCRIPTION
## Summary

The AWS plugin could not manage a Route53 A-`ALIAS` record. AWS canonicalizes DNS names with a trailing dot, but the `RecordSet` provisioner only stripped that dot from `Name` on read — not from `AliasTarget.DNSName`. So the stored (no-dot) state never matched the live (dotted) value:

- an unchanged ALIAS record produced phantom drift on every reconcile (a failing delete+create), and
- a fresh create looped on post-create read-back until max attempts, because the read-back never matched the desired value.

## Changes

- **Read:** strip the trailing dot from `AliasTarget.DNSName`, mirroring the existing `Name` normalization, so an unchanged ALIAS reconciles as a no-op and a create verifies.
- **Write:** restore the trailing dot (and honor `EvaluateTargetHealth`) via a shared `buildAliasTarget` helper now used by `Create`, `Update`, and `Delete`. This fixes two latent `Update` bugs: the delete-leg sent the dot-less DNSName (rejected by Route53 as *"values provided do not match the current values"*), and `EvaluateTargetHealth` was hardcoded to `false`.
- **Tests:** unit tests for the read/write normalization, plus conformance fixtures that create an A-ALIAS record pointing at an internal ALB and exercise create → reconcile-no-op → update — the gap that let this through (no prior fixture used an `AliasTarget`).

Closes PLA-23.