### PR TITLE
fix(acm): strip trailing dot from validation record values

### DIFF
--- a/pkg/cfres/certificatemanager/certificate.go
+++ b/pkg/cfres/certificatemanager/certificate.go
@@ -423,10 +423,13 @@ func normalizeKeyAlgorithmForCFN(s string) string {
 // Records may be empty if the cert uses EMAIL validation or is too new for ACM
 // to have populated the CNAMEs yet.
 //
-// Trailing dots are stripped from Name to match Route53::RecordSet's Read
-// normalization. Without that, a downstream Route53::RecordSet that
-// resolves cert.res.validationRecords.at(0).name sees a perpetual diff
-// against its own readback and gets delete+recreate'd on every reconcile.
+// Trailing dots are stripped from both Name and Value to match
+// Route53::RecordSet's Read normalization. Without that, a downstream
+// Route53::RecordSet that resolves cert.res.validationRecords.at(0).name /
+// .values sees a perpetual diff against its own readback (which strips the
+// dot) and gets delete+recreate'd on every reconcile. ACM returns the
+// validation CNAME target as `…acm-validations.aws.` (dotted), so the value
+// needs the same stripping the RecordSet read applies to CNAME RDATA.
 func validationRecordsFromCert(cert *acmtypes.CertificateDetail) []ses.DnsRecord {
 	var records []ses.DnsRecord
 	for _, opt := range cert.DomainValidationOptions {
@@ -437,7 +440,7 @@ func validationRecordsFromCert(cert *acmtypes.CertificateDetail) []ses.DnsRecord
 		records = append(records, ses.DnsRecord{
 			Type:           string(rr.Type),
 			Name:           strings.TrimSuffix(*rr.Name, "."),
-			Values:         []string{*rr.Value},
+			Values:         []string{strings.TrimSuffix(*rr.Value, ".")},
 			RecommendedTtl: 300,
 		})
 	}

--- a/pkg/cfres/certificatemanager/certificate_test.go
+++ b/pkg/cfres/certificatemanager/certificate_test.go
@@ -415,6 +415,19 @@ func TestRead_PopulatesValidationRecords(t *testing.T) {
 	if got := rec0["Name"]; got != "_abc.example.com" {
 		t.Errorf("ValidationRecords[0].Name: want %q (no trailing dot), got %q", "_abc.example.com", got)
 	}
+	// The value is consumed by a downstream Route53::RecordSet via
+	// cert.res.validationRecords.at(0).values. RecordSet's Read strips the
+	// trailing dot from CNAME values, so this value must be stripped too —
+	// otherwise the cert-sourced desired (dotted) never matches the
+	// RecordSet's normalized read (dot-less) and the CNAME shows perpetual
+	// phantom drift.
+	values, ok := rec0["Values"].([]any)
+	if !ok || len(values) != 1 {
+		t.Fatalf("ValidationRecords[0].Values: want 1-element list, got %T %v", rec0["Values"], rec0["Values"])
+	}
+	if got := values[0]; got != "_xyz.acm-validations.aws" {
+		t.Errorf("ValidationRecords[0].Values[0]: want %q (no trailing dot), got %q", "_xyz.acm-validations.aws", got)
+	}
 }
 
 func TestRead_PopulatesValidationMethodFromDomainValidationOption(t *testing.T) {


### PR DESCRIPTION
## Summary

The PLA-28 RecordSet read fix normalized only the RecordSet's own read path. But the ACM DNS-validation CNAME's desired value is sourced from the Certificate via `cert.res.validationRecords.at(0).values`, and `validationRecordsFromCert` stripped the trailing dot from `Name` but not `Values`. ACM returns the validation target as `…acm-validations.aws.` (dotted), so the cert-sourced desired stayed dotted while the RecordSet read emitted dot-less — inverting the mismatch and leaving a phantom `update` on every reconcile.

## Changes

- **Certificate read** (`validationRecordsFromCert`): strip the trailing dot from the validation record value too, mirroring the existing `Name` normalization. The cert-sourced desired and the RecordSet read now agree on the same dot-less canonical form, so the validation CNAME reconciles as a no-op.
- **Unit test:** assert `ValidationRecords[0].Values[0]` is dot-stripped (alongside the existing `Name` assertion).
- **Conformance fixture** (`route53-recordset-cert-validation`): wires a CNAME RecordSet to a DNS-validated ACM certificate's `validationRecords` resolvable — the real cross-resource path the prior literal-value fixture could not reproduce.

Follow-up to the RecordSet-side fix; together they make a formae-managed ACM DNS-validation CNAME a clean no-op on reconcile.