### PR TITLE
feat(events): add EventBridge support (EventBus, Archive, Rule)

### DIFF
--- a/schema/pkl/events/archive.pkl
+++ b/schema/pkl/events/archive.pkl
@@ -1,0 +1,57 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+module aws.events.archive
+
+import "@formae/formae.pkl"
+import "../aws.pkl"
+
+const type = "AWS::Events::Archive"
+
+open class ArchiveResolvable extends formae.Resolvable {
+    hidden type = module.type
+
+    hidden arn: ArchiveResolvable = (this) {
+        property = "Arn"
+    }
+
+    hidden archiveName: ArchiveResolvable = (this) {
+        property = "ArchiveName"
+    }
+}
+
+@aws.ResourceHint {
+    type = module.type
+    identifier = "ArchiveName"
+    discoverable = true
+}
+open class Archive extends formae.Resource {
+
+    @aws.FieldHint { createOnly = true }
+    archiveName: String
+
+    @aws.FieldHint { createOnly = true }
+    sourceArn: String|formae.Resolvable
+
+    @aws.FieldHint
+    description: String?
+
+    @aws.FieldHint
+    eventPattern: Dynamic?
+
+    @aws.FieldHint
+    retentionDays: Int?
+
+    @aws.FieldHint
+    kmsKeyIdentifier: (String|formae.Resolvable)?
+
+    local parent = this
+
+    hidden res: ArchiveResolvable = new {
+        label = parent.label
+        stack = parent.stack?.label
+    }
+}

--- a/schema/pkl/events/archive.pkl
+++ b/schema/pkl/events/archive.pkl
@@ -39,7 +39,7 @@ open class Archive extends formae.Resource {
     @aws.FieldHint
     description: String?
 
-    @aws.FieldHint
+    @aws.FieldHint { updateMethod = "Atomic" }
     eventPattern: Dynamic?
 
     @aws.FieldHint

--- a/schema/pkl/events/eventbus.pkl
+++ b/schema/pkl/events/eventbus.pkl
@@ -47,7 +47,7 @@ open class EventBus extends formae.Resource {
     @aws.FieldHint { createOnly = true; writeOnly = true }
     eventSourceName: String?
 
-    @aws.FieldHint
+    @aws.FieldHint { updateMethod = "Atomic" }
     policy: Dynamic?
 
     @aws.FieldHint

--- a/schema/pkl/events/eventbus.pkl
+++ b/schema/pkl/events/eventbus.pkl
@@ -1,0 +1,71 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+module aws.events.eventbus
+
+import "@formae/formae.pkl"
+import "../aws.pkl"
+
+const type = "AWS::Events::EventBus"
+
+open class EventBusResolvable extends formae.Resolvable {
+    hidden type = module.type
+
+    hidden arn: EventBusResolvable = (this) {
+        property = "Arn"
+    }
+
+    hidden name: EventBusResolvable = (this) {
+        property = "Name"
+    }
+}
+
+@aws.SubResourceHint
+open class DeadLetterConfig extends formae.SubResource {
+    arn: (String|formae.Resolvable)?
+}
+
+@aws.ResourceHint {
+    type = module.type
+    identifier = "Name"
+    discoverable = true
+}
+open class EventBus extends formae.Resource {
+
+    @aws.FieldHint { createOnly = true }
+    name: String
+
+    @aws.FieldHint
+    description: String?
+
+    @aws.FieldHint
+    kmsKeyIdentifier: (String|formae.Resolvable)?
+
+    @aws.FieldHint { createOnly = true; writeOnly = true }
+    eventSourceName: String?
+
+    @aws.FieldHint
+    policy: Dynamic?
+
+    @aws.FieldHint
+    deadLetterConfig: DeadLetterConfig?
+
+    @aws.FieldHint { hasProviderDefault = true }
+    logConfig: Dynamic?
+
+    @aws.FieldHint {
+        updateMethod = "EntitySet"
+        indexField = "Key"
+    }
+    tags: Listing<aws.Tag>?
+
+    local parent = this
+
+    hidden res: EventBusResolvable = new {
+        label = parent.label
+        stack = parent.stack?.label
+    }
+}

--- a/schema/pkl/events/rule.pkl
+++ b/schema/pkl/events/rule.pkl
@@ -11,6 +11,8 @@ import "../aws.pkl"
 
 const type = "AWS::Events::Rule"
 
+typealias RuleState = "ENABLED"|"DISABLED"|"ENABLED_WITH_ALL_CLOUDTRAIL_MANAGEMENT_EVENTS"
+
 open class RuleResolvable extends formae.Resolvable {
     hidden type = module.type
 
@@ -212,7 +214,7 @@ open class Rule extends formae.Resource {
     scheduleExpression: String?
 
     @aws.FieldHint
-    state: String?
+    state: RuleState?
 
     @aws.FieldHint
     roleArn: (String|formae.Resolvable)?

--- a/schema/pkl/events/rule.pkl
+++ b/schema/pkl/events/rule.pkl
@@ -1,0 +1,233 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+module aws.events.rule
+
+import "@formae/formae.pkl"
+import "../aws.pkl"
+
+const type = "AWS::Events::Rule"
+
+open class RuleResolvable extends formae.Resolvable {
+    hidden type = module.type
+
+    hidden arn: RuleResolvable = (this) {
+        property = "Arn"
+    }
+
+    hidden name: RuleResolvable = (this) {
+        property = "Name"
+    }
+}
+
+@aws.SubResourceHint
+open class InputTransformer extends formae.SubResource {
+    inputPathsMap: Dynamic?
+    inputTemplate: String
+}
+
+@aws.SubResourceHint
+open class RetryPolicy extends formae.SubResource {
+    maximumRetryAttempts: Int?
+    maximumEventAgeInSeconds: Int?
+}
+
+@aws.SubResourceHint
+open class DeadLetterConfig extends formae.SubResource {
+    arn: (String|formae.Resolvable)?
+}
+
+@aws.SubResourceHint
+open class SqsParameters extends formae.SubResource {
+    messageGroupId: String
+}
+
+@aws.SubResourceHint
+open class KinesisParameters extends formae.SubResource {
+    partitionKeyPath: String
+}
+
+@aws.SubResourceHint
+open class HttpParameters extends formae.SubResource {
+    pathParameterValues: Listing<String>?
+    headerParameters: Dynamic?
+    queryStringParameters: Dynamic?
+}
+
+@aws.SubResourceHint
+open class RedshiftDataParameters extends formae.SubResource {
+    database: String
+    dbUser: String?
+    secretManagerArn: (String|formae.Resolvable)?
+    sql: String?
+    sqls: Listing<String>?
+    statementName: String?
+    withEvent: Boolean?
+}
+
+@aws.SubResourceHint
+open class SageMakerPipelineParameter extends formae.SubResource {
+    name: String
+    value: String
+}
+
+@aws.SubResourceHint
+open class SageMakerPipelineParameters extends formae.SubResource {
+    pipelineParameterList: Listing<SageMakerPipelineParameter>?
+}
+
+@aws.SubResourceHint
+open class AppSyncParameters extends formae.SubResource {
+    graphQLOperation: String
+}
+
+@aws.SubResourceHint
+open class RunCommandTarget extends formae.SubResource {
+    key: String
+    values: Listing<String>
+}
+
+@aws.SubResourceHint
+open class RunCommandParameters extends formae.SubResource {
+    runCommandTargets: Listing<RunCommandTarget>
+}
+
+@aws.SubResourceHint
+open class BatchArrayProperties extends formae.SubResource {
+    size: Int?
+}
+
+@aws.SubResourceHint
+open class BatchRetryStrategy extends formae.SubResource {
+    attempts: Int?
+}
+
+@aws.SubResourceHint
+open class BatchParameters extends formae.SubResource {
+    jobDefinition: String
+    jobName: String
+    arrayProperties: BatchArrayProperties?
+    retryStrategy: BatchRetryStrategy?
+}
+
+@aws.SubResourceHint
+open class AwsVpcConfiguration extends formae.SubResource {
+    subnets: Listing<String|formae.Resolvable>
+    securityGroups: Listing<String|formae.Resolvable>?
+    assignPublicIp: String?
+}
+
+@aws.SubResourceHint
+open class NetworkConfiguration extends formae.SubResource {
+    awsVpcConfiguration: AwsVpcConfiguration?
+}
+
+@aws.SubResourceHint
+open class CapacityProviderStrategyItem extends formae.SubResource {
+    capacityProvider: String
+    base: Int?
+    weight: Int?
+}
+
+@aws.SubResourceHint
+open class PlacementStrategy extends formae.SubResource {
+    field: String?
+    type: String?
+}
+
+@aws.SubResourceHint
+open class PlacementConstraint extends formae.SubResource {
+    type: String?
+    expression: String?
+}
+
+@aws.SubResourceHint
+open class EcsParameters extends formae.SubResource {
+    taskDefinitionArn: String|formae.Resolvable
+    taskCount: Int?
+    launchType: String?
+    platformVersion: String?
+    group: String?
+    enableECSManagedTags: Boolean?
+    enableExecuteCommand: Boolean?
+    propagateTags: String?
+    referenceId: String?
+    networkConfiguration: NetworkConfiguration?
+    capacityProviderStrategy: Listing<CapacityProviderStrategyItem>?
+    // NOTE: CloudControl names this property "PlacementStrategies" (plural).
+    placementStrategies: Listing<PlacementStrategy>?
+    placementConstraints: Listing<PlacementConstraint>?
+    tagList: Listing<aws.Tag>?
+}
+
+@aws.SubResourceHint
+open class Target extends formae.SubResource {
+    id: String
+    arn: String|formae.Resolvable
+    roleArn: (String|formae.Resolvable)?
+    input: String?
+    inputPath: String?
+    inputTransformer: InputTransformer?
+    retryPolicy: RetryPolicy?
+    deadLetterConfig: DeadLetterConfig?
+    sqsParameters: SqsParameters?
+    kinesisParameters: KinesisParameters?
+    httpParameters: HttpParameters?
+    redshiftDataParameters: RedshiftDataParameters?
+    sageMakerPipelineParameters: SageMakerPipelineParameters?
+    appSyncParameters: AppSyncParameters?
+    runCommandParameters: RunCommandParameters?
+    batchParameters: BatchParameters?
+    ecsParameters: EcsParameters?
+}
+
+@aws.ResourceHint {
+    type = module.type
+    identifier = "Arn"
+    discoverable = true
+}
+open class Rule extends formae.Resource {
+
+    @aws.FieldHint { createOnly = true }
+    name: String
+
+    @aws.FieldHint
+    description: String?
+
+    @aws.FieldHint { createOnly = true }
+    eventBusName: (String|formae.Resolvable)?
+
+    @aws.FieldHint
+    eventPattern: Dynamic?
+
+    @aws.FieldHint
+    scheduleExpression: String?
+
+    @aws.FieldHint
+    state: String?
+
+    @aws.FieldHint
+    roleArn: (String|formae.Resolvable)?
+
+    @aws.FieldHint {
+        updateMethod = "EntitySet"
+        indexField = "Id"
+    }
+    targets: Listing<Target>?
+
+    @aws.FieldHint {
+        updateMethod = "EntitySet"
+        indexField = "Key"
+    }
+    tags: Listing<aws.Tag>?
+
+    local parent = this
+
+    hidden res: RuleResolvable = new {
+        label = parent.label
+        stack = parent.stack?.label
+    }
+}

--- a/schema/pkl/events/rule.pkl
+++ b/schema/pkl/events/rule.pkl
@@ -200,7 +200,7 @@ open class Rule extends formae.Resource {
     @aws.FieldHint { createOnly = true }
     eventBusName: (String|formae.Resolvable)?
 
-    @aws.FieldHint
+    @aws.FieldHint { updateMethod = "Atomic" }
     eventPattern: Dynamic?
 
     @aws.FieldHint

--- a/schema/pkl/events/rule.pkl
+++ b/schema/pkl/events/rule.pkl
@@ -188,6 +188,11 @@ open class Target extends formae.SubResource {
     type = module.type
     identifier = "Arn"
     discoverable = true
+    parent = "AWS::Events::EventBus"
+    listParam = new formae.ListProperty {
+        parentProperty = "Name"
+        listParameter = "EventBusName"
+    }
 }
 open class Rule extends formae.Resource {
 

--- a/scripts/ci/clean-environment.sh
+++ b/scripts/ci/clean-environment.sh
@@ -736,6 +736,53 @@ aws logs describe-log-groups --region "$REGION" --log-group-name-prefix "/formae
     fi
 done
 
+# ============================================================================
+# EventBridge (events) Resources (regional)
+# ============================================================================
+# The events conformance fixtures create custom event buses, archives, and
+# rules (all named with the $FORMAE_PREFIX). Deletion order is strict: an
+# archive pins its source bus and a rule pins its bus, while a rule's targets
+# pin the rule. So tear down archives and rules (targets first) before the
+# buses. The default bus is never deleted — only test-prefixed rules on it are.
+
+# Collect test event buses once (used for both rule iteration and bus deletion).
+EVENTS_TEST_BUSES=()
+while IFS= read -r bus_name; do
+    [[ -n "$bus_name" && "$bus_name" == *"$FORMAE_PREFIX"* ]] && EVENTS_TEST_BUSES+=("$bus_name")
+done < <(aws events list-event-buses --region "$REGION" --query "EventBuses[].Name" --output text 2>/dev/null | tr '\t' '\n')
+
+# Delete archives first (an archive pins its source event bus).
+echo "Cleaning EventBridge test archives..."
+aws events list-archives --region "$REGION" \
+    --query "Archives[?contains(ArchiveName, '$FORMAE_PREFIX')].ArchiveName" --output text 2>/dev/null | tr '\t' '\n' | while read -r arch; do
+    if [[ -n "$arch" ]]; then
+        echo "  Deleting EventBridge archive: $arch"
+        aws events delete-archive --archive-name "$arch" --region "$REGION" 2>/dev/null || true
+    fi
+done
+
+# Delete rules (removing their targets first) on each test bus AND the default
+# bus — a rule that still has targets cannot be deleted.
+echo "Cleaning EventBridge test rules..."
+for bus_name in "${EVENTS_TEST_BUSES[@]}" default; do
+    aws events list-rules --event-bus-name "$bus_name" --region "$REGION" \
+        --query "Rules[?contains(Name, '$FORMAE_PREFIX')].Name" --output text 2>/dev/null | tr '\t' '\n' | while read -r rule_name; do
+        if [[ -n "$rule_name" ]]; then
+            echo "  Deleting EventBridge rule: $rule_name (bus: $bus_name)"
+            target_ids=$(aws events list-targets-by-rule --rule "$rule_name" --event-bus-name "$bus_name" --region "$REGION" --query "Targets[].Id" --output text 2>/dev/null | tr '\t' ' ')
+            [[ -n "$target_ids" ]] && aws events remove-targets --rule "$rule_name" --event-bus-name "$bus_name" --ids $target_ids --force --region "$REGION" 2>/dev/null || true
+            aws events delete-rule --name "$rule_name" --event-bus-name "$bus_name" --region "$REGION" 2>/dev/null || true
+        fi
+    done
+done
+
+# Delete the test event buses (after their archives and rules are gone).
+echo "Cleaning EventBridge test event buses..."
+for bus_name in "${EVENTS_TEST_BUSES[@]}"; do
+    echo "  Deleting EventBridge event bus: $bus_name"
+    aws events delete-event-bus --name "$bus_name" --region "$REGION" 2>/dev/null || true
+done
+
 # 23a. Delete EC2 flow logs with test prefix (before VPCs)
 echo "Cleaning EC2 test flow logs..."
 aws ec2 describe-flow-logs --region "$REGION" \

--- a/testdata/events-archive-update.pkl
+++ b/testdata/events-archive-update.pkl
@@ -1,0 +1,39 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/events/eventbus.pkl"
+import "@aws/events/archive.pkl"
+
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local stackName = "plugin-sdk-test-events-archive-\(testRunID)"
+
+local eventBus = new eventbus.EventBus {
+  label = "plugin-sdk-test-archive-bus"
+  name = "formae-plugin-sdk-test-archive-bus-\(testRunID)"
+}
+
+local testArchive = new archive.Archive {
+  label = "plugin-sdk-test-archive"
+  archiveName = "formae-plugin-sdk-test-archive-\(testRunID)"
+  sourceArn = eventBus.res.arn
+  description = "formae plugin sdk test archive (updated)"
+  retentionDays = 3
+  eventPattern = new Dynamic {
+    source = new Listing { "formae.plugin.sdk.test" }
+  }
+}
+
+forma {
+  new formae.Stack { label = stackName; description = "Plugin SDK test for EventBridge Archive" }
+  new formae.Target { label = "aws-target"; config = new aws.Config { region = "us-east-1" } }
+  eventBus
+  testArchive
+}

--- a/testdata/events-archive.pkl
+++ b/testdata/events-archive.pkl
@@ -1,0 +1,39 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/events/eventbus.pkl"
+import "@aws/events/archive.pkl"
+
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local stackName = "plugin-sdk-test-events-archive-\(testRunID)"
+
+local eventBus = new eventbus.EventBus {
+  label = "plugin-sdk-test-archive-bus"
+  name = "formae-plugin-sdk-test-archive-bus-\(testRunID)"
+}
+
+local testArchive = new archive.Archive {
+  label = "plugin-sdk-test-archive"
+  archiveName = "formae-plugin-sdk-test-archive-\(testRunID)"
+  sourceArn = eventBus.res.arn
+  description = "formae plugin sdk test archive"
+  retentionDays = 1
+  eventPattern = new Dynamic {
+    source = new Listing { "formae.plugin.sdk.test" }
+  }
+}
+
+forma {
+  new formae.Stack { label = stackName; description = "Plugin SDK test for EventBridge Archive" }
+  new formae.Target { label = "aws-target"; config = new aws.Config { region = "us-east-1" } }
+  eventBus
+  testArchive
+}

--- a/testdata/events-eventbus-update.pkl
+++ b/testdata/events-eventbus-update.pkl
@@ -1,0 +1,30 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/events/eventbus.pkl"
+
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local stackName = "plugin-sdk-test-events-eventbus-\(testRunID)"
+
+local eventBus = new eventbus.EventBus {
+  label = "plugin-sdk-test-eventbus"
+  name = "formae-plugin-sdk-test-bus-\(testRunID)"
+  description = "formae plugin sdk test bus (updated)"
+  tags {
+    new { key = "Environment"; value = "updated" }
+  }
+}
+
+forma {
+  new formae.Stack { label = stackName; description = "Plugin SDK test for EventBridge EventBus" }
+  new formae.Target { label = "aws-target"; config = new aws.Config { region = "us-east-1" } }
+  eventBus
+}

--- a/testdata/events-eventbus.pkl
+++ b/testdata/events-eventbus.pkl
@@ -1,0 +1,39 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/events/eventbus.pkl"
+
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local stackName = "plugin-sdk-test-events-eventbus-\(testRunID)"
+
+local eventBus = new eventbus.EventBus {
+  label = "plugin-sdk-test-eventbus"
+  name = "formae-plugin-sdk-test-bus-\(testRunID)"
+  description = "formae plugin sdk test bus"
+  policy = new Dynamic {
+    Version = "2012-10-17"
+    Statement = new Listing {
+      new Dynamic {
+        Sid = "AllowPutEvents"
+        Effect = "Allow"
+        Principal = new Dynamic { AWS = "*" }
+        Action = "events:PutEvents"
+        Resource = eventBus.res.arn
+      }
+    }
+  }
+}
+
+forma {
+  new formae.Stack { label = stackName; description = "Plugin SDK test for EventBridge EventBus" }
+  new formae.Target { label = "aws-target"; config = new aws.Config { region = "us-east-1" } }
+  eventBus
+}

--- a/testdata/events-eventbus.pkl
+++ b/testdata/events-eventbus.pkl
@@ -18,18 +18,6 @@ local eventBus = new eventbus.EventBus {
   label = "plugin-sdk-test-eventbus"
   name = "formae-plugin-sdk-test-bus-\(testRunID)"
   description = "formae plugin sdk test bus"
-  policy = new Dynamic {
-    Version = "2012-10-17"
-    Statement = new Listing {
-      new Dynamic {
-        Sid = "AllowPutEvents"
-        Effect = "Allow"
-        Principal = new Dynamic { AWS = "*" }
-        Action = "events:PutEvents"
-        Resource = eventBus.res.arn
-      }
-    }
-  }
 }
 
 forma {

--- a/testdata/events-rule-update.pkl
+++ b/testdata/events-rule-update.pkl
@@ -1,0 +1,64 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/events/eventbus.pkl"
+import "@aws/events/rule.pkl"
+import "@aws/sqs/queue.pkl"
+
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local stackName = "plugin-sdk-test-events-rule-\(testRunID)"
+
+local eventBus = new eventbus.EventBus {
+  label = "plugin-sdk-test-rule-bus"
+  name = "formae-plugin-sdk-test-rule-bus-\(testRunID)"
+}
+
+local targetQueue = new queue.Queue {
+  label = "plugin-sdk-test-rule-queue"
+  queueName = "formae-plugin-sdk-test-rule-queue-\(testRunID)"
+}
+
+local secondQueue = new queue.Queue {
+  label = "plugin-sdk-test-rule-queue-2"
+  queueName = "formae-plugin-sdk-test-rule-queue2-\(testRunID)"
+}
+
+local testRule = new rule.Rule {
+  label = "plugin-sdk-test-rule"
+  name = "formae-plugin-sdk-test-rule-\(testRunID)"
+  eventBusName = eventBus.res.name
+  description = "formae plugin sdk test rule (updated)"
+  eventPattern = new Dynamic {
+    source = new Listing { "formae.plugin.sdk.test.updated" }
+  }
+  state = "ENABLED"
+  targets {
+    new {
+      id = "sqs-target"
+      arn = targetQueue.res.arn
+      input = "{\"hello\":\"updated\"}"
+    }
+    new {
+      id = "sqs-target-2"
+      arn = secondQueue.res.arn
+      input = "{\"second\":\"target\"}"
+    }
+  }
+}
+
+forma {
+  new formae.Stack { label = stackName; description = "Plugin SDK test for EventBridge Rule" }
+  new formae.Target { label = "aws-target"; config = new aws.Config { region = "us-east-1" } }
+  eventBus
+  targetQueue
+  secondQueue
+  testRule
+}

--- a/testdata/events-rule.pkl
+++ b/testdata/events-rule.pkl
@@ -1,0 +1,53 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/events/eventbus.pkl"
+import "@aws/events/rule.pkl"
+import "@aws/sqs/queue.pkl"
+
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local stackName = "plugin-sdk-test-events-rule-\(testRunID)"
+
+local eventBus = new eventbus.EventBus {
+  label = "plugin-sdk-test-rule-bus"
+  name = "formae-plugin-sdk-test-rule-bus-\(testRunID)"
+}
+
+local targetQueue = new queue.Queue {
+  label = "plugin-sdk-test-rule-queue"
+  queueName = "formae-plugin-sdk-test-rule-queue-\(testRunID)"
+}
+
+local testRule = new rule.Rule {
+  label = "plugin-sdk-test-rule"
+  name = "formae-plugin-sdk-test-rule-\(testRunID)"
+  eventBusName = eventBus.res.name
+  description = "formae plugin sdk test rule"
+  eventPattern = new Dynamic {
+    source = new Listing { "formae.plugin.sdk.test" }
+  }
+  state = "ENABLED"
+  targets {
+    new {
+      id = "sqs-target"
+      arn = targetQueue.res.arn
+      input = "{\"hello\":\"world\"}"
+    }
+  }
+}
+
+forma {
+  new formae.Stack { label = stackName; description = "Plugin SDK test for EventBridge Rule" }
+  new formae.Target { label = "aws-target"; config = new aws.Config { region = "us-east-1" } }
+  eventBus
+  targetQueue
+  testRule
+}


### PR DESCRIPTION
Adds an `events/` service to the AWS plugin: `AWS::Events::EventBus`, `AWS::Events::Archive`, and `AWS::Events::Rule` (full-fidelity targets), all CloudControl-backed (no Go provisioner). EventBus, Archive, and Rule each expose an `Arn` resolvable; the EventBus `Arn` lets consumers reference the bus (e.g. an `events:PutEvents` IAM statement) without hand-building the ARN from region+account.

Closes PLA-84.

## What's in it

- `schema/pkl/events/eventbus.pkl` — `EventBus` (`identifier = Name`) + `Arn`/`Name` resolvable.
- `schema/pkl/events/archive.pkl` — `Archive` (`identifier = ArchiveName`); `sourceArn` wires to `eventBus.res.arn`.
- `schema/pkl/events/rule.pkl` — `Rule` (`identifier = Arn`) with the complete CloudControl `Target` sub-resource tree (~22 typed sub-resource classes) + `Arn`/`Name` resolvable.
- Six conformance fixtures (`testdata/events-*.pkl`, create + `-update` per resource).

## Design choices (stricter than raw CloudControl, on purpose)

- **Name required** on all three (CloudControl marks `Rule.Name`/`Archive.ArchiveName` optional) — eliminates the auto-named-identity-before-first-Read edge case in v1. Auto-naming deferred.
- **`Rule.eventBusName` is createOnly** — a rule's bus membership is encoded in its ARN, so moving buses is a replace, not an in-place update.
- **`Rule.targets`: `EntitySet` / `indexField = "Id"`** — EventBridge target identity is `Id`.
- **`updateMethod = "Atomic"`** on the `Dynamic` JSON-blob fields (`eventPattern`, bus `policy`) — opaque single-value documents replace wholesale (matches `iam/role.pkl`'s `assumeRolePolicyDocument`).
- **`Rule` is modeled as a child of `AWS::Events::EventBus`** (`parent` + `listParam` on `EventBusName`) so custom-bus rules are discoverable per-bus (CloudControl's Rule list is bus-scoped). Precedent: lambda `Permission` → `Function`.

## Validation

- **Local:** `make build`, `make test-unit`, `make lint`, `make verify-schema`, `pkl eval formae-plugin.pkl` — all green. No Go / `go.mod` / `minFormaeVersion` change.
- **Conformance (`debug-conformance`, real AWS):** `events-eventbus`, `events-archive`, `events-rule` — all green (CRUD + discovery) on commit `77891b7`. Proves: the `Arn` resolvable as a cross-resource input (Archive `sourceArn = bus.res.arn`); Rule identity by the returned `Arn` (create→read→update→delete addressed by ARN); the `targets` `EntitySet`/`Id` update round-trips (update modifies one target's input and adds a second); and per-bus Rule discovery. The final commit (`9ad04cc`, constraining `Rule.state` to a literal enum union) is a non-behavioral input-validation tightening — the conformance fixtures already use a valid member (`ENABLED`) — re-validated locally via `pkl eval` + `verify-schema` + `build`.

## Deferred (v1 scope)

- Per-service Target parameter objects (`EcsParameters`, `BatchParameters`, `RedshiftDataParameters`, `SageMakerPipelineParameters`, `AppSyncParameters`, `RunCommandParameters`, `HttpParameters`, `KinesisParameters`) are typed and statically validated, but not runtime-conformance-tested (would need live ECS/Batch/etc.). `hasProviderDefault`/enum tuning for them is observe-first follow-up.
- The create fixture exercises the infra-free Target fields at runtime via the update path; `InputTransformer`/`RetryPolicy`/`DeadLetterConfig` round-trip remains static-validation-only.
- Default-bus Rule discovery is transitively dependent on the default bus being discovered as an EventBus; v1 has no default-bus fixture (only custom-bus is exercised).
- Auto-named Rule/Archive; `AWS::Scheduler::Schedule` (separate service).