### PR TITLE
docs(examples): add lambda-http-source example

### DIFF
--- a/examples/lambda-http-source/README.md
+++ b/examples/lambda-http-source/README.md
@@ -39,6 +39,34 @@ publish release vX.Y.Z (asset: handler.zip)
 4. Pick a globally-unique bucket name — edit `bucketName` in `main.pkl`
    (`...-artifacts-changeme`).
 
+## The handler and its release
+
+The function code lives in [`handler/index.mjs`](handler/index.mjs) — a minimal
+Node.js 20 handler that logs the event and returns:
+
+```js
+export const handler = async (event) => {
+  console.log("OrderPlaced received:", JSON.stringify(event.detail ?? event));
+  return { ok: true, orderId: event?.detail?.orderId ?? null };
+};
+```
+
+The forma never sees this code directly — it fetches a **release asset**. So you
+package the handler and publish it as a release, once per version:
+
+```bash
+cd examples/lambda-http-source/handler
+zip ../handler.zip index.mjs
+
+# Publish it as the v1.0.0 release asset of your repo (GitHub CLI shown):
+gh release create v1.0.0 ../handler.zip --repo YOUR_ORG/YOUR_APP --title v1.0.0
+```
+
+That makes `https://github.com/YOUR_ORG/YOUR_APP/releases/download/v1.0.0/handler.zip`
+resolve — which is exactly the URL the `HttpSource` in `main.pkl` is templated to
+build from `app-version`. (For a private repo the download needs a token; see the
+`headers` note in `main.pkl` and the Variants section below.)
+
 ## Deploy
 
 Apply, passing the release version you want to deploy:
@@ -49,8 +77,8 @@ formae apply --properties app-version=1.0.0 examples/lambda-http-source/main.pkl
 
 What happens: the agent creates the versioned bucket, **fetches the release asset
 and uploads it** as `handler-1.0.0.zip` (recording its `VersionId`), creates the
-role / log group / function (with `Code` pointing at that exact object version),
-then the event bus, rule, and invoke permission.
+role and function (with `Code` pointing at that exact object version), then the
+event bus, rule, and invoke permission.
 
 Verify it landed:
 

--- a/examples/lambda-http-source/README.md
+++ b/examples/lambda-http-source/README.md
@@ -139,3 +139,25 @@ not force-resent on every reconcile.)
 ```bash
 formae destroy --stack lambda-http-source
 ```
+
+**Note on the versioned bucket.** `destroy` removes every resource except the
+artifacts bucket, which fails with *"bucket not empty - delete all versions"*.
+This is by design: formae will not delete a data store that still holds data, and
+S3 keeps prior **versions** (and a delete-marker) after the object is removed
+because the bucket is versioned. Empty the versions first, then re-run destroy:
+
+```bash
+BUCKET=<your artifacts bucket>; REGION=<your region>
+
+# delete all object versions
+aws s3api delete-objects --bucket "$BUCKET" --region "$REGION" --delete \
+  "$(aws s3api list-object-versions --bucket "$BUCKET" --region "$REGION" \
+     --output json --query '{Objects: Versions[].{Key:Key,VersionId:VersionId}}')"
+
+# delete all delete-markers
+aws s3api delete-objects --bucket "$BUCKET" --region "$REGION" --delete \
+  "$(aws s3api list-object-versions --bucket "$BUCKET" --region "$REGION" \
+     --output json --query '{Objects: DeleteMarkers[].{Key:Key,VersionId:VersionId}}')"
+
+formae destroy --stack lambda-http-source   # now the empty bucket is removed
+```

--- a/examples/lambda-http-source/README.md
+++ b/examples/lambda-http-source/README.md
@@ -1,0 +1,113 @@
+# Event-driven Lambda from a versioned release artifact
+
+A small, end-to-end example that ties together three capabilities of the AWS
+plugin:
+
+| Resource | What it shows |
+|---|---|
+| `AWS::S3::Object` with a structured **`HttpSource`** | The agent fetches the deployment package over HTTPS from a release URL and uploads it to S3 — no bytes shipped through the CLI. |
+| `AWS::Lambda::Function` with `Code.s3ObjectVersion` | The S3 object's **VersionId** is the redeploy signal: a new release redeploys; an unchanged re-apply does **not** (no phantom redeploys). |
+| `AWS::Events::EventBus` + `AWS::Events::Rule` + `AWS::Lambda::Permission` | An EventBridge rule on a custom bus routes matching events to the function. |
+
+The deployment package is addressed by version: `app-version` is templated into
+the release URL, so bumping it points the `HttpSource` at a new release.
+
+```
+publish release vX.Y.Z (asset: handler.zip)
+   └─> formae apply --properties app-version=X.Y.Z
+         └─> HttpSource re-fetches the asset -> new S3 VersionId
+               └─> Lambda Code.s3ObjectVersion changes -> redeploy
+```
+
+## Prerequisites
+
+1. A running formae agent with AWS credentials for your account/region.
+2. The AWS plugin installed (`aws@0.1.13-dev.7` or newer — the release that adds
+   `HttpSource`).
+3. A reachable **release asset** that is your Lambda deployment zip. Edit
+   `main.pkl` and replace the placeholder URL:
+
+   ```pkl
+   url = "https://github.com/YOUR_ORG/YOUR_APP/releases/download/v\(appVersion)/handler.zip"
+   ```
+
+   Any HTTPS URL that returns the zip works (a public GitHub release asset, an
+   S3 pre-signed URL, an artifact server, …). For a **private** GitHub repo,
+   uncomment the `headers` block in `main.pkl` and export `GITHUB_TOKEN` (a
+   fine-grained token with `contents: read`) in the **agent's** environment.
+
+4. Pick a globally-unique bucket name — edit `bucketName` in `main.pkl`
+   (`...-artifacts-changeme`).
+
+## Deploy
+
+Apply, passing the release version you want to deploy:
+
+```bash
+formae apply --properties app-version=1.0.0 examples/lambda-http-source/main.pkl
+```
+
+What happens: the agent creates the versioned bucket, **fetches the release asset
+and uploads it** as `handler-1.0.0.zip` (recording its `VersionId`), creates the
+role / log group / function (with `Code` pointing at that exact object version),
+then the event bus, rule, and invoke permission.
+
+Verify it landed:
+
+```bash
+formae inventory --stack lambda-http-source
+```
+
+Fire a test event onto the bus and confirm the function ran:
+
+```bash
+aws events put-events --entries '[{
+  "EventBusName": "lambda-http-source-bus",
+  "Source": "com.example.orders",
+  "DetailType": "OrderPlaced",
+  "Detail": "{\"orderId\":\"42\"}"
+}]'
+
+aws logs tail /aws/lambda/lambda-http-source-handler --since 2m
+```
+
+## The redeploy loop
+
+This is the point of `HttpSource` + `s3ObjectVersion`.
+
+**A new release redeploys.** Publish `v1.0.1` (a new `handler.zip` asset), then:
+
+```bash
+formae apply --properties app-version=1.0.1 examples/lambda-http-source/main.pkl
+```
+
+The URL now resolves to the `v1.0.1` asset → the agent re-fetches → a new S3
+`VersionId` → the function's `Code.s3ObjectVersion` changes → a genuine redeploy.
+
+**An unchanged re-apply does not.** Re-run the *same* version:
+
+```bash
+formae apply --properties app-version=1.0.1 examples/lambda-http-source/main.pkl
+```
+
+The resolved object is unchanged, so the plan shows **no change** to the function
+— no phantom `UpdateFunctionCode`, no version churn. (`Code` is write-only but is
+not force-resent on every reconcile.)
+
+## Variants
+
+- **Private repo:** uncomment the `headers` block in `main.pkl`; the agent sends
+  `Authorization: Bearer <token>` and drops it on the cross-origin redirect to
+  the asset's blob host. The header value is write-only and never persisted in
+  cleartext.
+- **GitHub Actions artifact instead of a release asset:** an Actions artifact's
+  download URL is keyed by an opaque artifact id (not derivable from a version)
+  and is a zip that *wraps* your file. Fetching it needs the GitHub plugin's
+  `WorkflowRun` to resolve the URL, plus `extract = "handler.zip"` on the
+  `HttpSource` to pull the member out of the artifact zip.
+
+## Clean up
+
+```bash
+formae destroy --stack lambda-http-source
+```

--- a/examples/lambda-http-source/handler/index.mjs
+++ b/examples/lambda-http-source/handler/index.mjs
@@ -1,0 +1,12 @@
+// Minimal Lambda handler for the lambda-http-source example.
+//
+// Runtime: nodejs20.x (see main.pkl). The function is wired as `index.handler`,
+// so this file must be named index.mjs (or index.js) at the root of the zip.
+//
+// It is invoked by EventBridge for "OrderPlaced" events on the custom bus; it
+// just logs the event detail and returns. Replace with your real application.
+
+export const handler = async (event) => {
+  console.log("OrderPlaced received:", JSON.stringify(event.detail ?? event));
+  return { ok: true, orderId: event?.detail?.orderId ?? null };
+};

--- a/examples/lambda-http-source/main.pkl
+++ b/examples/lambda-http-source/main.pkl
@@ -1,0 +1,160 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+/// Event-driven Lambda whose deployment package is delivered by a versioned
+/// release artifact, fetched over HTTPS by the agent (no bytes through the CLI).
+///
+/// Demonstrates, end to end:
+///   * AWS::S3::Object with a structured `HttpSource` — the agent fetches the
+///     deployment zip from a release URL and uploads it to a versioned bucket.
+///   * AWS::Lambda::Function whose `Code.s3ObjectVersion` is the S3 object's
+///     VersionId, so a new release => new VersionId => a genuine redeploy, and
+///     an unchanged re-apply => same VersionId => NO redeploy (no phantom churn).
+///   * AWS::Events::EventBus + AWS::Events::Rule routing matching events to the
+///     Lambda, with an AWS::Lambda::Permission granting EventBridge invoke.
+///
+/// Release loop (see README): publish a release `vX.Y.Z` whose asset is the
+/// handler zip, then `formae apply --properties app-version=X.Y.Z`.
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/s3/bucket.pkl"
+import "@aws/s3/object.pkl"
+import "@aws/lambda/func.pkl"
+import "@aws/lambda/permission.pkl"
+import "@aws/iam/role.pkl"
+import "@aws/events/eventbus.pkl"
+import "@aws/events/rule.pkl"
+
+import "vars.pkl"
+
+// The release tag of the deployment package. Required on every apply:
+//   formae apply --properties app-version=1.0.0 examples/lambda-http-source/main.pkl
+// Changing it is the redeploy signal (see the `pkg` object below).
+local appVersion = (new formae.Prop { flag = "app-version"; default = "1.0.0" }).value
+
+// ── Artifact bucket (versioning ON) ─────────────────────────────────────────
+// Versioning must be enabled so each uploaded package gets a distinct VersionId —
+// that VersionId is what drives (and gates) Lambda redeploys.
+//
+// NOTE: S3 bucket names are globally unique. Change this to something you own.
+local artifactsBucket = new bucket.Bucket {
+  label = "ArtifactsBucket"
+  bucketName = "\(vars.projectName)-artifacts-changeme"
+  versioningConfiguration = new bucket.VersioningConfiguration { status = "Enabled" }
+}
+
+// ── Deployment package, fetched from a versioned release asset (HttpSource) ──
+// The agent GETs the URL over HTTPS and uploads the body to S3. The URL is
+// templated from `app-version`, so bumping the property points at a new release
+// => the agent re-fetches => a new S3 VersionId => the Lambda redeploys.
+//
+// This release asset is the deployment zip itself, so no `extract` is needed.
+// (Use `extract = "handler.zip"` only when the URL returns a zip that *wraps*
+//  the artifact, e.g. a GitHub Actions artifact, which is always double-zipped.)
+local pkg = new object.Object {
+  label = "HandlerPackage"
+  bucket = artifactsBucket.res.bucketName
+  key = "handler-\(appVersion).zip"
+  source = new object.HttpSource {
+    url = "https://github.com/YOUR_ORG/YOUR_APP/releases/download/v\(appVersion)/handler.zip"
+
+    // For a PRIVATE repo, send a token. The header value is writeOnly (never
+    // persisted in cleartext); the agent reads the token from its own environment:
+    //
+    // headers = new Mapping<String, String> {
+    //   ["Authorization"] = "Bearer \(read("env:GITHUB_TOKEN"))"
+    // }
+  }
+}
+
+// ── Lambda execution role ───────────────────────────────────────────────────
+local execRole = new role.Role {
+  label = "HandlerRole"
+  roleName = "\(vars.projectName)-handler-role"
+  assumeRolePolicyDocument = new Dynamic {
+    ["Version"] = "2012-10-17"
+    ["Statement"] {
+      new {
+        ["Effect"] = "Allow"
+        ["Principal"] { ["Service"] = "lambda.amazonaws.com" }
+        ["Action"] = "sts:AssumeRole"
+      }
+    }
+  }
+  managedPolicyArns { "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole" }
+}
+
+// ── The function ────────────────────────────────────────────────────────────
+// `Code` is sourced from the S3 object. `s3ObjectVersion = pkg.res.versionId`
+// makes the resolved VersionId the redeploy signal: same package => same
+// VersionId => no diff => no redeploy; new release => new VersionId => redeploy.
+// (The function logs to its default group, /aws/lambda/<functionName>.)
+local handler = new func.Function {
+  label = "Handler"
+  functionName = "\(vars.projectName)-handler"
+  runtime = "nodejs20.x"
+  architectures { "arm64" }
+  handler = "index.handler"
+  role = execRole.res.arn
+  memorySize = 256
+  timeout = 10
+  code = new func.Code {
+    s3Bucket = pkg.res.bucket
+    s3Key = pkg.res.key
+    s3ObjectVersion = pkg.res.versionId
+  }
+}
+
+// ── EventBridge: a custom bus + a rule that routes matching events to the Lambda ─
+local bus = new eventbus.EventBus {
+  label = "AppBus"
+  name = "\(vars.projectName)-bus"
+}
+
+// Fires the Lambda for any "OrderPlaced" event from source "com.example.orders".
+// (A schedule would use `scheduleExpression` instead, but scheduled rules must
+//  live on the default bus; custom buses use event patterns.)
+local routeRule = new rule.Rule {
+  label = "RouteRule"
+  name = "\(vars.projectName)-route"
+  eventBusName = bus.res.name
+  eventPattern = new Dynamic {
+    ["source"] { "com.example.orders" }
+    ["detail-type"] { "OrderPlaced" }
+  }
+  state = "ENABLED"
+  targets {
+    new {
+      id = "handler"
+      arn = handler.res.arn
+    }
+  }
+}
+
+// Allow EventBridge to invoke the function, scoped to this rule.
+local invokePermission = new permission.Permission {
+  label = "EventBridgeInvoke"
+  functionName = handler.res.functionName
+  action = "lambda:InvokeFunction"
+  principal = "events.amazonaws.com"
+  sourceArn = routeRule.res.arn
+}
+
+forma {
+  vars.stack
+  vars.target
+
+  artifactsBucket
+  pkg
+
+  execRole
+  handler
+
+  bus
+  routeRule
+  invokePermission
+}

--- a/examples/lambda-http-source/vars.pkl
+++ b/examples/lambda-http-source/vars.pkl
@@ -1,0 +1,23 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+import "@formae/formae.pkl"
+import "@aws/aws.pkl"
+
+projectName = "lambda-http-source"
+region = "us-east-1"
+
+stack: formae.Stack = new {
+  label = "lambda-http-source"
+  description = "Event-driven Lambda whose code is fetched from a versioned release artifact"
+}
+
+target: formae.Target = new formae.Target {
+  label = "lambda-http-source-target"
+  config = new aws.Config {
+    region = module.region
+  }
+}


### PR DESCRIPTION
## Summary

Adds an `examples/lambda-http-source` example: an event-driven Lambda whose deployment package is delivered by `AWS::S3::Object`'s structured `HttpSource` remote source.

It demonstrates, end to end:

- **`AWS::S3::Object` with `HttpSource`** - the agent fetches the deployment zip over HTTPS from a release URL (templated from an `app-version` property) and uploads it to a versioned bucket; no bytes pass through the CLI.
- **Version-driven redeploys** - the function's `Code.s3ObjectVersion` is the object's VersionId, so a new release redeploys the function and re-applying the same version is a no-op (no phantom redeploys).
- **EventBridge** - a custom `AWS::Events::EventBus` + `AWS::Events::Rule` route matching events to the function, with an `AWS::Lambda::Permission` granting invoke.

Includes the handler source (`handler/index.mjs`) and a README walkthrough: build and publish the release asset, deploy, the redeploy loop, sending a test event, and cleanup. Verified with `formae eval`.