### PR TITLE
fix(secretsmanager): resolve secret.res.arn to the Id property

### DIFF
--- a/schema/pkl/secretsmanager/secret.pkl
+++ b/schema/pkl/secretsmanager/secret.pkl
@@ -36,8 +36,12 @@ open class ReplicaRegion extends formae.SubResource {
 open class SecretResolvable extends formae.Resolvable {
     type = module.type
 
+    // CloudControl exposes the secret's ARN as the primary identifier `Id`
+    // (and `Ref`); there is no separate `Arn` property on this resource type.
+    // Map `arn` onto `Id` so `secret.res.arn` resolves instead of failing
+    // terminally against a property that is never present.
     hidden arn: SecretResolvable = (this) {
-        property = "Arn"
+        property = "Id"
     }
 
     hidden id: SecretResolvable = (this) {

--- a/testdata/iam-rolepolicy-secret-arn.pkl
+++ b/testdata/iam-rolepolicy-secret-arn.pkl
@@ -1,0 +1,79 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/iam/role.pkl"
+import "@aws/iam/rolepolicy.pkl"
+import "@aws/secretsmanager/secret.pkl"
+
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local stackName = "plugin-sdk-test-iam-rolepolicy-secret-arn-\(testRunID)"
+
+// Secret whose ARN the policy grants access to. Its ARN is referenced via
+// `secret.res.arn`, which must resolve to the secret's identifier (the ARN);
+// a regression there makes the RolePolicy fail terminally in the resolve phase.
+local theSecret = new secret.Secret {
+  label = "test-secret-for-rolepolicy-arn"
+  name = "formae-plugin-sdk-test-rp-secret-\(testRunID)"
+  description = "Secret whose ARN is referenced by a RolePolicy via secret.res.arn"
+}
+
+// Role the policy attaches to.
+local parentRole = new role.Role {
+  label = "test-role-for-rolepolicy-arn"
+  roleName = "formae-plugin-sdk-test-rp-arn-role-\(testRunID)"
+  assumeRolePolicyDocument {
+    ["Version"] = "2012-10-17"
+    ["Statement"] {
+      new {
+        ["Effect"] = "Allow"
+        ["Principal"] {
+          ["Service"] = "lambda.amazonaws.com"
+        }
+        ["Action"] = "sts:AssumeRole"
+      }
+    }
+  }
+}
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for resolving a Secret ARN (secret.res.arn) in a RolePolicy document"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  theSecret
+  parentRole
+
+  // RolePolicy under test: its policy document grants secretsmanager:GetSecretValue
+  // on the secret's ARN, referenced through `theSecret.res.arn`.
+  new rolepolicy.RolePolicy {
+    label = "plugin-sdk-test-rolepolicy-secret-arn"
+    roleName = parentRole.res.roleName
+    policyName = "formae-plugin-sdk-test-rp-secret-arn-\(testRunID)"
+    policyDocument {
+      ["Version"] = "2012-10-17"
+      ["Statement"] {
+        new {
+          ["Effect"] = "Allow"
+          ["Action"] = "secretsmanager:GetSecretValue"
+          ["Resource"] = theSecret.res.arn
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

`AWS::SecretsManager::Secret` exposed a `.res.arn` resolvable mapped to a property `Arn`, but CloudControl models the secret’s ARN as the primary identifier `Id` (and `Ref`) — the resource type has no `Arn` property. Any reference to `secret.res.arn` therefore resolved against a key that is never present and failed terminally in the resolve phase, before any AWS call (the dependent resource was marked `Failed` with no error and a sub-second duration).

## Changes

- **Schema:** map the `arn` resolvable onto `Id` so `secret.res.arn` resolves to the ARN, like `id`/`ref` already do. Chosen over injecting a synthetic `Arn` key in `Secret.Read`, which would fabricate a property AWS does not have (extract/drift risk) and would need to cover every read path.
- **Conformance fixture** (`iam-rolepolicy-secret-arn`): a Secret + Role + a leaf RolePolicy whose policy document grants `secretsmanager:GetSecretValue` on the secret’s ARN via `secret.res.arn`, exercising the resolution end-to-end. With the bug the RolePolicy fails to resolve; with the fix the rendered policy `Resource` ref carries `$property = "Id"`.

Workaround on affected versions: reference `secret.res.id` (or `secret.res.ref`). Not a regression — present identically since at least the prior stable line.