### PR TITLE
feat(s3): structured HttpSource remote source for AWS::S3::Object

### DIFF
--- a/pkg/cfres/s3/httpfetch.go
+++ b/pkg/cfres/s3/httpfetch.go
@@ -1,0 +1,61 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package s3
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+func guardURL(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("invalid source URL")
+	}
+	if u.Scheme != "https" {
+		return fmt.Errorf("source URL must be https")
+	}
+	host := u.Hostname()
+	ips, err := net.LookupIP(host)
+	if err != nil {
+		return fmt.Errorf("cannot resolve source host %q", host)
+	}
+	for _, ip := range ips {
+		if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsPrivate() ||
+			ip.Equal(net.ParseIP("169.254.169.254")) {
+			return fmt.Errorf("source host %q resolves to a disallowed address", host)
+		}
+	}
+	return nil
+}
+
+func newHardenedClient(timeout time.Duration) *http.Client {
+	return &http.Client{
+		Timeout: timeout,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 10 {
+				return fmt.Errorf("too many redirects")
+			}
+			// reject https→non-https downgrade
+			if len(via) > 0 && via[0].URL.Scheme == "https" && req.URL.Scheme != "https" {
+				return fmt.Errorf("refusing redirect to non-https %q", req.URL.Scheme)
+			}
+			if req.URL.Scheme == "https" {
+				if err := guardURL(req.URL.String()); err != nil {
+					return err
+				}
+			}
+			// strip auth + secret headers on host change (belt-and-suspenders)
+			if len(via) > 0 && !strings.EqualFold(req.URL.Host, via[0].URL.Host) {
+				req.Header.Del("Authorization")
+			}
+			return nil
+		},
+	}
+}

--- a/pkg/cfres/s3/httpfetch.go
+++ b/pkg/cfres/s3/httpfetch.go
@@ -31,10 +31,11 @@ var dialIPGuard = func(ip net.IP) error {
 }
 
 // isDisallowedIP reports whether ip is in a range that must not be dialed
-// (loopback, link-local unicast/multicast, private/RFC-1918, IMDS endpoint).
+// (unspecified 0.0.0.0/::, loopback, link-local unicast/multicast,
+// private/RFC-1918, IMDS endpoint).
 func isDisallowedIP(ip net.IP) bool {
-	return ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsPrivate() ||
-		ip.Equal(net.ParseIP("169.254.169.254"))
+	return ip.IsUnspecified() || ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() ||
+		ip.IsPrivate() || ip.Equal(net.ParseIP("169.254.169.254"))
 }
 
 func guardURL(raw string) error {

--- a/pkg/cfres/s3/httpfetch.go
+++ b/pkg/cfres/s3/httpfetch.go
@@ -16,6 +16,9 @@ import (
 // lookupIP is the DNS resolver used by guardURL; overridable in tests.
 var lookupIP = net.LookupIP
 
+// guardURLFn is the URL guard used by fetchHTTPSource; overridable in tests.
+var guardURLFn = guardURL
+
 func guardURL(raw string) error {
 	u, err := url.Parse(raw)
 	if err != nil {

--- a/pkg/cfres/s3/httpfetch.go
+++ b/pkg/cfres/s3/httpfetch.go
@@ -13,6 +13,9 @@ import (
 	"time"
 )
 
+// lookupIP is the DNS resolver used by guardURL; overridable in tests.
+var lookupIP = net.LookupIP
+
 func guardURL(raw string) error {
 	u, err := url.Parse(raw)
 	if err != nil {
@@ -22,7 +25,7 @@ func guardURL(raw string) error {
 		return fmt.Errorf("source URL must be https")
 	}
 	host := u.Hostname()
-	ips, err := net.LookupIP(host)
+	ips, err := lookupIP(host)
 	if err != nil {
 		return fmt.Errorf("cannot resolve source host %q", host)
 	}
@@ -42,16 +45,14 @@ func newHardenedClient(timeout time.Duration) *http.Client {
 			if len(via) >= 10 {
 				return fmt.Errorf("too many redirects")
 			}
-			// reject https→non-https downgrade
-			if len(via) > 0 && via[0].URL.Scheme == "https" && req.URL.Scheme != "https" {
+			// reject any non-https redirect target unconditionally
+			if req.URL.Scheme != "https" {
 				return fmt.Errorf("refusing redirect to non-https %q", req.URL.Scheme)
 			}
-			if req.URL.Scheme == "https" {
-				if err := guardURL(req.URL.String()); err != nil {
-					return err
-				}
+			if err := guardURL(req.URL.String()); err != nil {
+				return err
 			}
-			// strip auth + secret headers on host change (belt-and-suspenders)
+			// strip auth + secret headers on host change (compare against first hop)
 			if len(via) > 0 && !strings.EqualFold(req.URL.Host, via[0].URL.Host) {
 				req.Header.Del("Authorization")
 			}

--- a/pkg/cfres/s3/httpfetch.go
+++ b/pkg/cfres/s3/httpfetch.go
@@ -5,11 +5,13 @@
 package s3
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"
 	"net/url"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -18,6 +20,22 @@ var lookupIP = net.LookupIP
 
 // guardURLFn is the URL guard used by fetchHTTPSource; overridable in tests.
 var guardURLFn = guardURL
+
+// dialIPGuard is called at dial time with the already-resolved IP; overridable
+// in tests that point at loopback httptest servers through fetchHTTPSource.
+var dialIPGuard = func(ip net.IP) error {
+	if isDisallowedIP(ip) {
+		return fmt.Errorf("dial to disallowed address blocked")
+	}
+	return nil
+}
+
+// isDisallowedIP reports whether ip is in a range that must not be dialed
+// (loopback, link-local unicast/multicast, private/RFC-1918, IMDS endpoint).
+func isDisallowedIP(ip net.IP) bool {
+	return ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsPrivate() ||
+		ip.Equal(net.ParseIP("169.254.169.254"))
+}
 
 func guardURL(raw string) error {
 	u, err := url.Parse(raw)
@@ -33,8 +51,7 @@ func guardURL(raw string) error {
 		return fmt.Errorf("cannot resolve source host %q", host)
 	}
 	for _, ip := range ips {
-		if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsPrivate() ||
-			ip.Equal(net.ParseIP("169.254.169.254")) {
+		if isDisallowedIP(ip) {
 			return fmt.Errorf("source host %q resolves to a disallowed address", host)
 		}
 	}
@@ -42,8 +59,31 @@ func guardURL(raw string) error {
 }
 
 func newHardenedClient(timeout time.Duration) *http.Client {
+	// Clone the default transport so we inherit sane defaults (connection
+	// pooling, timeouts, etc.) and only override DialContext.
+	base := http.DefaultTransport.(*http.Transport).Clone()
+	dialer := &net.Dialer{
+		Control: func(network, address string, _ syscall.RawConn) error {
+			host, _, err := net.SplitHostPort(address)
+			if err != nil {
+				return err
+			}
+			ip := net.ParseIP(host)
+			if ip == nil {
+				// address is already resolved at this point; if ParseIP fails
+				// something is very wrong — reject to be safe.
+				return fmt.Errorf("dial address %q is not a valid IP", host)
+			}
+			return dialIPGuard(ip)
+		},
+	}
+	base.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		return dialer.DialContext(ctx, network, addr)
+	}
+
 	return &http.Client{
-		Timeout: timeout,
+		Timeout:   timeout,
+		Transport: base,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if len(via) >= 10 {
 				return fmt.Errorf("too many redirects")
@@ -55,9 +95,13 @@ func newHardenedClient(timeout time.Duration) *http.Client {
 			if err := guardURL(req.URL.String()); err != nil {
 				return err
 			}
-			// strip auth + secret headers on host change (compare against first hop)
+			// strip ALL headers from the original request on host change so that
+			// any secret header (Authorization, X-Api-Key, etc.) is not leaked
+			// to a different host.
 			if len(via) > 0 && !strings.EqualFold(req.URL.Host, via[0].URL.Host) {
-				req.Header.Del("Authorization")
+				for k := range via[0].Header {
+					req.Header.Del(k)
+				}
 			}
 			return nil
 		},

--- a/pkg/cfres/s3/httpfetch_test.go
+++ b/pkg/cfres/s3/httpfetch_test.go
@@ -1,0 +1,69 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package s3
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestGuardURL_RejectsNonHTTPS(t *testing.T) {
+	if err := guardURL("http://example.com/x"); err == nil {
+		t.Fatal("expected http:// to be rejected")
+	}
+}
+func TestGuardURL_RejectsMetadataIP(t *testing.T) {
+	if err := guardURL("https://169.254.169.254/latest/meta-data/"); err == nil {
+		t.Fatal("expected metadata IP to be rejected")
+	}
+}
+func TestGuardURL_RejectsLoopbackAndRFC1918(t *testing.T) {
+	for _, u := range []string{"https://127.0.0.1/x", "https://10.0.0.5/x", "https://192.168.1.1/x"} {
+		if err := guardURL(u); err == nil {
+			t.Fatalf("expected %s to be rejected", u)
+		}
+	}
+}
+func TestHardenedClient_DropsAuthOnHostChange(t *testing.T) {
+	// blob server records whether it saw an Authorization header
+	var sawAuth bool
+	blob := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawAuth = r.Header.Get("Authorization") != ""
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer blob.Close()
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, blob.URL, http.StatusFound) // 302 to a different host:port
+	}))
+	defer api.Close()
+	req, _ := http.NewRequest(http.MethodGet, api.URL, nil)
+	req.Header.Set("Authorization", "Bearer secret")
+	resp, err := newHardenedClient(30 * time.Second).Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if sawAuth {
+		t.Fatal("Authorization leaked to the redirect target")
+	}
+}
+func TestHardenedClient_RejectsDowngradeToHTTP(t *testing.T) {
+	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer httpSrv.Close()
+	tlsSrv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, httpSrv.URL, http.StatusFound) // https -> http
+	}))
+	defer tlsSrv.Close()
+	c := newHardenedClient(30 * time.Second)
+	c.Transport = tlsSrv.Client().Transport // trust the test TLS cert
+	req, _ := http.NewRequest(http.MethodGet, tlsSrv.URL, nil)
+	if _, err := c.Do(req); err == nil {
+		t.Fatal("expected https->http downgrade to be rejected")
+	}
+}

--- a/pkg/cfres/s3/httpfetch_test.go
+++ b/pkg/cfres/s3/httpfetch_test.go
@@ -7,6 +7,8 @@
 package s3
 
 import (
+	"crypto/tls"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -31,22 +33,37 @@ func TestGuardURL_RejectsLoopbackAndRFC1918(t *testing.T) {
 	}
 }
 func TestHardenedClient_DropsAuthOnHostChange(t *testing.T) {
+	// stub DNS so guardURL accepts the httptest TLS servers (which bind to loopback)
+	orig := lookupIP
+	lookupIP = func(host string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("93.184.216.34")}, nil
+	}
+	defer func() { lookupIP = orig }()
+
 	// blob server records whether it saw an Authorization header
 	var sawAuth bool
-	blob := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	blob := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		sawAuth = r.Header.Get("Authorization") != ""
 		_, _ = w.Write([]byte("ok"))
 	}))
 	defer blob.Close()
-	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Redirect(w, r, blob.URL, http.StatusFound) // 302 to a different host:port
+
+	api := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, blob.URL, http.StatusFound) // https→https, different host:port
 	}))
 	defer api.Close()
+
+	client := newHardenedClient(30 * time.Second)
+	// accept self-signed certs from both test servers
+	client.Transport = &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // test-only
+	}
+
 	req, _ := http.NewRequest(http.MethodGet, api.URL, nil)
 	req.Header.Set("Authorization", "Bearer secret")
-	resp, err := newHardenedClient(30 * time.Second).Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("request failed (guard rejected redirect): %v", err)
 	}
 	_ = resp.Body.Close()
 	if sawAuth {

--- a/pkg/cfres/s3/httpfetch_test.go
+++ b/pkg/cfres/s3/httpfetch_test.go
@@ -26,7 +26,7 @@ func TestGuardURL_RejectsMetadataIP(t *testing.T) {
 	}
 }
 func TestGuardURL_RejectsLoopbackAndRFC1918(t *testing.T) {
-	for _, u := range []string{"https://127.0.0.1/x", "https://10.0.0.5/x", "https://192.168.1.1/x"} {
+	for _, u := range []string{"https://127.0.0.1/x", "https://10.0.0.5/x", "https://192.168.1.1/x", "https://0.0.0.0/x", "https://[::]/x"} {
 		if err := guardURL(u); err == nil {
 			t.Fatalf("expected %s to be rejected", u)
 		}

--- a/pkg/cfres/s3/httpfetch_test.go
+++ b/pkg/cfres/s3/httpfetch_test.go
@@ -34,16 +34,17 @@ func TestGuardURL_RejectsLoopbackAndRFC1918(t *testing.T) {
 }
 func TestHardenedClient_DropsAuthOnHostChange(t *testing.T) {
 	// stub DNS so guardURL accepts the httptest TLS servers (which bind to loopback)
-	orig := lookupIP
+	origLookup := lookupIP
 	lookupIP = func(host string) ([]net.IP, error) {
 		return []net.IP{net.ParseIP("93.184.216.34")}, nil
 	}
-	defer func() { lookupIP = orig }()
+	defer func() { lookupIP = origLookup }()
 
-	// blob server records whether it saw an Authorization header
-	var sawAuth bool
+	// blob server records whether it saw Authorization or X-Api-Key headers
+	var sawAuth, sawAPIKey bool
 	blob := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		sawAuth = r.Header.Get("Authorization") != ""
+		sawAPIKey = r.Header.Get("X-Api-Key") != ""
 		_, _ = w.Write([]byte("ok"))
 	}))
 	defer blob.Close()
@@ -54,13 +55,17 @@ func TestHardenedClient_DropsAuthOnHostChange(t *testing.T) {
 	defer api.Close()
 
 	client := newHardenedClient(30 * time.Second)
-	// accept self-signed certs from both test servers
+	// Replace transport to accept self-signed test certs. This loses the
+	// DialContext Control hook, but dialIPGuard is not under test here —
+	// header stripping is. lookupIP is already stubbed to return a public IP
+	// so guardURL in CheckRedirect won't reject the loopback hosts.
 	client.Transport = &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // test-only
 	}
 
 	req, _ := http.NewRequest(http.MethodGet, api.URL, nil)
 	req.Header.Set("Authorization", "Bearer secret")
+	req.Header.Set("X-Api-Key", "secret2")
 	resp, err := client.Do(req)
 	if err != nil {
 		t.Fatalf("request failed (guard rejected redirect): %v", err)
@@ -68,6 +73,30 @@ func TestHardenedClient_DropsAuthOnHostChange(t *testing.T) {
 	_ = resp.Body.Close()
 	if sawAuth {
 		t.Fatal("Authorization leaked to the redirect target")
+	}
+	if sawAPIKey {
+		t.Fatal("X-Api-Key leaked to the redirect target")
+	}
+}
+
+func TestHardenedClient_BlocksRebindingDial(t *testing.T) {
+	// Do NOT override dialIPGuard — the point is to prove the Control hook
+	// blocks the actual loopback dial even when guardURL would have been fooled
+	// by a DNS-rebinding attack (pre-dial check saw a public IP; actual TCP
+	// connect goes to 127.0.0.1).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("should not reach here"))
+	}))
+	defer srv.Close()
+
+	// Use newHardenedClient without replacing the transport so the DialContext
+	// Control hook remains active.
+	client := newHardenedClient(30 * time.Second)
+
+	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+	_, err := client.Do(req)
+	if err == nil {
+		t.Fatal("expected dial to loopback to be blocked by dialIPGuard")
 	}
 }
 func TestHardenedClient_RejectsDowngradeToHTTP(t *testing.T) {

--- a/pkg/cfres/s3/object.go
+++ b/pkg/cfres/s3/object.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -68,8 +69,15 @@ func parseNativeID(nativeID string) (bucket, key string, err error) {
 	return parts[0], parts[1], nil
 }
 
+const (
+	maxDownloadBytes    = 256 << 20
+	maxDecompressedBytes = 256 << 20
+	fetchTimeout        = 5 * time.Minute
+)
+
 // resolveBodyWithCloser returns an io.Reader for the object body and a closer function.
 // Exactly one of Content, ContentBase64, or Source may be set. If none is set, returns nil reader.
+// Source may be a plain URL string (legacy) or an HttpSource map with Url/Headers/Extract keys.
 func resolveBodyWithCloser(props map[string]any) (io.Reader, func(), error) {
 	content, hasContent := props["Content"]
 	contentBase64, hasBase64 := props["ContentBase64"]
@@ -102,24 +110,90 @@ func resolveBodyWithCloser(props map[string]any) (io.Reader, func(), error) {
 	}
 
 	if hasSource {
-		sourceStr := source.(string)
-		resp, err := http.Get(sourceStr) //nolint:gosec // Source URL is user-provided infrastructure config
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to fetch source URL %s: %w", sourceStr, err)
+		switch s := source.(type) {
+		case string:
+			return fetchPlainURL(s)
+		case map[string]any:
+			return fetchHTTPSource(s)
+		default:
+			return nil, nil, fmt.Errorf("invalid source type")
 		}
-		defer func() { _ = resp.Body.Close() }()
-		if resp.StatusCode != http.StatusOK {
-			return nil, nil, fmt.Errorf("source URL %s returned status %d", sourceStr, resp.StatusCode)
-		}
-		// Buffer into memory so the SDK can determine Content-Length
-		data, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to read source URL %s: %w", sourceStr, err)
-		}
-		return bytes.NewReader(data), func() {}, nil
 	}
 
 	return nil, func() {}, nil
+}
+
+// fetchPlainURL fetches a URL using a plain http.Get (legacy string-Source path).
+func fetchPlainURL(sourceStr string) (io.Reader, func(), error) {
+	resp, err := http.Get(sourceStr) //nolint:gosec // Source URL is user-provided infrastructure config
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to fetch source URL %s: %w", sourceStr, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, nil, fmt.Errorf("source URL %s returned status %d", sourceStr, resp.StatusCode)
+	}
+	// Buffer into memory so the SDK can determine Content-Length
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to read source URL %s: %w", sourceStr, err)
+	}
+	return bytes.NewReader(data), func() {}, nil
+}
+
+// redactErr strips the URL (including any signed query params or auth tokens)
+// from a *url.Error, returning a sanitised version safe to include in error messages.
+func redactErr(err error) error {
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		return fmt.Errorf("%s request failed: %w", urlErr.Op, urlErr.Err)
+	}
+	return err
+}
+
+// fetchHTTPSource fetches a URL using the hardened HTTP client, optionally adding
+// request headers and extracting a zip member from the response body.
+// Keys follow PascalCase (Url, Headers, Extract) as produced by the PKL schema.
+func fetchHTTPSource(m map[string]any) (io.Reader, func(), error) {
+	rawURL, _ := m["Url"].(string)
+	if err := guardURLFn(rawURL); err != nil {
+		return nil, nil, err
+	}
+	req, err := http.NewRequest(http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	if hdrs, ok := m["Headers"].(map[string]any); ok {
+		for k, v := range hdrs {
+			if vs, ok := v.(string); ok {
+				req.Header.Set(k, vs)
+			}
+		}
+	}
+	resp, err := newHardenedClient(fetchTimeout).Do(req)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to fetch source (host %s): %w", req.URL.Host, redactErr(err))
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		// NEVER include headers or the full URL — status + host only
+		return nil, nil, fmt.Errorf("source fetch returned %d from host %s", resp.StatusCode, req.URL.Host)
+	}
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxDownloadBytes+1))
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed reading source: %w", err)
+	}
+	if int64(len(data)) > maxDownloadBytes {
+		return nil, nil, fmt.Errorf("source exceeds max download size")
+	}
+	if member, ok := m["Extract"].(string); ok && member != "" {
+		out, err := extractZipMember(data, member, maxDecompressedBytes)
+		if err != nil {
+			return nil, nil, err
+		}
+		return bytes.NewReader(out), func() {}, nil
+	}
+	return bytes.NewReader(data), func() {}, nil
 }
 
 func (o *Object) Create(ctx context.Context, request *resource.CreateRequest) (*resource.CreateResult, error) {

--- a/pkg/cfres/s3/object_test.go
+++ b/pkg/cfres/s3/object_test.go
@@ -14,6 +14,9 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -618,4 +621,70 @@ func TestResolveBody_HttpSource_ErrorRedactsHeaders(t *testing.T) {
 	if strings.Contains(err.Error(), "SUPERSECRET") {
 		t.Fatal("error leaked the auth token")
 	}
+}
+
+// TestResolveBody_MutualExclusivity_HttpSource asserts that providing both a
+// Content string and a structured HttpSource (Source map) is rejected. The
+// count>1 guard in resolveBodyWithCloser must treat a Source map as one source,
+// so that mixing it with Content triggers the mutual-exclusion error.
+func TestResolveBody_MutualExclusivity_HttpSource(t *testing.T) {
+	props := map[string]any{
+		"Content": "x",
+		"Source":  map[string]any{"Url": "https://example.com/x"},
+	}
+	if _, _, err := resolveBodyWithCloser(props); err == nil {
+		t.Fatal("expected mutual-exclusion error with Content + Source")
+	}
+}
+
+func objectPKLPath() string {
+	_, filename, _, _ := runtime.Caller(0)
+	// pkg/cfres/s3/ -> (repo root)/schema/pkl/s3/object.pkl
+	root := filepath.Join(filepath.Dir(filename), "..", "..", "..", "schema", "pkl", "s3")
+	return filepath.Join(root, "object.pkl")
+}
+
+// TestSchema_SourceIsWriteOnly asserts that the `source` field in object.pkl
+// carries @aws.FieldHint { writeOnly = true } and does NOT carry
+// requiredOnUpdate = true. The writeOnly annotation tells the agent the field
+// is never returned by Read, preventing phantom-redeploy loops on every sync.
+// requiredOnUpdate must stay absent: S3 does not REDACT the source on read
+// (it simply never returns it), so the agent must not treat an absent source
+// field after a Read as a reason to trigger an update.
+//
+// This is a textual test against the PKL source — the same approach used for
+// ECS attachesTo annotations — because running ExtractSchema requires a live
+// pkl CLI subprocess and network access, making it unsuitable for make test-unit.
+func TestSchema_SourceIsWriteOnly(t *testing.T) {
+	content, err := os.ReadFile(objectPKLPath())
+	if err != nil {
+		t.Fatalf("could not read object.pkl: %v", err)
+	}
+	src := string(content)
+
+	// Find the `source` field declaration and its preceding annotation block.
+	lines := strings.Split(src, "\n")
+	for i, line := range lines {
+		if !strings.Contains(line, "source:") {
+			continue
+		}
+		// Collect annotation lines immediately preceding this field declaration.
+		// They form a block starting with @aws.FieldHint.
+		annotationBlock := ""
+		for j := i - 1; j >= 0; j-- {
+			trimmed := strings.TrimSpace(lines[j])
+			if trimmed == "" {
+				break
+			}
+			annotationBlock = trimmed + "\n" + annotationBlock
+		}
+		if !strings.Contains(annotationBlock, "writeOnly = true") {
+			t.Errorf("source field: expected @aws.FieldHint { writeOnly = true } before source: declaration, got annotation block:\n%s", annotationBlock)
+		}
+		if strings.Contains(annotationBlock, "requiredOnUpdate") {
+			t.Errorf("source field: requiredOnUpdate must not be set on source — it causes phantom-redeploy loops because S3 never returns the source on Read; annotation block:\n%s", annotationBlock)
+		}
+		return
+	}
+	t.Fatal("source: field declaration not found in object.pkl")
 }

--- a/pkg/cfres/s3/object_test.go
+++ b/pkg/cfres/s3/object_test.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -573,9 +574,13 @@ func TestResolveBody_HttpSource_HeadersAndExtract(t *testing.T) {
 	}))
 	defer srv.Close()
 	// Override guardURLFn so the http:// test server is not rejected by the https-only check.
-	orig := guardURLFn
+	origGuard := guardURLFn
 	guardURLFn = func(raw string) error { return nil }
-	defer func() { guardURLFn = orig }()
+	defer func() { guardURLFn = origGuard }()
+	// Override dialIPGuard so the loopback httptest server is not blocked at dial time.
+	origDial := dialIPGuard
+	dialIPGuard = func(ip net.IP) error { return nil }
+	defer func() { dialIPGuard = origDial }()
 	props := map[string]any{"Source": map[string]any{
 		"Url":     srv.URL,
 		"Headers": map[string]any{"Authorization": "Bearer tok"},
@@ -608,9 +613,13 @@ func TestResolveBody_HttpSource_ErrorRedactsHeaders(t *testing.T) {
 	}))
 	defer srv.Close()
 	// Override guardURLFn so the http:// test server is not rejected by the https-only check.
-	orig := guardURLFn
+	origGuard := guardURLFn
 	guardURLFn = func(raw string) error { return nil }
-	defer func() { guardURLFn = orig }()
+	defer func() { guardURLFn = origGuard }()
+	// Override dialIPGuard so the loopback httptest server is not blocked at dial time.
+	origDial := dialIPGuard
+	dialIPGuard = func(ip net.IP) error { return nil }
+	defer func() { dialIPGuard = origDial }()
 	props := map[string]any{"Source": map[string]any{
 		"Url": srv.URL, "Headers": map[string]any{"Authorization": "Bearer SUPERSECRET"},
 	}}

--- a/pkg/cfres/s3/object_test.go
+++ b/pkg/cfres/s3/object_test.go
@@ -14,6 +14,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -559,4 +560,62 @@ func TestList_MissingBucketName(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "BucketName")
+}
+
+func TestResolveBody_HttpSource_HeadersAndExtract(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Write(zipWith(t, map[string]string{"carys-cars.jar": "JAR"})) // reuse Task 4 helper
+	}))
+	defer srv.Close()
+	// Override guardURLFn so the http:// test server is not rejected by the https-only check.
+	orig := guardURLFn
+	guardURLFn = func(raw string) error { return nil }
+	defer func() { guardURLFn = orig }()
+	props := map[string]any{"Source": map[string]any{
+		"Url":     srv.URL,
+		"Headers": map[string]any{"Authorization": "Bearer tok"},
+		"Extract": "carys-cars.jar",
+	}}
+	reader, closer, err := resolveBodyWithCloser(props)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closer()
+	if gotAuth != "Bearer tok" {
+		t.Fatalf("auth header not sent: %q", gotAuth)
+	}
+	b, _ := io.ReadAll(reader)
+	if string(b) != "JAR" {
+		t.Fatalf("got %q", b)
+	}
+}
+
+func TestResolveBody_HttpSource_RejectsHTTP(t *testing.T) {
+	props := map[string]any{"Source": map[string]any{"Url": "http://example.com/x"}}
+	if _, _, err := resolveBodyWithCloser(props); err == nil {
+		t.Fatal("expected http:// rejection")
+	}
+}
+
+func TestResolveBody_HttpSource_ErrorRedactsHeaders(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+	// Override guardURLFn so the http:// test server is not rejected by the https-only check.
+	orig := guardURLFn
+	guardURLFn = func(raw string) error { return nil }
+	defer func() { guardURLFn = orig }()
+	props := map[string]any{"Source": map[string]any{
+		"Url": srv.URL, "Headers": map[string]any{"Authorization": "Bearer SUPERSECRET"},
+	}}
+	_, _, err := resolveBodyWithCloser(props)
+	if err == nil {
+		t.Fatal("expected 403 error")
+	}
+	if strings.Contains(err.Error(), "SUPERSECRET") {
+		t.Fatal("error leaked the auth token")
+	}
 }

--- a/pkg/cfres/s3/ziputil.go
+++ b/pkg/cfres/s3/ziputil.go
@@ -1,0 +1,48 @@
+package s3
+
+import (
+	"archive/zip"
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+)
+
+func extractZipMember(data []byte, member string, maxDecompressed int64) ([]byte, error) {
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return nil, fmt.Errorf("source is not a valid zip archive")
+	}
+	var match *zip.File
+	for _, f := range zr.File {
+		if f.Name != member {
+			continue
+		}
+		if match != nil {
+			return nil, fmt.Errorf("ambiguous: multiple entries named %q", member)
+		}
+		if f.FileInfo().IsDir() {
+			return nil, fmt.Errorf("%q is a directory, not a file", member)
+		}
+		if f.Mode()&os.ModeSymlink != 0 {
+			return nil, fmt.Errorf("%q is a symlink", member)
+		}
+		match = f
+	}
+	if match == nil {
+		return nil, fmt.Errorf("zip member %q not found", member)
+	}
+	rc, err := match.Open()
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rc.Close() }()
+	out, err := io.ReadAll(io.LimitReader(rc, maxDecompressed+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(out)) > maxDecompressed {
+		return nil, fmt.Errorf("zip member %q exceeds decompressed size cap", member)
+	}
+	return out, nil
+}

--- a/pkg/cfres/s3/ziputil_test.go
+++ b/pkg/cfres/s3/ziputil_test.go
@@ -1,0 +1,111 @@
+//go:build unit
+
+package s3
+
+import (
+	"archive/zip"
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+)
+
+func zipWith(t *testing.T, entries map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for name, content := range entries {
+		w, err := zw.Create(name)
+		if err != nil {
+			t.Fatalf("zipWith: Create(%q): %v", name, err)
+		}
+		if _, err := w.Write([]byte(content)); err != nil {
+			t.Fatalf("zipWith: Write(%q): %v", name, err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("zipWith: Close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func TestExtractZipMember_Happy(t *testing.T) {
+	z := zipWith(t, map[string]string{"carys-cars.jar": "JARBYTES"})
+	got, err := extractZipMember(z, "carys-cars.jar", 1<<30)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "JARBYTES" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestExtractZipMember_Missing(t *testing.T) {
+	z := zipWith(t, map[string]string{"other.jar": "x"})
+	if _, err := extractZipMember(z, "carys-cars.jar", 1<<30); err == nil {
+		t.Fatal("expected missing-member error")
+	}
+}
+
+func TestExtractZipMember_Duplicate(t *testing.T) {
+	// Build a zip manually with two entries of the same name.
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for range 2 {
+		w, err := zw.Create("dup")
+		if err != nil {
+			t.Fatalf("Create dup: %v", err)
+		}
+		if _, err := w.Write([]byte("content")); err != nil {
+			t.Fatalf("Write dup: %v", err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	z := buf.Bytes()
+	if _, err := extractZipMember(z, "dup", 1<<30); err == nil {
+		t.Fatal("expected ambiguous-member error")
+	}
+}
+
+func TestExtractZipMember_RejectsDirAndSymlink(t *testing.T) {
+	// Directory entry: name ends with "/"
+	var dirBuf bytes.Buffer
+	zw := zip.NewWriter(&dirBuf)
+	if _, err := zw.Create("adir/"); err != nil {
+		t.Fatalf("Create dir: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if _, err := extractZipMember(dirBuf.Bytes(), "adir/", 1<<30); err == nil {
+		t.Fatal("expected directory-entry error")
+	}
+
+	// Symlink entry: set mode to os.ModeSymlink
+	var symBuf bytes.Buffer
+	zw2 := zip.NewWriter(&symBuf)
+	hdr := &zip.FileHeader{Name: "link"}
+	hdr.SetMode(0777 | os.ModeSymlink)
+	w, err := zw2.CreateHeader(hdr)
+	if err != nil {
+		t.Fatalf("CreateHeader symlink: %v", err)
+	}
+	if _, err := w.Write([]byte("target")); err != nil {
+		t.Fatalf("Write symlink: %v", err)
+	}
+	if err := zw2.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if _, err := extractZipMember(symBuf.Bytes(), "link", 1<<30); err == nil {
+		t.Fatal("expected symlink-entry error")
+	}
+}
+
+func TestExtractZipMember_ZipBombCap(t *testing.T) {
+	z := zipWith(t, map[string]string{"big": strings.Repeat("A", 1<<20)})
+	if _, err := extractZipMember(z, "big", 1<<10); err == nil {
+		t.Fatal("expected decompressed-size cap error")
+	}
+}

--- a/schema/pkl/s3/object.pkl
+++ b/schema/pkl/s3/object.pkl
@@ -43,6 +43,20 @@ typealias ChecksumAlgorithm = "CRC32"|"CRC32C"|"SHA1"|"SHA256"|"CRC64NVME"
 
 typealias ObjectCannedACL = "private"|"public-read"|"public-read-write"|"authenticated-read"|"aws-exec-read"|"bucket-owner-read"|"bucket-owner-full-control"
 
+@aws.SubResourceHint
+open class HttpSource extends formae.SubResource {
+    /// URL to fetch (must be https://). String or a resolvable.
+    url: (String | formae.Resolvable)
+
+    /// HTTP request headers for the INITIAL request. Values may embed a
+    /// resolvable, e.g. formae.Embed("Bearer \(secret.res.value)").
+    @aws.FieldHint { writeOnly = true }
+    headers: (Mapping<String, String>)?
+
+    /// Extract exactly this member from a downloaded zip; omit to upload verbatim.
+    extract: String?
+}
+
 typealias ObjectLockLegalHoldStatus = "ON"|"OFF"
 
 typealias ObjectLockMode = "GOVERNANCE"|"COMPLIANCE"
@@ -80,7 +94,7 @@ open class Object extends formae.Resource {
     @aws.FieldHint {
         writeOnly = true
     }
-    source: String?
+    source: (String | HttpSource)?
 
     @aws.FieldHint
     contentType: String?

--- a/testdata/s3-object-httpsource-update.pkl
+++ b/testdata/s3-object-httpsource-update.pkl
@@ -1,0 +1,52 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/s3/bucket.pkl"
+import "@aws/s3/object.pkl"
+
+// Read the test run ID from environment variable set by the test harness
+// This ensures consistent naming within a test run but unique names between runs
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local stackName = "plugin-sdk-test-s3-object-httpsource-\(testRunID)"
+
+local myBucket = new bucket.Bucket {
+  label = "s3-object-httpsource-test-bucket"
+  bucketName = "formae-plugin-sdk-test-objhttp-\(testRunID)"
+}
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for S3 Object with a structured HttpSource"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  myBucket
+
+  new object.Object {
+    label = "plugin-sdk-test-object"
+    bucket = myBucket.res.bucketName
+    key = "test-artifacts/hello.txt"
+    source = new object.HttpSource {
+      url = "https://raw.githubusercontent.com/aws/aws-sdk-go-v2/main/NOTICE.txt"
+    }
+    // contentType changed to exercise the update path (a readable property; the
+    // writeOnly source is unchanged so the body is not re-fetched).
+    contentType = "application/octet-stream"
+    storageClass = "STANDARD"
+  }
+}

--- a/testdata/s3-object-httpsource.pkl
+++ b/testdata/s3-object-httpsource.pkl
@@ -1,0 +1,53 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/s3/bucket.pkl"
+import "@aws/s3/object.pkl"
+
+// Read the test run ID from environment variable set by the test harness
+// This ensures consistent naming within a test run but unique names between runs
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local stackName = "plugin-sdk-test-s3-object-httpsource-\(testRunID)"
+
+local myBucket = new bucket.Bucket {
+  label = "s3-object-httpsource-test-bucket"
+  bucketName = "formae-plugin-sdk-test-objhttp-\(testRunID)"
+}
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for S3 Object with a structured HttpSource"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  myBucket
+
+  new object.Object {
+    label = "plugin-sdk-test-object"
+    bucket = myBucket.res.bucketName
+    key = "test-artifacts/hello.txt"
+    // Structured remote source: the agent fetches the body over HTTPS. Public,
+    // unauthenticated URL (no headers) — exercises the HttpSource fetch + upload
+    // path end-to-end. Header auth and zip extraction are covered by unit tests.
+    source = new object.HttpSource {
+      url = "https://raw.githubusercontent.com/aws/aws-sdk-go-v2/main/NOTICE.txt"
+    }
+    contentType = "text/plain"
+    storageClass = "STANDARD"
+  }
+}


### PR DESCRIPTION
## Summary

`AWS::S3::Object.source` can now be a structured `HttpSource` (`url` + `headers` + `extract`) in addition to a plain string URL. This lets the agent fetch an authenticated, zip-wrapped artifact (e.g. a CI build artifact) over HTTPS and upload a named member as the object body — without shipping the bytes through the API.

- **Schema:** `source` becomes `(String | HttpSource)`. `HttpSource { url; headers (writeOnly); extract }`. `Content`/`ContentBase64` and the plain-string URL form are unchanged and stay mutually exclusive.
- **Hardened fetch:** HTTPS-only; redirect cap; all request headers stripped on a cross-host redirect; SSRF guard rejecting loopback / link-local / RFC-1918 / the cloud metadata IP, re-validated at dial time so DNS rebinding cannot bypass it; bounded request timeout and a max-download cap.
- **Safe extraction:** when `extract` is set, exactly one regular-file zip member is uploaded; duplicate names, directory and symlink entries are rejected, and a decompressed-size cap guards against zip bombs.
- **No phantom re-upload:** `source` is `writeOnly` and is deliberately *not* `requiredOnUpdate`, so an unchanged resolved source yields no diff (no re-PUT, stable `VersionId`); only a changed URL triggers a re-fetch. Header values are `writeOnly` and are never written to error messages or logs.

Adds unit coverage for the redirect/SSRF policy, header redaction, zip extraction edge cases, the mutual-exclusion guard, and the writeOnly-not-requiredOnUpdate invariant.