### PR TITLE
fix(route53): normalize trailing dot on hostname-valued ResourceRecords

### DIFF
--- a/pkg/cfres/route53/record_set.go
+++ b/pkg/cfres/route53/record_set.go
@@ -644,6 +644,24 @@ func buildAliasTarget(raw map[string]any) (*types.AliasTarget, error) {
 	}, nil
 }
 
+// hostnameValuedRecordTypes are record types whose RDATA is a domain name that
+// AWS canonicalizes with a trailing dot. Their ResourceRecords values must have
+// the trailing dot stripped on read to match dot-less desired state. TXT/SPF
+// (quoted character strings — a trailing dot is data) and A/AAAA (IP addresses)
+// are deliberately excluded.
+var hostnameValuedRecordTypes = map[string]bool{
+	"CNAME": true,
+	"DNAME": true,
+	"NS":    true,
+	"PTR":   true,
+	"MX":    true,
+	"SRV":   true,
+}
+
+func isHostnameValuedRecordType(recordType string) bool {
+	return hostnameValuedRecordTypes[recordType]
+}
+
 // buildReadProperties maps an AWS ResourceRecordSet into the formae property
 // map returned by Read.
 func buildReadProperties(found *types.ResourceRecordSet, hostedZoneID, name, recordType string) map[string]any {
@@ -663,9 +681,17 @@ func buildReadProperties(found *types.ResourceRecordSet, hostedZoneID, name, rec
 			"EvaluateTargetHealth": found.AliasTarget.EvaluateTargetHealth,
 		}
 	} else {
+		stripDot := isHostnameValuedRecordType(recordType)
 		records := make([]string, 0, len(found.ResourceRecords))
 		for _, rr := range found.ResourceRecords {
-			records = append(records, aws.ToString(rr.Value))
+			value := aws.ToString(rr.Value)
+			if stripDot {
+				// AWS canonicalizes domain-name record values with a trailing
+				// dot; strip it so a dot-less desired value (e.g. an ACM
+				// validation target) reconciles as a no-op.
+				value = strings.TrimSuffix(value, ".")
+			}
+			records = append(records, value)
 		}
 		props["ResourceRecords"] = records
 		if found.TTL != nil {

--- a/pkg/cfres/route53/record_set_unit_test.go
+++ b/pkg/cfres/route53/record_set_unit_test.go
@@ -38,6 +38,65 @@ func TestBuildReadProperties_StripsAliasTargetTrailingDot(t *testing.T) {
 		"alias DNSName should have its trailing dot stripped to match stored state")
 }
 
+// AWS canonicalizes domain-name record values with a trailing dot. A CNAME
+// whose desired value is dot-less (e.g. an ACM DNS-validation target) reads back
+// dotted and shows phantom drift on every reconcile, so hostname-valued
+// ResourceRecords must be stripped the same way Name and AliasTarget.DNSName are.
+func TestBuildReadProperties_StripsCNAMEResourceRecordTrailingDot(t *testing.T) {
+	found := &types.ResourceRecordSet{
+		Name: aws.String("_abc.example.com."),
+		Type: types.RRTypeCname,
+		ResourceRecords: []types.ResourceRecord{
+			{Value: aws.String("_7a296c6d591b252a4209b817f2ba6fbe.jkddzztszm.acm-validations.aws.")},
+		},
+	}
+
+	props := buildReadProperties(found, "Z9999999", "_abc.example.com.", "CNAME")
+
+	records, ok := props["ResourceRecords"].([]string)
+	require.True(t, ok, "ResourceRecords should be present")
+	require.Len(t, records, 1)
+	assert.Equal(t, "_7a296c6d591b252a4209b817f2ba6fbe.jkddzztszm.acm-validations.aws", records[0],
+		"CNAME record value should have its trailing dot stripped to match dot-less desired state")
+}
+
+// MX values are "<pref> <hostname>." — the hostname's trailing dot must be
+// stripped too.
+func TestBuildReadProperties_StripsMXResourceRecordTrailingDot(t *testing.T) {
+	found := &types.ResourceRecordSet{
+		Name: aws.String("example.com."),
+		Type: types.RRTypeMx,
+		ResourceRecords: []types.ResourceRecord{
+			{Value: aws.String("10 mail.example.com.")},
+		},
+	}
+
+	props := buildReadProperties(found, "Z9999999", "example.com.", "MX")
+
+	records := props["ResourceRecords"].([]string)
+	require.Len(t, records, 1)
+	assert.Equal(t, "10 mail.example.com", records[0])
+}
+
+// TXT (and SPF) values are quoted character strings, not domain names — a
+// trailing dot is legitimate content and must NOT be stripped.
+func TestBuildReadProperties_PreservesTXTResourceRecordTrailingDot(t *testing.T) {
+	found := &types.ResourceRecordSet{
+		Name: aws.String("example.com."),
+		Type: types.RRTypeTxt,
+		ResourceRecords: []types.ResourceRecord{
+			{Value: aws.String(`"some verification token ending in a dot."`)},
+		},
+	}
+
+	props := buildReadProperties(found, "Z9999999", "example.com.", "TXT")
+
+	records := props["ResourceRecords"].([]string)
+	require.Len(t, records, 1)
+	assert.Equal(t, `"some verification token ending in a dot."`, records[0],
+		"TXT values must be preserved verbatim — the trailing dot is data, not an FQDN terminator")
+}
+
 // When building an AWS AliasTarget from stored (no-dot) state to send back to
 // Route53, the trailing dot must be restored. The Update path deletes the prior
 // record by value, and Route53 rejects the delete unless the alias DNSName

--- a/testdata/route53-recordset-cname.pkl
+++ b/testdata/route53-recordset-cname.pkl
@@ -1,0 +1,61 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/route53/hostedzone.pkl"
+import "@aws/route53/recordset.pkl"
+
+// Read the test run ID from environment variable set by the test harness
+// This ensures consistent naming within a test run but unique names between runs
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local stackName = "plugin-sdk-test-route53-recordset-cname-\(testRunID)"
+local domainName = "sdk-cname-\(testRunID).test-formae.io"
+
+// HostedZone dependency - RecordSet needs a hosted zone to live in
+local hz = new hostedzone.HostedZone {
+  label = "test-hosted-zone-for-cname"
+  name = domainName
+  hostedZoneConfig = new hostedzone.HostedZoneConfig {
+    comment = "SDK test hosted zone for CNAME RecordSet tests"
+  }
+}
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for Route53 CNAME RecordSet re-reconcile (trailing-dot drift)"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  // HostedZone required for RecordSet
+  hz
+
+  // CNAME RecordSet under test. The value is declared WITHOUT a trailing dot;
+  // AWS canonicalizes the stored record value WITH one, so without trailing-dot
+  // normalization on read this record shows phantom `update` drift on every
+  // re-reconcile (the conformance harness's post-sync idempotency check). It
+  // must reconcile as a no-op.
+  new recordset.RecordSet {
+    label = "plugin-sdk-test-recordset-cname"
+    hostedZoneId = hz.res.id
+    name = "www.\(domainName)"
+    type = "CNAME"
+    ttl = 300
+    resourceRecords = new Listing {
+      "cname-target.example.com"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

PLA-23 stripped the trailing dot from an ALIAS `AliasTarget.DNSName` on read, but `ResourceRecords` values were left verbatim. AWS canonicalizes domain-name record values with a trailing dot, so a CNAME whose desired value is dot-less (e.g. an ACM DNS-validation target ending in `acm-validations.aws.`) reads back dotted and shows a phantom `update` on every reconcile. Because record-set updates are delete-old + create-new, that can fail `InvalidChangeBatch` and block the stack.

## Changes

- **Read normalization:** strip the trailing dot from `ResourceRecords` values for record types whose RDATA is a domain name (`CNAME`, `DNAME`, `NS`, `PTR`, `MX`, `SRV`). `TXT`/`SPF` are excluded (quoted character strings — a trailing dot is data); `A`/`AAAA` are IPs.
- **Unit tests:** CNAME and MX values get the trailing dot stripped; TXT values are preserved verbatim (guard against over-stripping).
- **Conformance fixture** (`route53-recordset-cname`): creates a CNAME with a dot-less value; the harness's post-sync idempotency check asserts the re-reconcile is a no-op (this is the gap that let it through — prior fixtures used IP A-records or dotted CNAME values, neither of which trips the drift).

Note: this makes dot-less the canonical stored form for these record values, consistent with the ALIAS fix and with how resolvable/ACM outputs render.