### PR TITLE
fix: green up the AWS conformance matrix (EKS version, RDS snapshots, CloudControl throttling)

### DIFF
--- a/pkg/ccx/retry.go
+++ b/pkg/ccx/retry.go
@@ -33,8 +33,14 @@ import (
 //
 // Both surfaces need an in-process exponential-backoff loop with a budget
 // long enough to absorb AWS's typical 30-60s recovery window.
+//
+// The budget is sized for sustained CloudControl throttling during the
+// conformance matrix, where many resource types poll status concurrently:
+// 10 attempts over the 1s..30s backoff give roughly a 3-minute window, enough
+// for status reads to ride out the throttling bursts that previously exhausted
+// a 6-attempt budget and failed otherwise-healthy applies.
 const (
-	defaultRetryMaxAttempts = 6
+	defaultRetryMaxAttempts = 10
 	defaultRetryBaseDelay   = 1 * time.Second
 	defaultRetryMaxDelay    = 30 * time.Second
 )

--- a/schema/pkl/eks/ekscluster.pkl
+++ b/schema/pkl/eks/ekscluster.pkl
@@ -118,6 +118,12 @@ open class ResourcesVpcConfig extends formae.SubResource {
     @aws.FieldHint{edgeKind = "runtimeDependency"; hasProviderDefault = true}
     securityGroupIds: Listing<String|formae.Resolvable>?
     subnetIds: Listing<String|formae.Resolvable>
+
+    // AWS populates the control-plane egress mode (e.g. on EKS 1.32+) even when
+    // the user doesn't set it, so treat it as a provider default to avoid
+    // phantom drift on every read.
+    @aws.FieldHint{hasProviderDefault = true}
+    controlPlaneEgressMode: String?
 }
 
 @aws.SubResourceHint

--- a/scripts/ci/clean-environment.sh
+++ b/scripts/ci/clean-environment.sh
@@ -439,6 +439,23 @@ aws rds describe-db-instances --region "$REGION" \
     fi
 done
 
+# --- RDS manual DB snapshots
+# A DBInstance delete through CloudControl creates a final snapshot by default,
+# and instance cleanup above does not remove it. These accumulate against the
+# per-account 100 manual-snapshot limit until a later delete fails with
+# ServiceLimitExceeded ("cannot create more than 100 manual snapshots"),
+# blocking the rds-dbinstance conformance teardown. Purge the test-owned manual
+# snapshots so each run starts under the limit. Match on either the snapshot id
+# or its source instance id, since final-snapshot ids are auto-generated.
+echo "Cleaning RDS test manual DB snapshots..."
+aws rds describe-db-snapshots --snapshot-type manual --region "$REGION" \
+    --query "DBSnapshots[?contains(DBSnapshotIdentifier, '$SDK_PREFIX') || contains(DBSnapshotIdentifier, '$FORMAE_PREFIX') || contains(DBSnapshotIdentifier, '$TEST_PREFIX') || contains(DBInstanceIdentifier, '$SDK_PREFIX') || contains(DBInstanceIdentifier, '$FORMAE_PREFIX') || contains(DBInstanceIdentifier, '$TEST_PREFIX')].DBSnapshotIdentifier" --output text 2>/dev/null | tr '\t' '\n' | while read -r snap; do
+    if [[ -n "$snap" ]]; then
+        echo "  Deleting RDS manual snapshot: $snap"
+        aws rds delete-db-snapshot --db-snapshot-identifier "$snap" --region "$REGION" 2>/dev/null || true
+    fi
+done
+
 # --- RDS DB subnet groups (after DB instances, before VPCs)
 echo "Cleaning RDS test DB subnet groups..."
 aws rds describe-db-subnet-groups --region "$REGION" \

--- a/testdata/eks-cluster-update.pkl
+++ b/testdata/eks-cluster-update.pkl
@@ -89,7 +89,7 @@ forma {
     label = "plugin-sdk-test-eks"
     name = "formae-sdk-test-eks-\(testRunID)"
     roleArn = testRole.res.arn
-    version = "1.29"
+    version = "1.32"
     resourcesVpcConfig = new {
       subnetIds {
         testSubnet1.res.subnetId

--- a/testdata/eks-cluster.pkl
+++ b/testdata/eks-cluster.pkl
@@ -89,7 +89,7 @@ forma {
     label = "plugin-sdk-test-eks"
     name = "formae-sdk-test-eks-\(testRunID)"
     roleArn = testRole.res.arn
-    version = "1.29"
+    version = "1.32"
     resourcesVpcConfig = new {
       subnetIds {
         testSubnet1.res.subnetId


### PR DESCRIPTION
Three independent failures were making the AWS plugin conformance matrix (and nightly) red. None are correctness regressions — they're fixture staleness, environment hygiene, and throttling resilience.

## EKS — unsupported Kubernetes version
`eks-cluster` create failed with `unsupported Kubernetes version 1.29` — AWS no longer accepts 1.29. Bumped the conformance fixture to 1.32.

## RDS — manual-snapshot limit
`rds-dbinstance` teardown failed with `cannot create more than 100 manual snapshots` (ServiceLimitExceeded). A DBInstance delete through CloudControl creates a final snapshot by default, and the cleanup script removed instances but not those snapshots, so they accumulated to the per-account limit and blocked further deletes. Environment cleanup now purges test-owned manual snapshots (matched on snapshot id or source instance id), so each run starts under the limit.

## CloudControl throttling
`ecs-service-with-lb-rule-routing` and `elasticbeanstalk-applicationversion` failed when concurrent status polling across the matrix tripped AWS throttling and exhausted the 6-attempt status-read retry budget. Raised the default to 10 attempts (~3-minute window over the existing 1s–30s exponential backoff) so status reads ride out throttling bursts.

## Testing
- `go test -tags=unit ./pkg/ccx/...` and `make lint` pass.
- `bash -n` on the cleanup script passes.
- EKS/RDS fixes validate against the conformance matrix.