### PR TITLE
feat(cloudfront): embed resolvables in Function.functionCode (PLA-68)

### DIFF
--- a/examples/PklProject
+++ b/examples/PklProject
@@ -6,6 +6,6 @@ dependencies {
 
   // Formae schema - fetched from public registry
   ["formae"] {
-    uri = "package://hub.platform.engineering/plugins/pkl/schema/pkl/formae/formae@0.86.0"
+    uri = "package://hub.platform.engineering/plugins/pkl/schema/pkl/formae/formae@0.87.0"
   }
 }

--- a/formae-plugin.pkl
+++ b/formae-plugin.pkl
@@ -5,13 +5,13 @@
  */
 
 name = "aws"
-version = "0.1.8-dev.0"
+version = "0.1.13-dev.0"
 namespace = "AWS"
 summary = "AWS resource plugin (CloudControl-based)"
 description = "AWS CloudControl resource plugin for Formae"
 category = "cloud"
 license = "FSL-1.1-ALv2"
-minFormaeVersion = "0.86.2"
+minFormaeVersion = "0.87.0"
 
 output {
   renderer = new JsonRenderer {}

--- a/schema/pkl/PklProject
+++ b/schema/pkl/PklProject
@@ -2,7 +2,7 @@ amends "pkl:Project"
 
 dependencies {
   ["formae"] {
-    uri = "package://hub.platform.engineering/plugins/pkl/schema/pkl/formae/formae@0.86.0"
+    uri = "package://hub.platform.engineering/plugins/pkl/schema/pkl/formae/formae@0.87.0"
   }
 }
 

--- a/schema/pkl/cloudfront/cffunction.pkl
+++ b/schema/pkl/cloudfront/cffunction.pkl
@@ -57,7 +57,7 @@ open class Function extends formae.Resource {
     autoPublish: Boolean?
 
     @aws.FieldHint
-    functionCode: String
+    functionCode: String|formae.Embedded
 
     @aws.FieldHint
     functionConfig: FunctionConfig

--- a/testdata/PklProject
+++ b/testdata/PklProject
@@ -6,6 +6,6 @@ dependencies {
 
   // Formae schema - fetched from public registry
   ["formae"] {
-    uri = "package://hub.platform.engineering/plugins/pkl/schema/pkl/formae/formae@0.86.0"
+    uri = "package://hub.platform.engineering/plugins/pkl/schema/pkl/formae/formae@0.87.0"
   }
 }


### PR DESCRIPTION
Widens `Function.functionCode` from `String` to `String|formae.Embedded`, so a
KeyValueStore's post-create `Id` can be embedded directly in the cf-js-2.0
source via `formae.embed("…\(kvStore.res.id)…")` — enabling single-apply
deployment of a Function + its KeyValueStore.

## Changes
- `schema/pkl/cloudfront/cffunction.pkl`: `functionCode: String|formae.Embedded`
- `minFormaeVersion` → `0.87.0` (the formae release carrying the `formae.Embedded` type)
- formae schema dependency → `0.87.0` in all PklProjects
- plugin `version` → `0.1.13-dev.0`

## Validation
Validated end-to-end against **real AWS** via the `debug-conformance` workflow
(formae built from the PLA-68 agent branch, schema 0.87.0). The full CRUD
lifecycle — Create / Verify / Extract / Sync / Update / Replace / Destroy — is
green for an embedded `KeyValueStore.Id` inside `functionCode`.

Discovery is **out of scope** for embeds by design (an embed only originates in
user code; there is nothing to reconstruct from a baked-in cloud literal), so
the temporary validation fixture is not included here — it would fail
discovery's out-of-band create path, and the conformance SDK has no per-fixture
CRUD-only opt-out yet. Re-adding CRUD-only embed coverage is a tracked follow-up.

## Release sequencing
This change is intended for the **`0.1.13-dev.0`** dev tag, paired with a formae
agent built from the PLA-68 branch. A **stable** `0.1.13` must wait until the
PLA-68 agent machinery ships in a released formae and `minFormaeVersion` points
at that release — `0.87.0` currently carries the schema, not a released agent.