### PR TITLE
fix(ses): apply EmailIdentity Update via SESv2; raise conformance discovery timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,13 @@ jobs:
         env:
           AWS_REGION: us-east-1
           FORMAE_TEST_RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}
+          # Discovery polls inventory for the OOB-created resource. The 2-min
+          # default is too tight when CloudControl ListResources gets throttled
+          # in the shared test account (discovery scans every parent — e.g. each
+          # EFS filesystem — so leftover resources from parallel jobs inflate the
+          # list-call volume and trigger Rate exceeded backoffs). 5 min gives
+          # discovery room to push past the throttling window.
+          FORMAE_TEST_DISCOVERY_TIMEOUT: 5
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
         run: make conformance-test-crud-run conformance-test-discovery-run TEST=${{ matrix.test-case }} PARALLEL=1 TIMEOUT=120
 

--- a/.github/workflows/debug-conformance.yml
+++ b/.github/workflows/debug-conformance.yml
@@ -165,6 +165,9 @@ jobs:
         env:
           AWS_REGION: us-east-1
           FORMAE_TEST_RUN_ID: debug-${{ github.run_id }}-${{ github.run_attempt }}
+          # See ci.yml: 2-min discovery default is too tight under CloudControl
+          # ListResources throttling in the shared account.
+          FORMAE_TEST_DISCOVERY_TIMEOUT: 5
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
         # 90-minute timeout accommodates LB-attached fixtures (ALB provisioning
         # + ECS stabilization + destroy + reapply takes 65-80m). Smaller fixtures

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -258,6 +258,9 @@ jobs:
         env:
           AWS_REGION: us-east-1
           FORMAE_TEST_RUN_ID: nightly-main-${{ github.run_id }}
+          # See ci.yml: 2-min discovery default is too tight under CloudControl
+          # ListResources throttling in the shared account.
+          FORMAE_TEST_DISCOVERY_TIMEOUT: 5
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
         run: make conformance-test-crud-run conformance-test-discovery-run TEST=${{ matrix.test-case }} PARALLEL=1 TIMEOUT=120
 

--- a/pkg/cfres/ses/emailidentity.go
+++ b/pkg/cfres/ses/emailidentity.go
@@ -11,8 +11,10 @@ import (
 	"log/slog"
 	"strings"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/sesv2"
 	sesv2types "github.com/aws/aws-sdk-go-v2/service/sesv2/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 
 	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
 	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/ccx"
@@ -183,12 +185,183 @@ func (e *EmailIdentity) Create(ctx context.Context, request *resource.CreateRequ
 	return ccxClient.CreateResource(ctx, request)
 }
 
+// Update is custom (like Read). CloudControl's async AWS::SES::EmailIdentity
+// update handler fails intermittently with GeneralServiceException "security
+// token included in the request is invalid" (an AWS-side credential propagation
+// fault we cannot influence), so we apply each attribute group directly via the
+// SESv2 SDK instead of delegating to CloudControl.
 func (e *EmailIdentity) Update(ctx context.Context, request *resource.UpdateRequest) (*resource.UpdateResult, error) {
-	ccxClient, err := ccx.NewClient(e.cfg)
+	sesClient, err := e.sesClientFactory(e.cfg)
 	if err != nil {
+		return nil, fmt.Errorf("ses: build SESv2 client: %w", err)
+	}
+	awsCfg, err := e.cfg.ToAwsConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("ses: build AWS config: %w", err)
+	}
+	return e.updateWithClient(ctx, sesClient, sts.NewFromConfig(awsCfg), request)
+}
+
+func (e *EmailIdentity) updateWithClient(
+	ctx context.Context,
+	sesClient SesV2ClientInterface,
+	stsClient stsClientInterface,
+	request *resource.UpdateRequest,
+) (*resource.UpdateResult, error) {
+	identity := request.NativeID
+
+	var desired map[string]any
+	if err := json.Unmarshal(request.DesiredProperties, &desired); err != nil {
+		return nil, fmt.Errorf("ses: parse desired properties: %w", err)
+	}
+	// Prior is best-effort: it only drives diffs (DKIM once-per-day guard, tag
+	// removals). An unparseable prior degrades to "apply everything".
+	var prior map[string]any
+	if len(request.PriorProperties) > 0 {
+		_ = json.Unmarshal(request.PriorProperties, &prior)
+	}
+
+	if mf, ok := desired["MailFromAttributes"].(map[string]any); ok {
+		in := &sesv2.PutEmailIdentityMailFromAttributesInput{EmailIdentity: &identity}
+		if v, ok := mf["BehaviorOnMxFailure"].(string); ok {
+			in.BehaviorOnMxFailure = sesv2types.BehaviorOnMxFailure(v)
+		}
+		if v, ok := mf["MailFromDomain"].(string); ok && v != "" {
+			in.MailFromDomain = aws.String(v)
+		}
+		if _, err := sesClient.PutEmailIdentityMailFromAttributes(ctx, in); err != nil {
+			return nil, fmt.Errorf("ses: put mail-from attributes: %w", err)
+		}
+	}
+
+	if fb, ok := desired["FeedbackAttributes"].(map[string]any); ok {
+		in := &sesv2.PutEmailIdentityFeedbackAttributesInput{EmailIdentity: &identity}
+		if v, ok := fb["EmailForwardingEnabled"].(bool); ok {
+			in.EmailForwardingEnabled = v
+		}
+		if _, err := sesClient.PutEmailIdentityFeedbackAttributes(ctx, in); err != nil {
+			return nil, fmt.Errorf("ses: put feedback attributes: %w", err)
+		}
+	}
+
+	if cs, ok := desired["ConfigurationSet"].(string); ok && cs != "" {
+		if _, err := sesClient.PutEmailIdentityConfigurationSetAttributes(ctx, &sesv2.PutEmailIdentityConfigurationSetAttributesInput{
+			EmailIdentity:        &identity,
+			ConfigurationSetName: aws.String(cs),
+		}); err != nil {
+			return nil, fmt.Errorf("ses: put configuration-set attributes: %w", err)
+		}
+	}
+
+	// Easy-DKIM key length can be changed at most once per day, so only call
+	// when it actually changed.
+	desiredDkim := dkimKeyLength(desired)
+	if desiredDkim != "" && desiredDkim != dkimKeyLength(prior) {
+		if _, err := sesClient.PutEmailIdentityDkimSigningAttributes(ctx, &sesv2.PutEmailIdentityDkimSigningAttributesInput{
+			EmailIdentity:           &identity,
+			SigningAttributesOrigin: sesv2types.DkimSigningAttributesOriginAwsSes,
+			SigningAttributes: &sesv2types.DkimSigningAttributes{
+				NextSigningKeyLength: sesv2types.DkimSigningKeyLength(desiredDkim),
+			},
+		}); err != nil {
+			return nil, fmt.Errorf("ses: put dkim signing attributes: %w", err)
+		}
+	}
+
+	if err := e.reconcileTags(ctx, sesClient, stsClient, identity, prior, desired); err != nil {
 		return nil, err
 	}
-	return ccxClient.UpdateResource(ctx, request)
+
+	return &resource.UpdateResult{
+		ProgressResult: &resource.ProgressResult{
+			Operation:          resource.OperationUpdate,
+			OperationStatus:    resource.OperationStatusSuccess,
+			NativeID:           identity,
+			ResourceProperties: json.RawMessage(request.DesiredProperties),
+		},
+	}, nil
+}
+
+// dkimKeyLength digs DkimSigningAttributes.NextSigningKeyLength out of a
+// properties map, returning "" when absent.
+func dkimKeyLength(props map[string]any) string {
+	dkim, ok := props["DkimSigningAttributes"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	v, _ := dkim["NextSigningKeyLength"].(string)
+	return v
+}
+
+// reconcileTags upserts changed/new tags and removes tags absent from the
+// desired state. It only resolves the account ID (an STS round-trip needed to
+// build the identity ARN) when there is at least one tag change to apply.
+func (e *EmailIdentity) reconcileTags(
+	ctx context.Context,
+	sesClient SesV2ClientInterface,
+	stsClient stsClientInterface,
+	identity string,
+	prior, desired map[string]any,
+) error {
+	priorTags := parseTags(prior)
+	desiredTags := parseTags(desired)
+
+	var upsert []sesv2types.Tag
+	for k, v := range desiredTags {
+		if old, ok := priorTags[k]; !ok || old != v {
+			upsert = append(upsert, sesv2types.Tag{Key: aws.String(k), Value: aws.String(v)})
+		}
+	}
+	var remove []string
+	for k := range priorTags {
+		if _, ok := desiredTags[k]; !ok {
+			remove = append(remove, k)
+		}
+	}
+
+	if len(upsert) == 0 && len(remove) == 0 {
+		return nil
+	}
+
+	caller, err := stsClient.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+	if err != nil {
+		return fmt.Errorf("ses: resolve account for tag ARN: %w", err)
+	}
+	arn := fmt.Sprintf("arn:aws:ses:%s:%s:identity/%s", e.cfg.Region, aws.ToString(caller.Account), identity)
+
+	if len(upsert) > 0 {
+		if _, err := sesClient.TagResource(ctx, &sesv2.TagResourceInput{ResourceArn: &arn, Tags: upsert}); err != nil {
+			return fmt.Errorf("ses: tag identity: %w", err)
+		}
+	}
+	if len(remove) > 0 {
+		if _, err := sesClient.UntagResource(ctx, &sesv2.UntagResourceInput{ResourceArn: &arn, TagKeys: remove}); err != nil {
+			return fmt.Errorf("ses: untag identity: %w", err)
+		}
+	}
+	return nil
+}
+
+// parseTags converts a properties map's "Tags" list ([{Key,Value},...]) into a
+// key→value map, ignoring malformed entries.
+func parseTags(props map[string]any) map[string]string {
+	out := map[string]string{}
+	list, ok := props["Tags"].([]any)
+	if !ok {
+		return out
+	}
+	for _, raw := range list {
+		tag, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		key, _ := tag["Key"].(string)
+		val, _ := tag["Value"].(string)
+		if key != "" {
+			out[key] = val
+		}
+	}
+	return out
 }
 
 func (e *EmailIdentity) Delete(ctx context.Context, request *resource.DeleteRequest) (*resource.DeleteResult, error) {

--- a/pkg/cfres/ses/emailidentity_mock_test.go
+++ b/pkg/cfres/ses/emailidentity_mock_test.go
@@ -10,6 +10,7 @@ import (
 	"context"
 
 	"github.com/aws/aws-sdk-go-v2/service/sesv2"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -55,4 +56,64 @@ func (m *mockSesV2Client) ListConfigurationSets(ctx context.Context, input *sesv
 		return nil, args.Error(1)
 	}
 	return args.Get(0).(*sesv2.ListConfigurationSetsOutput), args.Error(1)
+}
+
+func (m *mockSesV2Client) PutEmailIdentityMailFromAttributes(ctx context.Context, input *sesv2.PutEmailIdentityMailFromAttributesInput, optFns ...func(*sesv2.Options)) (*sesv2.PutEmailIdentityMailFromAttributesOutput, error) {
+	args := m.Called(ctx, input)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*sesv2.PutEmailIdentityMailFromAttributesOutput), args.Error(1)
+}
+
+func (m *mockSesV2Client) PutEmailIdentityDkimSigningAttributes(ctx context.Context, input *sesv2.PutEmailIdentityDkimSigningAttributesInput, optFns ...func(*sesv2.Options)) (*sesv2.PutEmailIdentityDkimSigningAttributesOutput, error) {
+	args := m.Called(ctx, input)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*sesv2.PutEmailIdentityDkimSigningAttributesOutput), args.Error(1)
+}
+
+func (m *mockSesV2Client) PutEmailIdentityFeedbackAttributes(ctx context.Context, input *sesv2.PutEmailIdentityFeedbackAttributesInput, optFns ...func(*sesv2.Options)) (*sesv2.PutEmailIdentityFeedbackAttributesOutput, error) {
+	args := m.Called(ctx, input)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*sesv2.PutEmailIdentityFeedbackAttributesOutput), args.Error(1)
+}
+
+func (m *mockSesV2Client) PutEmailIdentityConfigurationSetAttributes(ctx context.Context, input *sesv2.PutEmailIdentityConfigurationSetAttributesInput, optFns ...func(*sesv2.Options)) (*sesv2.PutEmailIdentityConfigurationSetAttributesOutput, error) {
+	args := m.Called(ctx, input)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*sesv2.PutEmailIdentityConfigurationSetAttributesOutput), args.Error(1)
+}
+
+func (m *mockSesV2Client) TagResource(ctx context.Context, input *sesv2.TagResourceInput, optFns ...func(*sesv2.Options)) (*sesv2.TagResourceOutput, error) {
+	args := m.Called(ctx, input)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*sesv2.TagResourceOutput), args.Error(1)
+}
+
+func (m *mockSesV2Client) UntagResource(ctx context.Context, input *sesv2.UntagResourceInput, optFns ...func(*sesv2.Options)) (*sesv2.UntagResourceOutput, error) {
+	args := m.Called(ctx, input)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*sesv2.UntagResourceOutput), args.Error(1)
+}
+
+type mockStsClient struct {
+	mock.Mock
+}
+
+func (m *mockStsClient) GetCallerIdentity(ctx context.Context, input *sts.GetCallerIdentityInput, optFns ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error) {
+	args := m.Called(ctx, input)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*sts.GetCallerIdentityOutput), args.Error(1)
 }

--- a/pkg/cfres/ses/emailidentity_update_test.go
+++ b/pkg/cfres/ses/emailidentity_update_test.go
@@ -1,0 +1,144 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package ses
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sesv2"
+	sesv2types "github.com/aws/aws-sdk-go-v2/service/sesv2/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/config"
+)
+
+const (
+	testIdentity = "formae-conformance-abc123.example.com"
+	testAccount  = "123456789012"
+)
+
+func newEmailIdentityForUpdate(sesClient SesV2ClientInterface) *EmailIdentity {
+	return &EmailIdentity{
+		cfg:              &config.Config{Region: "us-east-1"},
+		sesClientFactory: func(*config.Config) (SesV2ClientInterface, error) { return sesClient, nil },
+	}
+}
+
+func TestUpdate_AppliesChangedAttributesViaSesV2(t *testing.T) {
+	ctx := context.Background()
+	sesClient := &mockSesV2Client{}
+	stsClient := &mockStsClient{}
+
+	stsClient.On("GetCallerIdentity", ctx, mock.Anything).
+		Return(&sts.GetCallerIdentityOutput{Account: aws.String(testAccount)}, nil)
+
+	sesClient.On("PutEmailIdentityMailFromAttributes", ctx, mock.MatchedBy(func(in *sesv2.PutEmailIdentityMailFromAttributesInput) bool {
+		return aws.ToString(in.EmailIdentity) == testIdentity &&
+			in.BehaviorOnMxFailure == sesv2types.BehaviorOnMxFailureRejectMessage &&
+			aws.ToString(in.MailFromDomain) == "mail."+testIdentity
+	})).Return(&sesv2.PutEmailIdentityMailFromAttributesOutput{}, nil)
+
+	sesClient.On("PutEmailIdentityDkimSigningAttributes", ctx, mock.MatchedBy(func(in *sesv2.PutEmailIdentityDkimSigningAttributesInput) bool {
+		return aws.ToString(in.EmailIdentity) == testIdentity &&
+			in.SigningAttributesOrigin == sesv2types.DkimSigningAttributesOriginAwsSes &&
+			in.SigningAttributes != nil &&
+			in.SigningAttributes.NextSigningKeyLength == sesv2types.DkimSigningKeyLengthRsa1024Bit
+	})).Return(&sesv2.PutEmailIdentityDkimSigningAttributesOutput{}, nil)
+
+	sesClient.On("PutEmailIdentityFeedbackAttributes", ctx, mock.MatchedBy(func(in *sesv2.PutEmailIdentityFeedbackAttributesInput) bool {
+		return aws.ToString(in.EmailIdentity) == testIdentity && in.EmailForwardingEnabled == false
+	})).Return(&sesv2.PutEmailIdentityFeedbackAttributesOutput{}, nil)
+
+	wantArn := "arn:aws:ses:us-east-1:" + testAccount + ":identity/" + testIdentity
+	sesClient.On("TagResource", ctx, mock.MatchedBy(func(in *sesv2.TagResourceInput) bool {
+		return aws.ToString(in.ResourceArn) == wantArn && len(in.Tags) == 1 &&
+			aws.ToString(in.Tags[0].Key) == "Environment" && aws.ToString(in.Tags[0].Value) == "updated"
+	})).Return(&sesv2.TagResourceOutput{}, nil)
+
+	prior := `{"EmailIdentity":"` + testIdentity + `","MailFromAttributes":{"BehaviorOnMxFailure":"USE_DEFAULT_VALUE","MailFromDomain":"mail.` + testIdentity + `"},"DkimSigningAttributes":{"NextSigningKeyLength":"RSA_2048_BIT"},"FeedbackAttributes":{"EmailForwardingEnabled":true},"Tags":[{"Key":"Environment","Value":"test"}]}`
+	desired := `{"EmailIdentity":"` + testIdentity + `","MailFromAttributes":{"BehaviorOnMxFailure":"REJECT_MESSAGE","MailFromDomain":"mail.` + testIdentity + `"},"DkimSigningAttributes":{"NextSigningKeyLength":"RSA_1024_BIT"},"FeedbackAttributes":{"EmailForwardingEnabled":false},"Tags":[{"Key":"Environment","Value":"updated"}]}`
+
+	e := newEmailIdentityForUpdate(sesClient)
+	res, err := e.updateWithClient(ctx, sesClient, stsClient, &resource.UpdateRequest{
+		NativeID:          testIdentity,
+		ResourceType:      "AWS::SES::EmailIdentity",
+		PriorProperties:   []byte(prior),
+		DesiredProperties: []byte(desired),
+	})
+
+	assert.NoError(t, err)
+	assert.NotNil(t, res)
+	assert.Equal(t, resource.OperationStatusSuccess, res.ProgressResult.OperationStatus)
+	assert.Equal(t, testIdentity, res.ProgressResult.NativeID)
+	sesClient.AssertExpectations(t)
+	stsClient.AssertExpectations(t)
+}
+
+func TestUpdate_DkimUnchanged_SkipsDkimPut(t *testing.T) {
+	ctx := context.Background()
+	sesClient := &mockSesV2Client{}
+	stsClient := &mockStsClient{}
+
+	// Only feedback changes; DKIM key length identical in prior/desired.
+	sesClient.On("PutEmailIdentityFeedbackAttributes", ctx, mock.Anything).
+		Return(&sesv2.PutEmailIdentityFeedbackAttributesOutput{}, nil)
+
+	prior := `{"EmailIdentity":"` + testIdentity + `","DkimSigningAttributes":{"NextSigningKeyLength":"RSA_2048_BIT"},"FeedbackAttributes":{"EmailForwardingEnabled":true}}`
+	desired := `{"EmailIdentity":"` + testIdentity + `","DkimSigningAttributes":{"NextSigningKeyLength":"RSA_2048_BIT"},"FeedbackAttributes":{"EmailForwardingEnabled":false}}`
+
+	e := newEmailIdentityForUpdate(sesClient)
+	res, err := e.updateWithClient(ctx, sesClient, stsClient, &resource.UpdateRequest{
+		NativeID:          testIdentity,
+		ResourceType:      "AWS::SES::EmailIdentity",
+		PriorProperties:   []byte(prior),
+		DesiredProperties: []byte(desired),
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, resource.OperationStatusSuccess, res.ProgressResult.OperationStatus)
+	sesClient.AssertNotCalled(t, "PutEmailIdentityDkimSigningAttributes", mock.Anything, mock.Anything)
+	// No tag changes → no STS call needed.
+	stsClient.AssertNotCalled(t, "GetCallerIdentity", mock.Anything, mock.Anything)
+	sesClient.AssertExpectations(t)
+}
+
+func TestUpdate_RemovedTag_IsUntagged(t *testing.T) {
+	ctx := context.Background()
+	sesClient := &mockSesV2Client{}
+	stsClient := &mockStsClient{}
+
+	stsClient.On("GetCallerIdentity", ctx, mock.Anything).
+		Return(&sts.GetCallerIdentityOutput{Account: aws.String(testAccount)}, nil)
+
+	wantArn := "arn:aws:ses:us-east-1:" + testAccount + ":identity/" + testIdentity
+	sesClient.On("UntagResource", ctx, mock.MatchedBy(func(in *sesv2.UntagResourceInput) bool {
+		return aws.ToString(in.ResourceArn) == wantArn && len(in.TagKeys) == 1 && in.TagKeys[0] == "Team"
+	})).Return(&sesv2.UntagResourceOutput{}, nil)
+
+	prior := `{"EmailIdentity":"` + testIdentity + `","Tags":[{"Key":"Environment","Value":"test"},{"Key":"Team","Value":"infra"}]}`
+	desired := `{"EmailIdentity":"` + testIdentity + `","Tags":[{"Key":"Environment","Value":"test"}]}`
+
+	e := newEmailIdentityForUpdate(sesClient)
+	res, err := e.updateWithClient(ctx, sesClient, stsClient, &resource.UpdateRequest{
+		NativeID:          testIdentity,
+		ResourceType:      "AWS::SES::EmailIdentity",
+		PriorProperties:   []byte(prior),
+		DesiredProperties: []byte(desired),
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, resource.OperationStatusSuccess, res.ProgressResult.OperationStatus)
+	// Environment tag unchanged → not re-tagged.
+	sesClient.AssertNotCalled(t, "TagResource", mock.Anything, mock.Anything)
+	sesClient.AssertExpectations(t)
+	stsClient.AssertExpectations(t)
+}

--- a/pkg/cfres/ses/sesclient.go
+++ b/pkg/cfres/ses/sesclient.go
@@ -8,6 +8,7 @@ import (
 	"context"
 
 	"github.com/aws/aws-sdk-go-v2/service/sesv2"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 )
 
 // SesV2ClientInterface is the narrow surface of the SESv2 SDK client used by
@@ -19,4 +20,20 @@ type SesV2ClientInterface interface {
 	UpdateConfigurationSetEventDestination(ctx context.Context, params *sesv2.UpdateConfigurationSetEventDestinationInput, optFns ...func(*sesv2.Options)) (*sesv2.UpdateConfigurationSetEventDestinationOutput, error)
 	DeleteConfigurationSetEventDestination(ctx context.Context, params *sesv2.DeleteConfigurationSetEventDestinationInput, optFns ...func(*sesv2.Options)) (*sesv2.DeleteConfigurationSetEventDestinationOutput, error)
 	ListConfigurationSets(ctx context.Context, params *sesv2.ListConfigurationSetsInput, optFns ...func(*sesv2.Options)) (*sesv2.ListConfigurationSetsOutput, error)
+
+	// EmailIdentity Update applies each attribute group via its own SESv2 call,
+	// bypassing CloudControl's async update handler (which fails intermittently
+	// with GeneralServiceException "security token invalid" in the SES path).
+	PutEmailIdentityMailFromAttributes(ctx context.Context, params *sesv2.PutEmailIdentityMailFromAttributesInput, optFns ...func(*sesv2.Options)) (*sesv2.PutEmailIdentityMailFromAttributesOutput, error)
+	PutEmailIdentityDkimSigningAttributes(ctx context.Context, params *sesv2.PutEmailIdentityDkimSigningAttributesInput, optFns ...func(*sesv2.Options)) (*sesv2.PutEmailIdentityDkimSigningAttributesOutput, error)
+	PutEmailIdentityFeedbackAttributes(ctx context.Context, params *sesv2.PutEmailIdentityFeedbackAttributesInput, optFns ...func(*sesv2.Options)) (*sesv2.PutEmailIdentityFeedbackAttributesOutput, error)
+	PutEmailIdentityConfigurationSetAttributes(ctx context.Context, params *sesv2.PutEmailIdentityConfigurationSetAttributesInput, optFns ...func(*sesv2.Options)) (*sesv2.PutEmailIdentityConfigurationSetAttributesOutput, error)
+	TagResource(ctx context.Context, params *sesv2.TagResourceInput, optFns ...func(*sesv2.Options)) (*sesv2.TagResourceOutput, error)
+	UntagResource(ctx context.Context, params *sesv2.UntagResourceInput, optFns ...func(*sesv2.Options)) (*sesv2.UntagResourceOutput, error)
+}
+
+// stsClientInterface is the narrow STS surface used to resolve the account ID
+// for building the EmailIdentity ARN that SESv2 Tag/Untag calls require.
+type stsClientInterface interface {
+	GetCallerIdentity(ctx context.Context, params *sts.GetCallerIdentityInput, optFns ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error)
 }


### PR DESCRIPTION
## Summary

Two fixes to stabilize the conformance matrix.

### fix(ses): apply EmailIdentity Update via SESv2, bypassing CloudControl

CloudControl's async `AWS::SES::EmailIdentity` update handler fails with
`GeneralServiceException: "The security token included in the request is
invalid (Service: SesV2, 403)"` — an AWS-side credential fault inside the
handler that we can't influence. It surfaces both synchronously and via the
status poll, and because `GeneralServiceException` is non-recoverable the
command goes straight to a terminal failure. Create and Read are unaffected.

`Update` is now custom (as `Read` already is), applying each attribute group
directly with the SESv2 SDK instead of delegating to CloudControl:

- `PutEmailIdentityMailFromAttributes`
- `PutEmailIdentityDkimSigningAttributes` — only when the key length actually
  changed, since Easy-DKIM caps that change to once per day
- `PutEmailIdentityFeedbackAttributes`
- `PutEmailIdentityConfigurationSetAttributes`
- `TagResource` / `UntagResource` — diffed against prior properties; the
  account ID (for the identity ARN) is resolved via STS only when a tag
  actually changes

Covered by new unit tests and verified green through the full CRUD + discovery
conformance lifecycle.

### ci: raise conformance discovery timeout to 5m

The 2-minute discovery default is too tight when CloudControl `ListResources`
gets throttled in the shared test account. Discovery scans every parent (e.g.
each EFS filesystem), so leftover resources from parallel jobs inflate the
list-call volume and trigger `Rate exceeded` backoffs that can push discovery
past 2 minutes — observed as a spurious `efs-mounttarget` "resource not
discovered" timeout. Bumped to 5m across the CI, nightly, and debug workflows;
overridable via `FORMAE_TEST_DISCOVERY_TIMEOUT`.