### PR TITLE
feat(schema): tag OIDC clientSecret + ECS service-config fields requiredOnUpdate

### DIFF
--- a/schema/pkl/ec2/verifiedaccesstrustprovider.pkl
+++ b/schema/pkl/ec2/verifiedaccesstrustprovider.pkl
@@ -23,7 +23,7 @@ open class OidcOptions extends formae.SubResource {
     authorizationEndpoint: (String|formae.Resolvable)?
     clientId: (String|formae.Resolvable)?
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{writeOnly = true; requiredOnUpdate = true}
     clientSecret: (String|formae.Resolvable)?
 
     issuer: (String|formae.Resolvable)?

--- a/schema/pkl/ecs/service.pkl
+++ b/schema/pkl/ecs/service.pkl
@@ -304,7 +304,7 @@ open class Service extends formae.Resource {
     @aws.FieldHint{createOnly = true}
     schedulingStrategy: SchedulingStrategy?
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{writeOnly = true; requiredOnUpdate = true}
     serviceConnectConfiguration: ServiceConnectConfiguration?
 
     @aws.FieldHint{createOnly = true}
@@ -323,7 +323,7 @@ open class Service extends formae.Resource {
     @aws.FieldHint
     taskDefinition: (String|formae.Resolvable)?
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{writeOnly = true; requiredOnUpdate = true}
     volumeConfigurations: Listing<VolumeConfiguration>?
 
     // No authoritative AWS doc, but the CC update-side semantics (empty

--- a/schema/pkl/elasticloadbalancingv2/listener.pkl
+++ b/schema/pkl/elasticloadbalancingv2/listener.pkl
@@ -47,7 +47,7 @@ open class AuthenticateOidcConfig extends formae.SubResource {
     authenticationRequestExtraParams: Mapping<String, Any>?
     authorizationEndpoint: String
     clientId: String
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{writeOnly = true; requiredOnUpdate = true}
     clientSecret: (String|formae.Resolvable)?
     issuer: String
     onUnauthenticatedRequest: String?

--- a/schema/pkl/elasticloadbalancingv2/listenerrule.pkl
+++ b/schema/pkl/elasticloadbalancingv2/listenerrule.pkl
@@ -40,7 +40,7 @@ open class AuthenticateOidcConfig extends formae.SubResource {
     authenticationRequestExtraParams: Mapping<String, Any>?
     authorizationEndpoint: String
     clientId: String
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{writeOnly = true; requiredOnUpdate = true}
     clientSecret: (String|formae.Resolvable)?
     issuer: String
     onUnauthenticatedRequest: String?


### PR DESCRIPTION
## Summary

Tags five `writeOnly` fields with the new `requiredOnUpdate = true` hint, so they are force-resent on every CloudControl update instead of only when changed. These are the fields where AWS rejects or silently reverts the resource if the value is absent from an update:

- **OIDC `clientSecret`** on `ElasticLoadBalancingV2::Listener`, `ElasticLoadBalancingV2::ListenerRule`, and `EC2::VerifiedAccessTrustProvider`. CloudControl returns the secret on Read as a `"REDACTED"` placeholder; any update that carries the OIDC config resubmits that placeholder and the provider rejects it (`AuthenticateOidcConfig` requires `ClientSecret` or `UseExistingClientSecret=true`; `ModifyVerifiedAccessTrustProvider` rejects `REDACTED`).
- **`ECS::Service` `serviceConnectConfiguration` and `volumeConfigurations`.** `UpdateService` treats an omitted block as "clear it" — omitting `serviceConnectConfiguration` on an unrelated update silently disables Service Connect on the new deployment.

Each verdict was confirmed with a live CloudControl `create → update-omitting-the-field → observe` probe (Service Connect and the OIDC secrets fail/revert; KMS rotation period, S3 ACL, VPC endpoint service contributor insights, and ECS cluster Service Connect defaults do not, and are intentionally left untagged).

`requiredOnUpdate` is defined in the formae schema package (0.87.0). Without the matching core change it is inert (the field still force-resends under the legacy `writeOnly` behavior), so this is forward-compatible and safe to merge independently.

Validated with `make verify-schema` (242 modules) and a direct render check that `RequiredOnUpdate` resolves `true`/`false` correctly.