### PR TITLE
fix(networkfirewall): replace FirewallPolicy default-action lists atomically on update

### DIFF
--- a/schema/pkl/networkfirewall/firewallpolicy.pkl
+++ b/schema/pkl/networkfirewall/firewallpolicy.pkl
@@ -31,8 +31,20 @@ open class StatefulEngineOptions extends formae.SubResource {
 
 @aws.SubResourceHint
 open class FirewallPolicyData extends formae.SubResource {
+    // The default-action lists are mutually-exclusive value sets that AWS
+    // replaces wholesale. Marking them Atomic makes formae emit a single
+    // whole-array `replace` on update instead of per-element remove+add:
+    // CloudControl does not reliably apply a remove+add pair against these
+    // lists, leaving both the old and new action present (which AWS then
+    // rejects, e.g. "aws:drop_strict / aws:drop_established cannot exist
+    // together"). See PLA-37.
+    @aws.FieldHint{updateMethod = "Atomic"}
     statelessDefaultActions: Listing<String>
+
+    @aws.FieldHint{updateMethod = "Atomic"}
     statelessFragmentDefaultActions: Listing<String>
+
+    @aws.FieldHint{updateMethod = "Atomic"}
     statefulDefaultActions: Listing<String>?
     statefulRuleGroupReferences: Listing<StatefulRuleGroupReference>?
     statelessRuleGroupReferences: Listing<StatelessRuleGroupReference>?

--- a/testdata/networkfirewall-update.pkl
+++ b/testdata/networkfirewall-update.pkl
@@ -1,0 +1,130 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+// Update fixture for the Network Firewall conformance test. Identical to
+// networkfirewall.pkl except the FirewallPolicy's statefulDefaultActions flips
+// from "aws:drop_established" to "aws:drop_strict". These two actions are
+// mutually exclusive, so the update must REPLACE the list — a per-element
+// remove+add leaves both present and AWS rejects it
+// ("aws:drop_strict / aws:drop_established cannot exist together"). Exercises
+// the updateMethod=Atomic schema hint on the *DefaultActions lists. See PLA-37.
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/ec2/vpc.pkl"
+import "@aws/ec2/subnet.pkl"
+import "@aws/networkfirewall/rulegroup.pkl"
+import "@aws/networkfirewall/firewallpolicy.pkl"
+import "@aws/networkfirewall/firewall.pkl"
+
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local stackName = "plugin-sdk-test-networkfirewall-\(testRunID)"
+local azA = "us-east-1a"
+local azB = "us-east-1b"
+
+local testVpc = new vpc.VPC {
+  label = "nfw-vpc"
+  cidrBlock = "10.0.0.0/16"
+  enableDnsSupport = true
+  enableDnsHostnames = true
+}
+
+// Dedicated firewall subnets, one per AZ.
+local fwSubnetA = new subnet.Subnet {
+  label = "nfw-fw-subnet-a"
+  vpcId = testVpc.res.vpcId
+  cidrBlock = "10.0.0.0/28"
+  availabilityZone = azA
+  tags = new Listing<aws.Tag> { new { key = "Name"; value = "nfw-fw-subnet-a" } }
+}
+local fwSubnetB = new subnet.Subnet {
+  label = "nfw-fw-subnet-b"
+  vpcId = testVpc.res.vpcId
+  cidrBlock = "10.0.0.16/28"
+  availabilityZone = azB
+  tags = new Listing<aws.Tag> { new { key = "Name"; value = "nfw-fw-subnet-b" } }
+}
+
+// Stateful domain-allowlist rule group (the FQDN allowlist).
+local allowlist = new rulegroup.RuleGroup {
+  label = "nfw-allowlist"
+  ruleGroupName = "nfw-allowlist-\(testRunID)"
+  type = "STATEFUL"
+  capacity = 100
+  ruleGroup = new rulegroup.RuleGroupData {
+    rulesSource = new rulegroup.RulesSource {
+      rulesSourceList = new rulegroup.RulesSourceList {
+        targets = new Listing<String> { "github.com"; "api.anthropic.com" }
+        targetTypes = new Listing<String> { "TLS_SNI"; "HTTP_HOST" }
+        generatedRulesType = "ALLOWLIST"
+      }
+    }
+    statefulRuleOptions = new rulegroup.StatefulRuleOptions {
+      ruleOrder = "STRICT_ORDER"
+    }
+  }
+}
+
+// Firewall policy referencing the allowlist rule group. The stateful default
+// action is flipped to aws:drop_strict to exercise the Atomic list replace.
+local policy = new firewallpolicy.FirewallPolicy {
+  label = "nfw-policy"
+  firewallPolicyName = "nfw-policy-\(testRunID)"
+  firewallPolicy = new firewallpolicy.FirewallPolicyData {
+    statelessDefaultActions = new Listing<String> { "aws:forward_to_sfe" }
+    statelessFragmentDefaultActions = new Listing<String> { "aws:forward_to_sfe" }
+    statefulDefaultActions = new Listing<String> { "aws:drop_strict" }
+    statefulEngineOptions = new firewallpolicy.StatefulEngineOptions {
+      ruleOrder = "STRICT_ORDER"
+    }
+    statefulRuleGroupReferences = new Listing<firewallpolicy.StatefulRuleGroupReference> {
+      new {
+        resourceArn = allowlist.res.arn
+        // STRICT_ORDER requires an explicit evaluation priority per reference.
+        priority = 1
+      }
+    }
+  }
+}
+
+// Firewall spanning both AZs. Listed last in the forma block: the conformance
+// harness verifies the final resource in the fixture and OOB-deletes it in
+// isolation, so it must be a leaf (nothing references its endpoints). The
+// per-AZ endpoint outputs and route wiring are exercised separately.
+local fw = new firewall.Firewall {
+  label = "nfw-firewall"
+  firewallName = "nfw-firewall-\(testRunID)"
+  firewallPolicyArn = policy.res.arn
+  vpcId = testVpc.res.vpcId
+  subnetMappings = new Listing<firewall.SubnetMapping> {
+    new { subnetId = fwSubnetA.res.subnetId }
+    new { subnetId = fwSubnetB.res.subnetId }
+  }
+}
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for AWS Network Firewall"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  testVpc
+  fwSubnetA
+  fwSubnetB
+  allowlist
+  policy
+  fw
+}


### PR DESCRIPTION
## Summary

Updating a list-valued field on `AWS::NetworkFirewall::FirewallPolicy` (e.g. `StatefulDefaultActions` from `["aws:drop_established"]` to `["aws:drop_strict"]`) failed at apply: formae generated a correct RFC-6902 remove+add, but AWS Cloud Control does not reliably apply that pair against these mutually-exclusive lists, leaving **both** values present — AWS then rejects it (`aws:drop_strict / aws:drop_established cannot exist together`).

Mark the three `*DefaultActions` lists `updateMethod = "Atomic"` so formae emits a single whole-array `replace`, matching how AWS's `UpdateFirewallPolicy` API replaces them wholesale.

## Changes
- `schema/pkl/networkfirewall/firewallpolicy.pkl`: `Atomic` hint on `statefulDefaultActions`, `statelessDefaultActions`, `statelessFragmentDefaultActions`.
- `testdata/networkfirewall-update.pkl`: new update fixture flipping `statefulDefaultActions` to exercise the replace path in conformance.

## Dependency
Requires the Atomic-array support in jsonpatch + formae core (platform-engineering-labs/formae#523). Conformance must run against an agent built from that branch.

## Testing
- `make verify-schema` PASS.
- `pkl eval` confirms all three lists resolve to `Atomic` hint keys.
- NetworkFirewall unit tests pass.
- Conformance: `networkfirewall` green via debug-conformance built against the core branch.
