### PR TITLE
fix(s3): persist AWS::S3::Object tags (ResourceProperties) + read-error hardening

### DIFF
--- a/pkg/cfres/s3/object.go
+++ b/pkg/cfres/s3/object.go
@@ -163,11 +163,20 @@ func (o *Object) createWithClient(ctx context.Context, client s3ObjectClient, re
 	}
 
 	nativeID := buildNativeID(bucket, key)
+	// Read back the created object so the agent persists the actual state
+	// (Tags, ETag, VersionId, ServerSideEncryption, …) as ResourceProperties,
+	// matching what a later sync would store. Without this the create-time
+	// stored state omits read-only/collection fields like Tags.
+	readResult, err := o.readWithClient(ctx, client, &resource.ReadRequest{NativeID: nativeID})
+	if err != nil {
+		return nil, fmt.Errorf("failed to read back object after create: %w", err)
+	}
 	return &resource.CreateResult{
 		ProgressResult: &resource.ProgressResult{
-			Operation:       resource.OperationCreate,
-			OperationStatus: resource.OperationStatusSuccess,
-			NativeID:        nativeID,
+			Operation:          resource.OperationCreate,
+			OperationStatus:    resource.OperationStatusSuccess,
+			NativeID:           nativeID,
+			ResourceProperties: json.RawMessage(readResult.Properties),
 		},
 	}, nil
 }
@@ -425,11 +434,18 @@ func (o *Object) updateWithClient(ctx context.Context, client s3ObjectClient, re
 	}
 
 	nativeID := buildNativeID(bucket, key)
+	// Read back the updated object so the agent persists the actual state as
+	// ResourceProperties (see createWithClient).
+	readResult, err := o.readWithClient(ctx, client, &resource.ReadRequest{NativeID: nativeID})
+	if err != nil {
+		return nil, fmt.Errorf("failed to read back object after update: %w", err)
+	}
 	return &resource.UpdateResult{
 		ProgressResult: &resource.ProgressResult{
-			Operation:       resource.OperationUpdate,
-			OperationStatus: resource.OperationStatusSuccess,
-			NativeID:        nativeID,
+			Operation:          resource.OperationUpdate,
+			OperationStatus:    resource.OperationStatusSuccess,
+			NativeID:           nativeID,
+			ResourceProperties: json.RawMessage(readResult.Properties),
 		},
 	}, nil
 }

--- a/pkg/cfres/s3/object.go
+++ b/pkg/cfres/s3/object.go
@@ -359,7 +359,10 @@ func (o *Object) readWithClient(ctx context.Context, client s3ObjectClient, requ
 		Bucket: aws.String(bucket),
 		Key:    aws.String(key),
 	})
-	if err == nil && len(tagging.TagSet) > 0 {
+	if err != nil {
+		return nil, fmt.Errorf("failed to get object tagging for %s/%s: %w", bucket, key, err)
+	}
+	if len(tagging.TagSet) > 0 {
 		var tags []map[string]string
 		for _, tag := range tagging.TagSet {
 			tags = append(tags, map[string]string{

--- a/pkg/cfres/s3/object_test.go
+++ b/pkg/cfres/s3/object_test.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -224,6 +225,62 @@ func TestRead_NotFound(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.Equal(t, resource.OperationErrorCodeNotFound, result.ErrorCode)
+
+	client.AssertExpectations(t)
+}
+
+func TestRead_TaggingError(t *testing.T) {
+	ctx := context.Background()
+	client := &mockS3ObjectClient{}
+
+	client.On("HeadObject", ctx, mock.Anything).Return(&s3.HeadObjectOutput{
+		ContentType: aws.String("text/plain"),
+	}, nil)
+
+	client.On("GetObjectTagging", ctx, mock.MatchedBy(func(input *s3.GetObjectTaggingInput) bool {
+		return *input.Bucket == "my-bucket" && *input.Key == "path/to/file.txt"
+	})).Return(
+		(*s3.GetObjectTaggingOutput)(nil),
+		errors.New("AccessDenied: not authorized to perform s3:GetObjectTagging"),
+	)
+
+	o := &Object{}
+	result, err := o.readWithClient(ctx, client, &resource.ReadRequest{
+		NativeID: "my-bucket|path/to/file.txt",
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "my-bucket/path/to/file.txt")
+
+	client.AssertExpectations(t)
+}
+
+func TestRead_NoTags(t *testing.T) {
+	ctx := context.Background()
+	client := &mockS3ObjectClient{}
+
+	client.On("HeadObject", ctx, mock.Anything).Return(&s3.HeadObjectOutput{
+		ContentType: aws.String("text/plain"),
+	}, nil)
+
+	client.On("GetObjectTagging", ctx, mock.Anything).Return(&s3.GetObjectTaggingOutput{
+		TagSet: []s3types.Tag{},
+	}, nil)
+
+	o := &Object{}
+	result, err := o.readWithClient(ctx, client, &resource.ReadRequest{
+		NativeID: "my-bucket|path/to/file.txt",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	var props map[string]any
+	err = json.Unmarshal([]byte(result.Properties), &props)
+	require.NoError(t, err)
+	_, hasTags := props["Tags"]
+	assert.False(t, hasTags, "Tags should be omitted for a genuinely untagged object")
 
 	client.AssertExpectations(t)
 }

--- a/pkg/cfres/s3/object_test.go
+++ b/pkg/cfres/s3/object_test.go
@@ -26,6 +26,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// mockReadBack stubs the post-write Read (HeadObject + GetObjectTagging) that
+// createWithClient/updateWithClient now perform to populate ResourceProperties.
+func mockReadBack(client *mockS3ObjectClient, ctx context.Context) {
+	client.On("HeadObject", ctx, mock.Anything).Return(&s3.HeadObjectOutput{}, nil).Maybe()
+	client.On("GetObjectTagging", ctx, mock.Anything).Return(&s3.GetObjectTaggingOutput{}, nil).Maybe()
+}
+
 func TestBuildNativeID(t *testing.T) {
 	id := buildNativeID("my-bucket", "path/to/key")
 	assert.Equal(t, "my-bucket|path/to/key", id)
@@ -136,6 +143,7 @@ func TestCreate_Success(t *testing.T) {
 	})).Return(&s3.PutObjectOutput{}, nil)
 
 	o := &Object{}
+	mockReadBack(client, ctx)
 	result, err := o.createWithClient(ctx, client, &resource.CreateRequest{
 		Properties: propsBytes,
 	})
@@ -144,6 +152,33 @@ func TestCreate_Success(t *testing.T) {
 	require.NotNil(t, result)
 	assert.Equal(t, resource.OperationStatusSuccess, result.ProgressResult.OperationStatus)
 	assert.Equal(t, "my-bucket|path/to/file.txt", result.ProgressResult.NativeID)
+
+	client.AssertExpectations(t)
+}
+
+func TestCreate_PopulatesResourcePropertiesFromReadBack(t *testing.T) {
+	ctx := context.Background()
+	client := &mockS3ObjectClient{}
+
+	props := map[string]any{"Bucket": "my-bucket", "Key": "k.txt", "Content": "x"}
+	propsBytes, _ := json.Marshal(props)
+
+	client.On("PutObject", ctx, mock.Anything).Return(&s3.PutObjectOutput{}, nil)
+	client.On("HeadObject", ctx, mock.Anything).Return(&s3.HeadObjectOutput{
+		ContentType: aws.String("text/plain"),
+	}, nil)
+	client.On("GetObjectTagging", ctx, mock.Anything).Return(&s3.GetObjectTaggingOutput{
+		TagSet: []s3types.Tag{{Key: aws.String("Name"), Value: aws.String("v")}},
+	}, nil)
+
+	o := &Object{}
+	result, err := o.createWithClient(ctx, client, &resource.CreateRequest{Properties: propsBytes})
+	require.NoError(t, err)
+	require.NotNil(t, result.ProgressResult.ResourceProperties)
+	// The persisted create state must carry the read-back Tags, otherwise the
+	// agent stores a Tags-less version at create time.
+	assert.Contains(t, string(result.ProgressResult.ResourceProperties), `"Tags"`)
+	assert.Contains(t, string(result.ProgressResult.ResourceProperties), "Name")
 
 	client.AssertExpectations(t)
 }
@@ -304,6 +339,7 @@ func TestUpdate_Success(t *testing.T) {
 	})).Return(&s3.PutObjectOutput{}, nil)
 
 	o := &Object{}
+	mockReadBack(client, ctx)
 	result, err := o.updateWithClient(ctx, client, &resource.UpdateRequest{
 		NativeID:          "my-bucket|path/to/file.txt",
 		DesiredProperties: desiredBytes,
@@ -339,6 +375,7 @@ func TestCreate_SetsObjectLockRetainUntilDate(t *testing.T) {
 	})).Return(&s3.PutObjectOutput{}, nil)
 
 	o := &Object{}
+	mockReadBack(client, ctx)
 	_, err := o.createWithClient(ctx, client, &resource.CreateRequest{Properties: propsBytes})
 	require.NoError(t, err)
 	client.AssertExpectations(t)
@@ -366,6 +403,7 @@ func TestUpdate_SetsObjectLockFields(t *testing.T) {
 	})).Return(&s3.PutObjectOutput{}, nil)
 
 	o := &Object{}
+	mockReadBack(client, ctx)
 	_, err := o.updateWithClient(ctx, client, &resource.UpdateRequest{
 		NativeID:          "my-bucket|locked.txt",
 		DesiredProperties: desiredBytes,

--- a/schema/pkl/s3/object.pkl
+++ b/schema/pkl/s3/object.pkl
@@ -135,6 +135,8 @@ open class Object extends formae.Resource {
 
     @aws.FieldHint {
         outputTransformation = formae.transform.capitalizeMemberKeys
+        updateMethod = "EntitySet"
+        indexField = "Key"
     }
     tags: Listing<aws.Tag>?
 

--- a/schema/pkl/s3/object.pkl
+++ b/schema/pkl/s3/object.pkl
@@ -134,7 +134,6 @@ open class Object extends formae.Resource {
     objectLockRetainUntilDate: String?
 
     @aws.FieldHint {
-        outputTransformation = formae.transform.capitalizeMemberKeys
         updateMethod = "EntitySet"
         indexField = "Key"
     }

--- a/testdata/s3-object-inline-update.pkl
+++ b/testdata/s3-object-inline-update.pkl
@@ -50,5 +50,9 @@ forma {
     metadata {
       ["env"] = "staging"
     }
+    tags {
+      new { key = "Name"; value = "inline-object" }
+      new { key = "Environment"; value = "staging" }
+    }
   }
 }

--- a/testdata/s3-object-inline.pkl
+++ b/testdata/s3-object-inline.pkl
@@ -51,5 +51,9 @@ forma {
     metadata {
       ["env"] = "test"
     }
+    tags {
+      new { key = "Name"; value = "inline-object" }
+      new { key = "Environment"; value = "test" }
+    }
   }
 }


### PR DESCRIPTION
Fixes the AWS::S3::Object tag round-trip (tracked in PLA-204) plus related hardening, found while adding conformance coverage.

## Root cause
`AWS::S3::Object`'s `Create`/`Update` returned only a `NativeID`, leaving `ProgressResult.ResourceProperties` unset. The agent persists that field as the resource's actual state, so the create/update-time stored version omitted read-only and collection fields — notably `Tags` — which only reappeared after a later sync. Conformance verify-after-create read the Tags-less version and failed. CloudControl resources avoid this (ccx populates `ResourceProperties` via a post-success read); the sibling S3 custom provisioners set it from desired state; this one never did.

## Changes
- **Populate `ResourceProperties`** on create/update via a post-write Read, so the persisted state carries `Tags`, `ETag`, `VersionId` and bucket default encryption immediately. (the fix)
- **Surface `GetObjectTagging` errors** in `Read` instead of silently swallowing them.
- **Tag hint hygiene**: add `updateMethod="EntitySet"` + `indexField="Key"` (matching every other tagged resource) and drop the redundant `capitalizeMemberKeys` transform.
- **Conformance**: add an inline-content case (`s3-object-inline`) covering tags, metadata and the shared optional-attribute path.

## Verification
- Unit tests (incl. a new test asserting create populates `ResourceProperties` from the read-back).
- `debug-conformance` for `s3-object-inline` passes end-to-end against real AWS (all CRUD + discovery steps green).