### PR TITLE
fix(secretsmanager): surface secretString so opaque rotation and setOnce work

### DIFF
--- a/schema/pkl/secretsmanager/secret.pkl
+++ b/schema/pkl/secretsmanager/secret.pkl
@@ -92,7 +92,7 @@ open class Secret extends formae.Resource {
     @aws.FieldHint {
         writeOnly = true
     }
-    hidden secretString: (formae.Value|String)?
+    secretString: (formae.Value|String)?
 
     @aws.FieldHint {
         outputTransformation = formae.transform.capitalizeMemberKeys


### PR DESCRIPTION
`secretString` was declared `hidden`, which drops it from the schema model under formae's current schema-reflection logic, so the value op was stripped before reaching the provider. Surfacing the field (keeping `writeOnly`) puts it back in the schema model so the op survives.

Result:
- A changed value rotates.
- `.opaque.setOnce` freezes — a sibling edit no longer emits the value.

Notes:
- The rotation / no-churn behavior depends on the core opaque-value suppression fix being present in the formae release this plugin runs against (the plugin pins released core). That fix is merged to formae `main` and ships in formae 0.86.2. Until a release containing it is in use, a surfaced opaque value can still churn (new version) or, for `setOnce`, corrupt (overwrite with the stored hash) on an unrelated sibling edit.
- The schema change is correct independently; the live behavior follows the core release.

Depends on a formae release containing the core opaque-value suppression fix (0.86.2).
