### PR TITLE
fix(ec2): tag LaunchTemplate writeOnly fields requiredOnUpdate

### DIFF
--- a/schema/pkl/ec2/launchtemplate.pkl
+++ b/schema/pkl/ec2/launchtemplate.pkl
@@ -372,15 +372,16 @@ open class LaunchTemplate extends formae.Resource {
     @aws.FieldHint{
         writeOnly = true
         requiredOnCreate = true
+        requiredOnUpdate = true
     }
     launchTemplateData: LaunchTemplateData?
 
     @aws.FieldHint{createOnly = true}
     launchTemplateName: String?
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{writeOnly = true; requiredOnUpdate = true}
     tagSpecifications: Listing<TagSpecification>?
 
-    @aws.FieldHint{writeOnly = true}
+    @aws.FieldHint{writeOnly = true; requiredOnUpdate = true}
     versionDescription: String?
 }


### PR DESCRIPTION
## Summary

- `AWS::EC2::LaunchTemplate`'s `launchTemplateData`, `versionDescription` and `tagSpecifications` are `writeOnly`. Since the `writeOnly`/`requiredOnUpdate` hint split, `writeOnly` alone no longer forces a field into the update payload — a changed value is emitted as a granular JSON-Patch `replace` (e.g. `replace /LaunchTemplateData/InstanceType`).
- CloudControl rejects that patch with `ValidationException: Invalid patch update: writeOnlyProperties [...] can only be updated using 'add' operation`. Only a top-level `add` of the whole writeOnly property is accepted; both `replace` and a nested `add` are rejected. Because `ValidationException` isn't a recognised CloudControl exception type, it surfaces as a terminal, non-retried failure.
- The failure was prior-state dependent (it reproduced only when the pre-update sync left the writeOnly value in stored state), which is why the `ec2-launchtemplate` conformance Update step failed intermittently rather than on every run.
- Tagging these fields `requiredOnUpdate` forces a full re-send, so the agent emits a whole-object `add` that CloudControl accepts. This mirrors the existing `requiredOnUpdate` tagging on IAM User, ECS Service and the ELBv2 listeners — LaunchTemplate was missed in that audit.

Verified by running the full `ec2-launchtemplate` conformance CRUD lifecycle locally against AWS (Create/Verify/Extract/Sync/Update/Replace/Destroy/OOB-Del all pass), and by reproducing the `replace`-vs-`add` CloudControl behaviour directly.