### PR TITLE
feat(route53): add custom provisioner for AWS::Route53::RecordSetGroup

### DIFF
--- a/pkg/cfres/route53/record_set_group.go
+++ b/pkg/cfres/route53/record_set_group.go
@@ -1,0 +1,592 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package route53
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/route53"
+	"github.com/aws/aws-sdk-go-v2/service/route53/types"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/cfres/prov"
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/cfres/registry"
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/config"
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/cfres/utils"
+)
+
+const recordSetGroupType = "AWS::Route53::RecordSetGroup"
+
+// maxChangesPerBatch is Route53's documented cap on the number of changes in a
+// single ChangeResourceRecordSets batch. The provisioner applies the whole
+// group atomically in one batch, so a group larger than this cannot be applied.
+const maxChangesPerBatch = 1000
+
+// unsupportedRecordFields are the advanced routing-policy fields the provisioner
+// does not support. They are rejected (not silently dropped) because without
+// SetIdentifier, (Name, Type) is a complete Route53 record identity — the
+// foundation of the NativeID key model. Supporting weighted/latency/geo routing
+// is deferred to a follow-up.
+var unsupportedRecordFields = []string{
+	"SetIdentifier",
+	"Weight",
+	"GeoLocation",
+	"GeoProximityLocation",
+	"Failover",
+	"MultiValueAnswer",
+	"Region",
+	"CidrRoutingConfig",
+	"HealthCheckId",
+}
+
+// recordKey is the complete identity of a supported record within a group:
+// its canonical (trailing-dot) name and record type.
+type recordKey struct {
+	Name string `json:"Name"`
+	Type string `json:"Type"`
+}
+
+type recordSetGroupClientInterface interface {
+	ChangeResourceRecordSets(ctx context.Context, params *route53.ChangeResourceRecordSetsInput, optFns ...func(*route53.Options)) (*route53.ChangeResourceRecordSetsOutput, error)
+	ListResourceRecordSets(ctx context.Context, params *route53.ListResourceRecordSetsInput, optFns ...func(*route53.Options)) (*route53.ListResourceRecordSetsOutput, error)
+	GetChange(ctx context.Context, params *route53.GetChangeInput, optFns ...func(*route53.Options)) (*route53.GetChangeOutput, error)
+}
+
+type RecordSetGroup struct {
+	cfg *config.Config
+}
+
+var _ prov.Provisioner = &RecordSetGroup{}
+
+func init() {
+	registry.Register(recordSetGroupType,
+		[]resource.Operation{
+			resource.OperationCreate,
+			resource.OperationRead,
+			resource.OperationUpdate,
+			resource.OperationCheckStatus,
+			resource.OperationDelete,
+		},
+		func(cfg *config.Config) prov.Provisioner {
+			return &RecordSetGroup{cfg: cfg}
+		})
+}
+
+// canonicalName returns the Route53 canonical form of a DNS name (trailing dot).
+func canonicalName(name string) string {
+	if !strings.HasSuffix(name, ".") {
+		return name + "."
+	}
+	return name
+}
+
+// encodeRecordSetGroupNativeID builds the composite identity for a group:
+// "<hostedZoneId>|<base64url(JSON of sorted [{Name,Type}] key list)>". The key
+// list is variable-length and record names can contain delimiter characters, so
+// base64(JSON) — not a plain delimiter-join — keeps it collision-free. Names are
+// canonicalized before encoding so encode/decode/match are dot-consistent.
+func encodeRecordSetGroupNativeID(hostedZoneID string, keys []recordKey) (string, error) {
+	canon := make([]recordKey, len(keys))
+	for i, k := range keys {
+		canon[i] = recordKey{Name: canonicalName(k.Name), Type: k.Type}
+	}
+	sort.Slice(canon, func(i, j int) bool {
+		if canon[i].Name != canon[j].Name {
+			return canon[i].Name < canon[j].Name
+		}
+		return canon[i].Type < canon[j].Type
+	})
+	data, err := json.Marshal(canon)
+	if err != nil {
+		return "", fmt.Errorf("failed to encode record keys: %w", err)
+	}
+	return hostedZoneID + "|" + base64.RawURLEncoding.EncodeToString(data), nil
+}
+
+func decodeRecordSetGroupNativeID(nativeID string) (string, []recordKey, error) {
+	parts := strings.SplitN(nativeID, "|", 2)
+	if len(parts) != 2 || parts[0] == "" {
+		return "", nil, fmt.Errorf("invalid NativeID format: expected 'hostedZoneId|base64keys', got: %s", nativeID)
+	}
+	data, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return "", nil, fmt.Errorf("invalid NativeID key segment: %w", err)
+	}
+	var keys []recordKey
+	if err := json.Unmarshal(data, &keys); err != nil {
+		return "", nil, fmt.Errorf("invalid NativeID key list: %w", err)
+	}
+	return parts[0], keys, nil
+}
+
+// parseRecordSets extracts and validates the RecordSets list from a property
+// map. A group with no records cannot be applied as an atomic change batch.
+func parseRecordSets(properties map[string]any) ([]any, error) {
+	raw, ok := properties["RecordSets"].([]any)
+	if !ok || len(raw) == 0 {
+		return nil, fmt.Errorf("at least one record set is required")
+	}
+	return raw, nil
+}
+
+// buildResourceRecordSet converts one declared record map into an AWS
+// ResourceRecordSet, validating it is a supported simple record, and returns its
+// canonical key.
+func buildResourceRecordSet(rec map[string]any) (*types.ResourceRecordSet, recordKey, error) {
+	for _, field := range unsupportedRecordFields {
+		if _, present := rec[field]; present {
+			return nil, recordKey{}, fmt.Errorf("unsupported routing field %q: the RecordSetGroup provisioner supports simple records only (name, type, ttl, resourceRecords, aliasTarget)", field)
+		}
+	}
+
+	name, err := utils.GetStringProperty(rec, "Name")
+	if err != nil {
+		return nil, recordKey{}, fmt.Errorf("invalid record Name: %w", err)
+	}
+	recordType, err := utils.GetStringProperty(rec, "Type")
+	if err != nil {
+		return nil, recordKey{}, fmt.Errorf("invalid record Type: %w", err)
+	}
+	cName := canonicalName(name)
+
+	rrs := &types.ResourceRecordSet{
+		Name: aws.String(cName),
+		Type: types.RRType(recordType),
+	}
+
+	var aliasTarget *types.AliasTarget
+	if aliasRaw, hasAlias := rec["AliasTarget"].(map[string]any); hasAlias {
+		aliasTarget, err = buildAliasTarget(aliasRaw)
+		if err != nil {
+			return nil, recordKey{}, fmt.Errorf("record %q: %w", name, err)
+		}
+	}
+
+	records := extractResourceRecords(rec)
+	if aliasTarget != nil {
+		if len(records) > 0 {
+			return nil, recordKey{}, fmt.Errorf("record %q: aliasTarget and resourceRecords are mutually exclusive", name)
+		}
+		rrs.AliasTarget = aliasTarget
+	} else {
+		if len(records) == 0 {
+			return nil, recordKey{}, fmt.Errorf("record %q: at least one resourceRecord is required when aliasTarget is not set", name)
+		}
+		rrs.ResourceRecords = records
+		rrs.TTL = aws.Int64(utils.GetInt64Property(rec, "TTL", 300))
+	}
+
+	return rrs, recordKey{Name: cName, Type: recordType}, nil
+}
+
+func extractResourceRecords(rec map[string]any) []types.ResourceRecord {
+	raw, ok := rec["ResourceRecords"].([]any)
+	if !ok {
+		return nil
+	}
+	records := make([]types.ResourceRecord, 0, len(raw))
+	for _, r := range raw {
+		if value, ok := r.(string); ok && value != "" {
+			records = append(records, types.ResourceRecord{Value: aws.String(value)})
+		}
+	}
+	return records
+}
+
+// listAllRecordSets paginates the full set of record sets in a hosted zone.
+func listAllRecordSets(ctx context.Context, client recordSetGroupClientInterface, hostedZoneID string) ([]types.ResourceRecordSet, error) {
+	var all []types.ResourceRecordSet
+	input := &route53.ListResourceRecordSetsInput{HostedZoneId: aws.String(hostedZoneID)}
+	for {
+		resp, err := client.ListResourceRecordSets(ctx, input)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, resp.ResourceRecordSets...)
+		if !resp.IsTruncated {
+			break
+		}
+		input.StartRecordName = resp.NextRecordName
+		input.StartRecordType = resp.NextRecordType
+		input.StartRecordIdentifier = resp.NextRecordIdentifier
+	}
+	return all, nil
+}
+
+// indexRecordSetsByKey maps live record sets by their canonical key.
+func indexRecordSetsByKey(recordSets []types.ResourceRecordSet) map[recordKey]*types.ResourceRecordSet {
+	m := make(map[recordKey]*types.ResourceRecordSet, len(recordSets))
+	for i := range recordSets {
+		rrs := &recordSets[i]
+		key := recordKey{Name: canonicalName(aws.ToString(rrs.Name)), Type: string(rrs.Type)}
+		m[key] = rrs
+	}
+	return m
+}
+
+func (r *RecordSetGroup) Create(ctx context.Context, request *resource.CreateRequest) (*resource.CreateResult, error) {
+	awsCfg, err := r.cfg.ToAwsConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("unable to load AWS config: %w", err)
+	}
+	return r.createWithClient(ctx, route53.NewFromConfig(awsCfg), request)
+}
+
+func (r *RecordSetGroup) createWithClient(ctx context.Context, client recordSetGroupClientInterface, request *resource.CreateRequest) (*resource.CreateResult, error) {
+	var properties map[string]any
+	if err := json.Unmarshal(request.Properties, &properties); err != nil {
+		return nil, fmt.Errorf("failed to parse properties: %w", err)
+	}
+
+	hostedZoneID, err := utils.GetStringProperty(properties, "HostedZoneId")
+	if err != nil {
+		return nil, fmt.Errorf("invalid HostedZoneId: %w", err)
+	}
+
+	rawRecords, err := parseRecordSets(properties)
+	if err != nil {
+		return nil, err
+	}
+	if len(rawRecords) > maxChangesPerBatch {
+		return nil, fmt.Errorf("record set group has %d records, which exceeds the Route53 atomic change-batch limit of %d", len(rawRecords), maxChangesPerBatch)
+	}
+
+	changes := make([]types.Change, 0, len(rawRecords))
+	keys := make([]recordKey, 0, len(rawRecords))
+	seen := make(map[recordKey]bool, len(rawRecords))
+	for _, raw := range rawRecords {
+		rec, ok := raw.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("invalid record set entry: expected an object, got %T", raw)
+		}
+		rrs, key, err := buildResourceRecordSet(rec)
+		if err != nil {
+			return nil, err
+		}
+		if seen[key] {
+			return nil, fmt.Errorf("duplicate record (Name=%s, Type=%s): a record set group cannot declare the same name+type twice without a routing policy", key.Name, key.Type)
+		}
+		seen[key] = true
+		keys = append(keys, key)
+		changes = append(changes, types.Change{Action: types.ChangeActionCreate, ResourceRecordSet: rrs})
+	}
+
+	result, err := client.ChangeResourceRecordSets(ctx, &route53.ChangeResourceRecordSetsInput{
+		HostedZoneId: aws.String(hostedZoneID),
+		ChangeBatch:  &types.ChangeBatch{Changes: changes},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create record set group: %w", err)
+	}
+
+	nativeID, err := encodeRecordSetGroupNativeID(hostedZoneID, keys)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resource.CreateResult{
+		ProgressResult: &resource.ProgressResult{
+			Operation:       resource.OperationCreate,
+			OperationStatus: resource.OperationStatusInProgress,
+			RequestID:       aws.ToString(result.ChangeInfo.Id),
+			NativeID:        nativeID,
+		},
+	}, nil
+}
+
+func (r *RecordSetGroup) Update(ctx context.Context, request *resource.UpdateRequest) (*resource.UpdateResult, error) {
+	awsCfg, err := r.cfg.ToAwsConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("unable to load AWS config: %w", err)
+	}
+	return r.updateWithClient(ctx, route53.NewFromConfig(awsCfg), request)
+}
+
+func (r *RecordSetGroup) updateWithClient(ctx context.Context, client recordSetGroupClientInterface, request *resource.UpdateRequest) (*resource.UpdateResult, error) {
+	var priorProperties, desiredProperties map[string]any
+	if err := json.Unmarshal(request.PriorProperties, &priorProperties); err != nil {
+		return nil, fmt.Errorf("failed to parse prior properties: %w", err)
+	}
+	if err := json.Unmarshal(request.DesiredProperties, &desiredProperties); err != nil {
+		return nil, fmt.Errorf("failed to parse desired properties: %w", err)
+	}
+
+	priorZoneID, err := utils.GetStringProperty(priorProperties, "HostedZoneId")
+	if err != nil {
+		return nil, fmt.Errorf("invalid prior HostedZoneId: %w", err)
+	}
+	desiredZoneID, err := utils.GetStringProperty(desiredProperties, "HostedZoneId")
+	if err != nil {
+		return nil, fmt.Errorf("invalid desired HostedZoneId: %w", err)
+	}
+	// hostedZoneId is createOnly; a zone change is a framework-driven replace,
+	// never an in-place update.
+	if priorZoneID != desiredZoneID {
+		return nil, fmt.Errorf("cannot move a record set group between hosted zones (%s -> %s)", priorZoneID, desiredZoneID)
+	}
+
+	desiredRecords, err := parseRecordSets(desiredProperties)
+	if err != nil {
+		return nil, err
+	}
+	if len(desiredRecords) > maxChangesPerBatch {
+		return nil, fmt.Errorf("record set group has %d records, which exceeds the Route53 atomic change-batch limit of %d", len(desiredRecords), maxChangesPerBatch)
+	}
+
+	changes := make([]types.Change, 0, len(desiredRecords))
+	desiredKeys := make([]recordKey, 0, len(desiredRecords))
+	desiredSet := make(map[recordKey]bool, len(desiredRecords))
+	for _, raw := range desiredRecords {
+		rec, ok := raw.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("invalid record set entry: expected an object, got %T", raw)
+		}
+		rrs, key, err := buildResourceRecordSet(rec)
+		if err != nil {
+			return nil, err
+		}
+		if desiredSet[key] {
+			return nil, fmt.Errorf("duplicate record (Name=%s, Type=%s): a record set group cannot declare the same name+type twice without a routing policy", key.Name, key.Type)
+		}
+		desiredSet[key] = true
+		desiredKeys = append(desiredKeys, key)
+		changes = append(changes, types.Change{Action: types.ChangeActionUpsert, ResourceRecordSet: rrs})
+	}
+
+	// Delete records dropped from the set, sourcing their values from LIVE
+	// Route53 state — a delete-by-value is rejected unless it matches the exact
+	// canonical record, so prior properties are too brittle (drift / canon).
+	live, err := listAllRecordSets(ctx, client, desiredZoneID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read live record sets: %w", err)
+	}
+	liveByKey := indexRecordSetsByKey(live)
+	for _, raw := range parsePriorKeys(priorProperties) {
+		if desiredSet[raw] {
+			continue
+		}
+		if liveRRS, present := liveByKey[raw]; present {
+			changes = append(changes, types.Change{Action: types.ChangeActionDelete, ResourceRecordSet: liveRRS})
+		}
+	}
+
+	nativeID, err := encodeRecordSetGroupNativeID(desiredZoneID, desiredKeys)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := client.ChangeResourceRecordSets(ctx, &route53.ChangeResourceRecordSetsInput{
+		HostedZoneId: aws.String(desiredZoneID),
+		ChangeBatch:  &types.ChangeBatch{Changes: changes},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to update record set group: %w", err)
+	}
+
+	return &resource.UpdateResult{
+		ProgressResult: &resource.ProgressResult{
+			Operation:       resource.OperationUpdate,
+			OperationStatus: resource.OperationStatusInProgress,
+			RequestID:       aws.ToString(result.ChangeInfo.Id),
+			NativeID:        nativeID,
+		},
+	}, nil
+}
+
+// parsePriorKeys extracts the canonical keys of the previously-applied records,
+// skipping any malformed entries (prior state is trusted but parsed leniently).
+func parsePriorKeys(priorProperties map[string]any) []recordKey {
+	raw, ok := priorProperties["RecordSets"].([]any)
+	if !ok {
+		return nil
+	}
+	keys := make([]recordKey, 0, len(raw))
+	for _, entry := range raw {
+		rec, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+		name, err := utils.GetStringProperty(rec, "Name")
+		if err != nil {
+			continue
+		}
+		recordType, err := utils.GetStringProperty(rec, "Type")
+		if err != nil {
+			continue
+		}
+		keys = append(keys, recordKey{Name: canonicalName(name), Type: recordType})
+	}
+	return keys
+}
+
+func (r *RecordSetGroup) Delete(ctx context.Context, request *resource.DeleteRequest) (*resource.DeleteResult, error) {
+	awsCfg, err := r.cfg.ToAwsConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("unable to load AWS config: %w", err)
+	}
+	return r.deleteWithClient(ctx, route53.NewFromConfig(awsCfg), request)
+}
+
+func (r *RecordSetGroup) deleteWithClient(ctx context.Context, client recordSetGroupClientInterface, request *resource.DeleteRequest) (*resource.DeleteResult, error) {
+	hostedZoneID, keys, err := decodeRecordSetGroupNativeID(request.NativeID)
+	if err != nil {
+		return nil, err
+	}
+
+	success := &resource.DeleteResult{
+		ProgressResult: &resource.ProgressResult{
+			Operation:       resource.OperationDelete,
+			OperationStatus: resource.OperationStatusSuccess,
+			NativeID:        request.NativeID,
+		},
+	}
+
+	live, err := listAllRecordSets(ctx, client, hostedZoneID)
+	if err != nil {
+		// The hosted zone is gone (or otherwise unreadable); there is nothing
+		// left to delete. Mirrors the singular provisioner treating an absent
+		// record as an already-satisfied delete.
+		return success, nil
+	}
+	liveByKey := indexRecordSetsByKey(live)
+
+	changes := make([]types.Change, 0, len(keys))
+	for _, key := range keys {
+		if liveRRS, present := liveByKey[key]; present {
+			changes = append(changes, types.Change{Action: types.ChangeActionDelete, ResourceRecordSet: liveRRS})
+		}
+	}
+	if len(changes) == 0 {
+		return success, nil
+	}
+
+	result, err := client.ChangeResourceRecordSets(ctx, &route53.ChangeResourceRecordSetsInput{
+		HostedZoneId: aws.String(hostedZoneID),
+		ChangeBatch:  &types.ChangeBatch{Changes: changes},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to delete record set group: %w", err)
+	}
+
+	return &resource.DeleteResult{
+		ProgressResult: &resource.ProgressResult{
+			Operation:          resource.OperationDelete,
+			OperationStatus:    resource.OperationStatusInProgress,
+			RequestID:          aws.ToString(result.ChangeInfo.Id),
+			NativeID:           request.NativeID,
+			ResourceProperties: json.RawMessage{},
+		},
+	}, nil
+}
+
+func (r *RecordSetGroup) Status(ctx context.Context, request *resource.StatusRequest) (*resource.StatusResult, error) {
+	awsCfg, err := r.cfg.ToAwsConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("unable to load AWS config: %w", err)
+	}
+	return r.statusWithClient(ctx, route53.NewFromConfig(awsCfg), request)
+}
+
+func (r *RecordSetGroup) statusWithClient(ctx context.Context, client recordSetGroupClientInterface, request *resource.StatusRequest) (*resource.StatusResult, error) {
+	result, err := client.GetChange(ctx, &route53.GetChangeInput{Id: aws.String(request.RequestID)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get change status: %w", err)
+	}
+
+	status := resource.OperationStatusInProgress
+	var resourceProperties json.RawMessage
+	if result.ChangeInfo.Status == types.ChangeStatusInsync {
+		status = resource.OperationStatusSuccess
+		if request.NativeID != "" {
+			readRes, readErr := r.readWithClient(ctx, client, &resource.ReadRequest{
+				NativeID:     request.NativeID,
+				ResourceType: request.ResourceType,
+				TargetConfig: request.TargetConfig,
+			})
+			if readErr == nil && readRes != nil && readRes.ErrorCode == "" {
+				resourceProperties = json.RawMessage(readRes.Properties)
+			}
+		}
+	}
+
+	return &resource.StatusResult{
+		ProgressResult: &resource.ProgressResult{
+			OperationStatus:    status,
+			RequestID:          aws.ToString(result.ChangeInfo.Id),
+			NativeID:           request.NativeID,
+			ResourceProperties: resourceProperties,
+		},
+	}, nil
+}
+
+func (r *RecordSetGroup) Read(ctx context.Context, request *resource.ReadRequest) (*resource.ReadResult, error) {
+	awsCfg, err := r.cfg.ToAwsConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("unable to load AWS config: %w", err)
+	}
+	return r.readWithClient(ctx, route53.NewFromConfig(awsCfg), request)
+}
+
+func (r *RecordSetGroup) readWithClient(ctx context.Context, client recordSetGroupClientInterface, request *resource.ReadRequest) (*resource.ReadResult, error) {
+	hostedZoneID, keys, err := decodeRecordSetGroupNativeID(request.NativeID)
+	if err != nil {
+		return nil, err
+	}
+
+	live, err := listAllRecordSets(ctx, client, hostedZoneID)
+	if err != nil {
+		return &resource.ReadResult{ResourceType: recordSetGroupType, ErrorCode: resource.OperationErrorCodeNotFound}, nil
+	}
+	liveByKey := indexRecordSetsByKey(live)
+
+	recordSets := make([]map[string]any, 0, len(keys))
+	for _, key := range keys {
+		if rrs, present := liveByKey[key]; present {
+			recordSets = append(recordSets, buildReadProperties(rrs, hostedZoneID, key.Name, key.Type))
+		}
+	}
+	if len(recordSets) == 0 {
+		return &resource.ReadResult{ResourceType: recordSetGroupType, ErrorCode: resource.OperationErrorCodeNotFound}, nil
+	}
+
+	// The record list is order-insensitive; sort it deterministically so an
+	// unchanged group never reads back as drift.
+	sort.Slice(recordSets, func(i, j int) bool {
+		ni, _ := recordSets[i]["Name"].(string)
+		nj, _ := recordSets[j]["Name"].(string)
+		if ni != nj {
+			return ni < nj
+		}
+		ti, _ := recordSets[i]["Type"].(string)
+		tj, _ := recordSets[j]["Type"].(string)
+		return ti < tj
+	})
+
+	propBytes, err := json.Marshal(map[string]any{
+		"HostedZoneId": hostedZoneID,
+		"RecordSets":   recordSets,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal properties: %w", err)
+	}
+
+	return &resource.ReadResult{
+		ResourceType: recordSetGroupType,
+		Properties:   string(propBytes),
+	}, nil
+}
+
+// List is not supported: RecordSetGroup is a non-discoverable CloudFormation
+// grouping abstraction with no AWS-native identity. Returning an explicit error
+// (rather than an empty list, which would falsely read as "no resources")
+// surfaces the unsupported operation honestly.
+func (r *RecordSetGroup) List(_ context.Context, _ *resource.ListRequest) (*resource.ListResult, error) {
+	return nil, fmt.Errorf("listing is not supported for %s (discoverable = false)", recordSetGroupType)
+}

--- a/pkg/cfres/route53/record_set_group.go
+++ b/pkg/cfres/route53/record_set_group.go
@@ -549,7 +549,12 @@ func (r *RecordSetGroup) readWithClient(ctx context.Context, client recordSetGro
 	recordSets := make([]map[string]any, 0, len(keys))
 	for _, key := range keys {
 		if rrs, present := liveByKey[key]; present {
-			recordSets = append(recordSets, buildReadProperties(rrs, hostedZoneID, key.Name, key.Type))
+			rec := buildReadProperties(rrs, hostedZoneID, key.Name, key.Type)
+			// HostedZoneId lives on the group (set below), not on each record.
+			// The singular helper adds a per-record copy; drop it so the read
+			// matches the declared record shape and doesn't read as drift.
+			delete(rec, "HostedZoneId")
+			recordSets = append(recordSets, rec)
 		}
 	}
 	if len(recordSets) == 0 {

--- a/pkg/cfres/route53/record_set_group_mock_test.go
+++ b/pkg/cfres/route53/record_set_group_mock_test.go
@@ -1,0 +1,36 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package route53
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/route53"
+	"github.com/stretchr/testify/mock"
+)
+
+type mockRoute53Client struct {
+	mock.Mock
+}
+
+func (m *mockRoute53Client) ChangeResourceRecordSets(ctx context.Context, input *route53.ChangeResourceRecordSetsInput, optFns ...func(*route53.Options)) (*route53.ChangeResourceRecordSetsOutput, error) {
+	args := m.Called(ctx, input)
+	out, _ := args.Get(0).(*route53.ChangeResourceRecordSetsOutput)
+	return out, args.Error(1)
+}
+
+func (m *mockRoute53Client) ListResourceRecordSets(ctx context.Context, input *route53.ListResourceRecordSetsInput, optFns ...func(*route53.Options)) (*route53.ListResourceRecordSetsOutput, error) {
+	args := m.Called(ctx, input)
+	out, _ := args.Get(0).(*route53.ListResourceRecordSetsOutput)
+	return out, args.Error(1)
+}
+
+func (m *mockRoute53Client) GetChange(ctx context.Context, input *route53.GetChangeInput, optFns ...func(*route53.Options)) (*route53.GetChangeOutput, error) {
+	args := m.Called(ctx, input)
+	out, _ := args.Get(0).(*route53.GetChangeOutput)
+	return out, args.Error(1)
+}

--- a/pkg/cfres/route53/record_set_group_unit_test.go
+++ b/pkg/cfres/route53/record_set_group_unit_test.go
@@ -268,6 +268,11 @@ func TestRecordSetGroup_Read_AssemblesAndSorts(t *testing.T) {
 	require.Len(t, props.RecordSets, 2)
 	assert.Equal(t, "a.example.com", props.RecordSets[0]["Name"], "records should be sorted by name")
 	assert.Equal(t, "b.example.com", props.RecordSets[1]["Name"])
+	// HostedZoneId belongs to the group, not to each record. The declared
+	// RecordSet shape carries no per-record HostedZoneId, so emitting one reads
+	// back as unexpected drift.
+	assert.NotContains(t, props.RecordSets[0], "HostedZoneId", "per-record entries must not carry HostedZoneId")
+	assert.NotContains(t, props.RecordSets[1], "HostedZoneId", "per-record entries must not carry HostedZoneId")
 }
 
 func TestRecordSetGroup_Read_NotFoundWhenNonePresent(t *testing.T) {

--- a/pkg/cfres/route53/record_set_group_unit_test.go
+++ b/pkg/cfres/route53/record_set_group_unit_test.go
@@ -1,0 +1,457 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package route53
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/route53"
+	"github.com/aws/aws-sdk-go-v2/service/route53/types"
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func recordSetGroupProps(zoneID string, records []map[string]any) json.RawMessage {
+	b, _ := json.Marshal(map[string]any{
+		"HostedZoneId": zoneID,
+		"RecordSets":   records,
+	})
+	return b
+}
+
+func changeOutput(id string) *route53.ChangeResourceRecordSetsOutput {
+	return &route53.ChangeResourceRecordSetsOutput{
+		ChangeInfo: &types.ChangeInfo{Id: aws.String(id)},
+	}
+}
+
+func captureChange(target **route53.ChangeResourceRecordSetsInput) func(mock.Arguments) {
+	return func(args mock.Arguments) {
+		*target = args.Get(1).(*route53.ChangeResourceRecordSetsInput)
+	}
+}
+
+func changesByAction(changes []types.Change) (upserts, deletes, creates []types.Change) {
+	for _, c := range changes {
+		switch c.Action {
+		case types.ChangeActionUpsert:
+			upserts = append(upserts, c)
+		case types.ChangeActionDelete:
+			deletes = append(deletes, c)
+		case types.ChangeActionCreate:
+			creates = append(creates, c)
+		}
+	}
+	return
+}
+
+// Create batches one CREATE change per declared record and returns the
+// ChangeInfo.Id plus a NativeID that round-trips to the managed keys.
+func TestRecordSetGroup_Create_BatchesCreateActions(t *testing.T) {
+	m := &mockRoute53Client{}
+	var captured *route53.ChangeResourceRecordSetsInput
+	m.On("ChangeResourceRecordSets", mock.Anything, mock.Anything).
+		Run(captureChange(&captured)).
+		Return(changeOutput("/change/C123"), nil)
+
+	rsg := &RecordSetGroup{}
+	props := recordSetGroupProps("Z123", []map[string]any{
+		{"Name": "a.example.com", "Type": "A", "TTL": 300, "ResourceRecords": []string{"192.0.2.1"}},
+		{"Name": "txt.example.com", "Type": "TXT", "TTL": 300, "ResourceRecords": []string{`"hello"`}},
+	})
+
+	res, err := rsg.createWithClient(context.Background(), m, &resource.CreateRequest{
+		ResourceType: recordSetGroupType,
+		Properties:   props,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, res.ProgressResult)
+	assert.Equal(t, resource.OperationStatusInProgress, res.ProgressResult.OperationStatus)
+	assert.Equal(t, "/change/C123", res.ProgressResult.RequestID)
+
+	require.Len(t, captured.ChangeBatch.Changes, 2)
+	_, _, creates := changesByAction(captured.ChangeBatch.Changes)
+	assert.Len(t, creates, 2, "every change on create should be a CREATE action")
+
+	zone, keys, err := decodeRecordSetGroupNativeID(res.ProgressResult.NativeID)
+	require.NoError(t, err)
+	assert.Equal(t, "Z123", zone)
+	assert.Len(t, keys, 2)
+}
+
+// Create supports alias records: an AliasTarget record carries the canonical
+// (dotted) DNSName and no ResourceRecords/TTL.
+func TestRecordSetGroup_Create_AliasRecord(t *testing.T) {
+	m := &mockRoute53Client{}
+	var captured *route53.ChangeResourceRecordSetsInput
+	m.On("ChangeResourceRecordSets", mock.Anything, mock.Anything).
+		Run(captureChange(&captured)).
+		Return(changeOutput("/change/C1"), nil)
+
+	rsg := &RecordSetGroup{}
+	props := recordSetGroupProps("Z123", []map[string]any{
+		{
+			"Name": "alias.example.com",
+			"Type": "A",
+			"AliasTarget": map[string]any{
+				"DNSName":              "lb-123.us-east-1.elb.amazonaws.com",
+				"HostedZoneId":         "Z35SXDOTRQ7X7K",
+				"EvaluateTargetHealth": true,
+			},
+		},
+	})
+
+	_, err := rsg.createWithClient(context.Background(), m, &resource.CreateRequest{Properties: props})
+	require.NoError(t, err)
+
+	require.Len(t, captured.ChangeBatch.Changes, 1)
+	rrs := captured.ChangeBatch.Changes[0].ResourceRecordSet
+	require.NotNil(t, rrs.AliasTarget)
+	assert.Equal(t, "lb-123.us-east-1.elb.amazonaws.com.", aws.ToString(rrs.AliasTarget.DNSName),
+		"alias DNSName should carry the canonical trailing dot")
+	assert.Empty(t, rrs.ResourceRecords)
+}
+
+// Update upserts every desired record and deletes the records dropped from the
+// set — sourcing the DELETE batch from LIVE Route53 state, not stale prior props.
+func TestRecordSetGroup_Update_DiffsAgainstLiveState(t *testing.T) {
+	m := &mockRoute53Client{}
+	live := &route53.ListResourceRecordSetsOutput{
+		ResourceRecordSets: []types.ResourceRecordSet{
+			{Name: aws.String("a.example.com."), Type: types.RRTypeA, TTL: aws.Int64(300), ResourceRecords: []types.ResourceRecord{{Value: aws.String("192.0.2.1")}}},
+			{Name: aws.String("b.example.com."), Type: types.RRTypeA, TTL: aws.Int64(300), ResourceRecords: []types.ResourceRecord{{Value: aws.String("192.0.2.9")}}},
+		},
+	}
+	m.On("ListResourceRecordSets", mock.Anything, mock.Anything).Return(live, nil)
+	var captured *route53.ChangeResourceRecordSetsInput
+	m.On("ChangeResourceRecordSets", mock.Anything, mock.Anything).
+		Run(captureChange(&captured)).
+		Return(changeOutput("/change/C1"), nil)
+
+	rsg := &RecordSetGroup{}
+	// prior b carries a DIFFERENT value than live b, proving DELETE sources live state.
+	prior := recordSetGroupProps("Z1", []map[string]any{
+		{"Name": "a.example.com", "Type": "A", "TTL": 300, "ResourceRecords": []string{"192.0.2.1"}},
+		{"Name": "b.example.com", "Type": "A", "TTL": 300, "ResourceRecords": []string{"192.0.2.5"}},
+	})
+	desired := recordSetGroupProps("Z1", []map[string]any{
+		{"Name": "a.example.com", "Type": "A", "TTL": 600, "ResourceRecords": []string{"192.0.2.1"}},
+		{"Name": "c.example.com", "Type": "A", "TTL": 300, "ResourceRecords": []string{"192.0.2.3"}},
+	})
+
+	res, err := rsg.updateWithClient(context.Background(), m, &resource.UpdateRequest{
+		PriorProperties:   prior,
+		DesiredProperties: desired,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, resource.OperationStatusInProgress, res.ProgressResult.OperationStatus)
+
+	upserts, deletes, _ := changesByAction(captured.ChangeBatch.Changes)
+	var upsertNames, deleteNames []string
+	for _, c := range upserts {
+		upsertNames = append(upsertNames, aws.ToString(c.ResourceRecordSet.Name))
+	}
+	for _, c := range deletes {
+		deleteNames = append(deleteNames, aws.ToString(c.ResourceRecordSet.Name))
+	}
+	assert.ElementsMatch(t, []string{"a.example.com.", "c.example.com."}, upsertNames)
+	require.Equal(t, []string{"b.example.com."}, deleteNames)
+	require.Len(t, deletes[0].ResourceRecordSet.ResourceRecords, 1)
+	assert.Equal(t, "192.0.2.9", aws.ToString(deletes[0].ResourceRecordSet.ResourceRecords[0].Value),
+		"DELETE should use the live value (192.0.2.9), not the stale prior value (192.0.2.5)")
+
+	// NativeID recomputed from the desired key set.
+	_, keys, err := decodeRecordSetGroupNativeID(res.ProgressResult.NativeID)
+	require.NoError(t, err)
+	assert.Len(t, keys, 2)
+}
+
+func TestRecordSetGroup_Update_RejectsHostedZoneChange(t *testing.T) {
+	rsg := &RecordSetGroup{}
+	prior := recordSetGroupProps("Z1", []map[string]any{{"Name": "a.example.com", "Type": "A", "TTL": 300, "ResourceRecords": []string{"192.0.2.1"}}})
+	desired := recordSetGroupProps("Z2", []map[string]any{{"Name": "a.example.com", "Type": "A", "TTL": 300, "ResourceRecords": []string{"192.0.2.1"}}})
+
+	_, err := rsg.updateWithClient(context.Background(), &mockRoute53Client{}, &resource.UpdateRequest{
+		PriorProperties:   prior,
+		DesiredProperties: desired,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "hosted zone")
+}
+
+// Delete reads live state for the managed keys and deletes by live value.
+func TestRecordSetGroup_Delete_DeletesFromLiveValues(t *testing.T) {
+	m := &mockRoute53Client{}
+	live := &route53.ListResourceRecordSetsOutput{
+		ResourceRecordSets: []types.ResourceRecordSet{
+			{Name: aws.String("a.example.com."), Type: types.RRTypeA, TTL: aws.Int64(300), ResourceRecords: []types.ResourceRecord{{Value: aws.String("192.0.2.1")}}},
+			{Name: aws.String("b.example.com."), Type: types.RRTypeA, TTL: aws.Int64(300), ResourceRecords: []types.ResourceRecord{{Value: aws.String("192.0.2.2")}}},
+		},
+	}
+	m.On("ListResourceRecordSets", mock.Anything, mock.Anything).Return(live, nil)
+	var captured *route53.ChangeResourceRecordSetsInput
+	m.On("ChangeResourceRecordSets", mock.Anything, mock.Anything).
+		Run(captureChange(&captured)).
+		Return(changeOutput("/change/C1"), nil)
+
+	nativeID, err := encodeRecordSetGroupNativeID("Z1", []recordKey{
+		{Name: "a.example.com.", Type: "A"},
+		{Name: "b.example.com.", Type: "A"},
+	})
+	require.NoError(t, err)
+
+	rsg := &RecordSetGroup{}
+	res, err := rsg.deleteWithClient(context.Background(), m, &resource.DeleteRequest{NativeID: nativeID})
+	require.NoError(t, err)
+	assert.Equal(t, resource.OperationStatusInProgress, res.ProgressResult.OperationStatus)
+
+	_, deletes, _ := changesByAction(captured.ChangeBatch.Changes)
+	assert.Len(t, deletes, 2, "both managed records should be deleted")
+}
+
+// Delete is idempotent: when no managed records remain live, it succeeds
+// without issuing a change batch.
+func TestRecordSetGroup_Delete_NoopWhenAbsent(t *testing.T) {
+	m := &mockRoute53Client{}
+	m.On("ListResourceRecordSets", mock.Anything, mock.Anything).
+		Return(&route53.ListResourceRecordSetsOutput{}, nil)
+
+	nativeID, err := encodeRecordSetGroupNativeID("Z1", []recordKey{{Name: "a.example.com.", Type: "A"}})
+	require.NoError(t, err)
+
+	rsg := &RecordSetGroup{}
+	res, err := rsg.deleteWithClient(context.Background(), m, &resource.DeleteRequest{NativeID: nativeID})
+	require.NoError(t, err)
+	assert.Equal(t, resource.OperationStatusSuccess, res.ProgressResult.OperationStatus)
+	m.AssertNotCalled(t, "ChangeResourceRecordSets", mock.Anything, mock.Anything)
+}
+
+// Read assembles the managed records into a sorted RecordSets list regardless
+// of the order Route53 returns them.
+func TestRecordSetGroup_Read_AssemblesAndSorts(t *testing.T) {
+	m := &mockRoute53Client{}
+	live := &route53.ListResourceRecordSetsOutput{
+		ResourceRecordSets: []types.ResourceRecordSet{
+			{Name: aws.String("b.example.com."), Type: types.RRTypeA, TTL: aws.Int64(300), ResourceRecords: []types.ResourceRecord{{Value: aws.String("192.0.2.2")}}},
+			{Name: aws.String("a.example.com."), Type: types.RRTypeA, TTL: aws.Int64(300), ResourceRecords: []types.ResourceRecord{{Value: aws.String("192.0.2.1")}}},
+		},
+	}
+	m.On("ListResourceRecordSets", mock.Anything, mock.Anything).Return(live, nil)
+
+	nativeID, err := encodeRecordSetGroupNativeID("Z1", []recordKey{
+		{Name: "a.example.com.", Type: "A"},
+		{Name: "b.example.com.", Type: "A"},
+	})
+	require.NoError(t, err)
+
+	rsg := &RecordSetGroup{}
+	res, err := rsg.readWithClient(context.Background(), m, &resource.ReadRequest{NativeID: nativeID})
+	require.NoError(t, err)
+	require.Empty(t, res.ErrorCode)
+
+	var props struct {
+		HostedZoneId string           `json:"HostedZoneId"`
+		RecordSets   []map[string]any `json:"RecordSets"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(res.Properties), &props))
+	assert.Equal(t, "Z1", props.HostedZoneId)
+	require.Len(t, props.RecordSets, 2)
+	assert.Equal(t, "a.example.com", props.RecordSets[0]["Name"], "records should be sorted by name")
+	assert.Equal(t, "b.example.com", props.RecordSets[1]["Name"])
+}
+
+func TestRecordSetGroup_Read_NotFoundWhenNonePresent(t *testing.T) {
+	m := &mockRoute53Client{}
+	m.On("ListResourceRecordSets", mock.Anything, mock.Anything).
+		Return(&route53.ListResourceRecordSetsOutput{}, nil)
+
+	nativeID, err := encodeRecordSetGroupNativeID("Z1", []recordKey{{Name: "a.example.com.", Type: "A"}})
+	require.NoError(t, err)
+
+	rsg := &RecordSetGroup{}
+	res, err := rsg.readWithClient(context.Background(), m, &resource.ReadRequest{NativeID: nativeID})
+	require.NoError(t, err)
+	assert.Equal(t, resource.OperationErrorCodeNotFound, res.ErrorCode)
+}
+
+// A partially-present group returns the records that exist so reconcile can
+// re-create the missing ones as drift.
+func TestRecordSetGroup_Read_PartialSubset(t *testing.T) {
+	m := &mockRoute53Client{}
+	live := &route53.ListResourceRecordSetsOutput{
+		ResourceRecordSets: []types.ResourceRecordSet{
+			{Name: aws.String("a.example.com."), Type: types.RRTypeA, TTL: aws.Int64(300), ResourceRecords: []types.ResourceRecord{{Value: aws.String("192.0.2.1")}}},
+		},
+	}
+	m.On("ListResourceRecordSets", mock.Anything, mock.Anything).Return(live, nil)
+
+	nativeID, err := encodeRecordSetGroupNativeID("Z1", []recordKey{
+		{Name: "a.example.com.", Type: "A"},
+		{Name: "b.example.com.", Type: "A"},
+	})
+	require.NoError(t, err)
+
+	rsg := &RecordSetGroup{}
+	res, err := rsg.readWithClient(context.Background(), m, &resource.ReadRequest{NativeID: nativeID})
+	require.NoError(t, err)
+	require.Empty(t, res.ErrorCode)
+
+	var props struct {
+		RecordSets []map[string]any `json:"RecordSets"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(res.Properties), &props))
+	assert.Len(t, props.RecordSets, 1)
+}
+
+func TestRecordSetGroup_Read_MalformedNativeID(t *testing.T) {
+	rsg := &RecordSetGroup{}
+	for _, id := range []string{"", "Z1", "Z1|not-base64!!", "|abc"} {
+		_, err := rsg.readWithClient(context.Background(), &mockRoute53Client{}, &resource.ReadRequest{NativeID: id})
+		assert.Error(t, err, "malformed NativeID %q should error", id)
+	}
+}
+
+func TestRecordSetGroup_Status_InsyncSuccess(t *testing.T) {
+	m := &mockRoute53Client{}
+	m.On("GetChange", mock.Anything, mock.Anything).
+		Return(&route53.GetChangeOutput{ChangeInfo: &types.ChangeInfo{Id: aws.String("/change/C1"), Status: types.ChangeStatusInsync}}, nil)
+	m.On("ListResourceRecordSets", mock.Anything, mock.Anything).
+		Return(&route53.ListResourceRecordSetsOutput{
+			ResourceRecordSets: []types.ResourceRecordSet{
+				{Name: aws.String("a.example.com."), Type: types.RRTypeA, TTL: aws.Int64(300), ResourceRecords: []types.ResourceRecord{{Value: aws.String("192.0.2.1")}}},
+			},
+		}, nil)
+
+	nativeID, err := encodeRecordSetGroupNativeID("Z1", []recordKey{{Name: "a.example.com.", Type: "A"}})
+	require.NoError(t, err)
+
+	rsg := &RecordSetGroup{}
+	res, err := rsg.statusWithClient(context.Background(), m, &resource.StatusRequest{RequestID: "/change/C1", NativeID: nativeID})
+	require.NoError(t, err)
+	assert.Equal(t, resource.OperationStatusSuccess, res.ProgressResult.OperationStatus)
+	assert.NotEmpty(t, res.ProgressResult.ResourceProperties)
+}
+
+func TestRecordSetGroup_Status_PendingInProgress(t *testing.T) {
+	m := &mockRoute53Client{}
+	m.On("GetChange", mock.Anything, mock.Anything).
+		Return(&route53.GetChangeOutput{ChangeInfo: &types.ChangeInfo{Id: aws.String("/change/C1"), Status: types.ChangeStatusPending}}, nil)
+
+	rsg := &RecordSetGroup{}
+	res, err := rsg.statusWithClient(context.Background(), m, &resource.StatusRequest{RequestID: "/change/C1"})
+	require.NoError(t, err)
+	assert.Equal(t, resource.OperationStatusInProgress, res.ProgressResult.OperationStatus)
+}
+
+func TestRecordSetGroup_Create_RejectsUnsupportedRoutingField(t *testing.T) {
+	rsg := &RecordSetGroup{}
+	props := recordSetGroupProps("Z1", []map[string]any{
+		{"Name": "a.example.com", "Type": "A", "TTL": 300, "ResourceRecords": []string{"192.0.2.1"}, "SetIdentifier": "primary", "Weight": 10},
+	})
+	_, err := rsg.createWithClient(context.Background(), &mockRoute53Client{}, &resource.CreateRequest{Properties: props})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "SetIdentifier")
+}
+
+func TestRecordSetGroup_Create_RejectsDuplicateKeys(t *testing.T) {
+	rsg := &RecordSetGroup{}
+	props := recordSetGroupProps("Z1", []map[string]any{
+		{"Name": "a.example.com", "Type": "A", "TTL": 300, "ResourceRecords": []string{"192.0.2.1"}},
+		{"Name": "a.example.com.", "Type": "A", "TTL": 300, "ResourceRecords": []string{"192.0.2.2"}},
+	})
+	_, err := rsg.createWithClient(context.Background(), &mockRoute53Client{}, &resource.CreateRequest{Properties: props})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate")
+}
+
+func TestRecordSetGroup_Create_RejectsAliasAndResourceRecords(t *testing.T) {
+	rsg := &RecordSetGroup{}
+	props := recordSetGroupProps("Z1", []map[string]any{
+		{
+			"Name":            "a.example.com",
+			"Type":            "A",
+			"ResourceRecords": []string{"192.0.2.1"},
+			"AliasTarget": map[string]any{
+				"DNSName":      "lb.example.com",
+				"HostedZoneId": "Z2",
+			},
+		},
+	})
+	_, err := rsg.createWithClient(context.Background(), &mockRoute53Client{}, &resource.CreateRequest{Properties: props})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mutually exclusive")
+}
+
+func TestRecordSetGroup_Create_RejectsRecordWithoutValues(t *testing.T) {
+	rsg := &RecordSetGroup{}
+	props := recordSetGroupProps("Z1", []map[string]any{
+		{"Name": "a.example.com", "Type": "A", "TTL": 300},
+	})
+	_, err := rsg.createWithClient(context.Background(), &mockRoute53Client{}, &resource.CreateRequest{Properties: props})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "resourceRecord")
+}
+
+func TestRecordSetGroup_Create_RejectsEmptyGroup(t *testing.T) {
+	rsg := &RecordSetGroup{}
+	props := recordSetGroupProps("Z1", []map[string]any{})
+	_, err := rsg.createWithClient(context.Background(), &mockRoute53Client{}, &resource.CreateRequest{Properties: props})
+	require.Error(t, err)
+}
+
+func TestRecordSetGroup_Create_RejectsOversizedBatch(t *testing.T) {
+	records := make([]map[string]any, maxChangesPerBatch+1)
+	for i := range records {
+		records[i] = map[string]any{
+			"Name":            fmt.Sprintf("r%d.example.com", i),
+			"Type":            "A",
+			"TTL":             300,
+			"ResourceRecords": []string{"192.0.2.1"},
+		}
+	}
+	rsg := &RecordSetGroup{}
+	_, err := rsg.createWithClient(context.Background(), &mockRoute53Client{}, &resource.CreateRequest{Properties: recordSetGroupProps("Z1", records)})
+	require.Error(t, err)
+}
+
+// NativeID encoding canonicalizes names (trailing dot) so encode/decode/match
+// are dot-consistent regardless of how the name was declared.
+func TestRecordSetGroup_NativeID_RoundTripCanonicalizesNames(t *testing.T) {
+	id1, err := encodeRecordSetGroupNativeID("Z1", []recordKey{{Name: "a.example.com", Type: "A"}})
+	require.NoError(t, err)
+	id2, err := encodeRecordSetGroupNativeID("Z1", []recordKey{{Name: "a.example.com.", Type: "A"}})
+	require.NoError(t, err)
+	assert.Equal(t, id1, id2, "dotted and dot-less names should encode to the same NativeID")
+
+	zone, keys, err := decodeRecordSetGroupNativeID(id1)
+	require.NoError(t, err)
+	assert.Equal(t, "Z1", zone)
+	require.Len(t, keys, 1)
+	assert.Equal(t, "a.example.com.", keys[0].Name)
+}
+
+// Encoding is order-insensitive: the same key set in any order yields the same
+// NativeID (the list is sorted before encoding).
+func TestRecordSetGroup_NativeID_OrderIndependent(t *testing.T) {
+	id1, err := encodeRecordSetGroupNativeID("Z1", []recordKey{{Name: "a.example.com.", Type: "A"}, {Name: "b.example.com.", Type: "A"}})
+	require.NoError(t, err)
+	id2, err := encodeRecordSetGroupNativeID("Z1", []recordKey{{Name: "b.example.com.", Type: "A"}, {Name: "a.example.com.", Type: "A"}})
+	require.NoError(t, err)
+	assert.Equal(t, id1, id2)
+}
+
+func TestRecordSetGroup_List_NotSupported(t *testing.T) {
+	rsg := &RecordSetGroup{}
+	_, err := rsg.List(context.Background(), &resource.ListRequest{})
+	require.Error(t, err, "List must return an explicit error, never an empty (false-empty) list")
+}

--- a/schema/pkl/route53/recordsetgroup.pkl
+++ b/schema/pkl/route53/recordsetgroup.pkl
@@ -67,7 +67,10 @@ open class RecordSet extends formae.SubResource {
     region: aws.Region?
     resourceRecords: Listing<String>?
     setIdentifier: String?
-    ttl: String?
+    @aws.FieldHint {
+        outputField = "TTL"
+    }
+    ttl: Number?
     type: String
     weight: Int?
 }

--- a/testdata/route53-recordsetgroup-update.pkl
+++ b/testdata/route53-recordsetgroup-update.pkl
@@ -1,0 +1,71 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/route53/hostedzone.pkl"
+import "@aws/route53/recordsetgroup.pkl"
+
+// Read the test run ID from environment variable set by the test harness
+// This ensures consistent naming within a test run but unique names between runs
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local stackName = "plugin-sdk-test-route53-recordsetgroup-\(testRunID)"
+local domainName = "sdk-\(testRunID).test-formae.io"
+
+// HostedZone dependency - same as create
+local hz = new hostedzone.HostedZone {
+  label = "test-hosted-zone"
+  name = domainName
+  hostedZoneConfig = new hostedzone.HostedZoneConfig {
+    comment = "SDK test hosted zone for RecordSetGroup tests"
+  }
+}
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for Route53 RecordSetGroup"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  // HostedZone required for the RecordSetGroup
+  hz
+
+  // RecordSetGroup with the diff exercised: www TTL 300 -> 600 and an extra
+  // value, the TXT record removed, and a new CNAME record added.
+  new recordsetgroup.RecordSetGroup {
+    label = "plugin-sdk-test-recordsetgroup"
+    hostedZoneId = hz.res.id
+    recordSets = new Listing {
+      new recordsetgroup.RecordSet {
+        name = "www.\(domainName)"
+        type = "A"
+        ttl = 600
+        resourceRecords = new Listing {
+          "192.0.2.1"
+          "192.0.2.2"
+        }
+      }
+      new recordsetgroup.RecordSet {
+        name = "cname.\(domainName)"
+        type = "CNAME"
+        ttl = 300
+        resourceRecords = new Listing {
+          "www.\(domainName)"
+        }
+      }
+    }
+  }
+}

--- a/testdata/route53-recordsetgroup-update.pkl
+++ b/testdata/route53-recordsetgroup-update.pkl
@@ -44,11 +44,11 @@ forma {
   hz
 
   // RecordSetGroup update: the (name, type) membership is unchanged (www/A and
-  // txt/TXT, same as create) so the NativeID — which encodes the managed record
-  // set — stays stable, and the update is an in-place UPSERT. The mutable values
-  // change: www's TTL 300 -> 600 with an extra address, and the TXT value is
-  // rewritten. (Adding/removing a record changes the group's identity and is a
-  // replace, not an update; that path is covered by unit tests.)
+  // ipv6/AAAA, same as create) so the NativeID — which encodes the managed
+  // record set — stays stable, and the update is an in-place UPSERT. The mutable
+  // values change: www's TTL 300 -> 600 with an extra address, and the AAAA
+  // value is rewritten. (Adding/removing a record changes the group's identity
+  // and is a replace, not an update; that path is covered by unit tests.)
   new recordsetgroup.RecordSetGroup {
     label = "plugin-sdk-test-recordsetgroup"
     hostedZoneId = hz.res.id
@@ -63,11 +63,11 @@ forma {
         }
       }
       new recordsetgroup.RecordSet {
-        name = "txt.\(domainName)"
-        type = "TXT"
+        name = "ipv6.\(domainName)"
+        type = "AAAA"
         ttl = 300
         resourceRecords = new Listing {
-          "\"formae-sdk-test-updated\""
+          "2001:db8::2"
         }
       }
     }

--- a/testdata/route53-recordsetgroup-update.pkl
+++ b/testdata/route53-recordsetgroup-update.pkl
@@ -43,8 +43,12 @@ forma {
   // HostedZone required for the RecordSetGroup
   hz
 
-  // RecordSetGroup with the diff exercised: www TTL 300 -> 600 and an extra
-  // value, the TXT record removed, and a new CNAME record added.
+  // RecordSetGroup update: the (name, type) membership is unchanged (www/A and
+  // txt/TXT, same as create) so the NativeID — which encodes the managed record
+  // set — stays stable, and the update is an in-place UPSERT. The mutable values
+  // change: www's TTL 300 -> 600 with an extra address, and the TXT value is
+  // rewritten. (Adding/removing a record changes the group's identity and is a
+  // replace, not an update; that path is covered by unit tests.)
   new recordsetgroup.RecordSetGroup {
     label = "plugin-sdk-test-recordsetgroup"
     hostedZoneId = hz.res.id
@@ -59,11 +63,11 @@ forma {
         }
       }
       new recordsetgroup.RecordSet {
-        name = "cname.\(domainName)"
-        type = "CNAME"
+        name = "txt.\(domainName)"
+        type = "TXT"
         ttl = 300
         resourceRecords = new Listing {
-          "www.\(domainName)"
+          "\"formae-sdk-test-updated\""
         }
       }
     }

--- a/testdata/route53-recordsetgroup.pkl
+++ b/testdata/route53-recordsetgroup.pkl
@@ -1,0 +1,69 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/route53/hostedzone.pkl"
+import "@aws/route53/recordsetgroup.pkl"
+
+// Read the test run ID from environment variable set by the test harness
+// This ensures consistent naming within a test run but unique names between runs
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local stackName = "plugin-sdk-test-route53-recordsetgroup-\(testRunID)"
+local domainName = "sdk-\(testRunID).test-formae.io"
+
+// HostedZone dependency - the RecordSetGroup lives in this zone
+local hz = new hostedzone.HostedZone {
+  label = "test-hosted-zone"
+  name = domainName
+  hostedZoneConfig = new hostedzone.HostedZoneConfig {
+    comment = "SDK test hosted zone for RecordSetGroup tests"
+  }
+}
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for Route53 RecordSetGroup"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  // HostedZone required for the RecordSetGroup
+  hz
+
+  // RecordSetGroup under test - a batch of two simple records changed atomically
+  new recordsetgroup.RecordSetGroup {
+    label = "plugin-sdk-test-recordsetgroup"
+    hostedZoneId = hz.res.id
+    recordSets = new Listing {
+      new recordsetgroup.RecordSet {
+        name = "www.\(domainName)"
+        type = "A"
+        ttl = 300
+        resourceRecords = new Listing {
+          "192.0.2.1"
+        }
+      }
+      new recordsetgroup.RecordSet {
+        name = "txt.\(domainName)"
+        type = "TXT"
+        ttl = 300
+        resourceRecords = new Listing {
+          "\"formae-sdk-test\""
+        }
+      }
+    }
+  }
+}

--- a/testdata/route53-recordsetgroup.pkl
+++ b/testdata/route53-recordsetgroup.pkl
@@ -56,12 +56,18 @@ forma {
           "192.0.2.1"
         }
       }
+      // Second record type in the batch. Deliberately AAAA (not TXT): a TXT
+      // value must be quote-wrapped, and formae's extract-to-pkl serialization
+      // mangles embedded quotes in listing elements (PLA-108), which fails the
+      // extract round-trip for reasons unrelated to this provisioner. The
+      // provisioner treats all simple record types uniformly, so AAAA gives
+      // clean multi-type coverage.
       new recordsetgroup.RecordSet {
-        name = "txt.\(domainName)"
-        type = "TXT"
+        name = "ipv6.\(domainName)"
+        type = "AAAA"
         ttl = 300
         resourceRecords = new Listing {
-          "\"formae-sdk-test\""
+          "2001:db8::1"
         }
       }
     }


### PR DESCRIPTION
## Summary

`AWS::Route53::RecordSetGroup` is `NON_PROVISIONABLE` in the AWS Cloud Control API, so the plugin's generic CRUD path can't manage it. This adds a custom provisioner that drives a single atomic `route53:ChangeResourceRecordSets` batch per operation, modelled on the existing singular `RecordSet` provisioner and reusing its helpers.

- **Scope** is deliberately narrow: simple records only (`name`, `type`, `ttl`, `resourceRecords`, `aliasTarget`). Advanced routing fields (`setIdentifier`, weighted/latency/geo/failover/multivalue) are rejected with an explicit error rather than silently dropped — which is what makes `(Name, Type)` a complete record identity.
- **Identity**: the group has no AWS-native id, so the NativeID is `hostedZoneId|base64url(JSON of the sorted [{Name,Type}] key list)`, letting a NativeID-only Read reconstruct exactly which records the group manages.
- **CRUD**: Create emits `CREATE` actions (a pre-existing conflicting record fails loudly); Update and Delete source their `DELETE` batch from live Route53 state to satisfy delete-by-value; Read sorts the record list to avoid perpetual drift.

## Notes

- Read no longer emits a per-record `HostedZoneId`. The group owns the hosted zone (it's a group-level property); the singular record helper adds a per-record copy, which read back as unexpected drift on every reconcile. It's stripped from each record and kept at the group level.
- The conformance update fixture exercises an in-place UPSERT on a stable `(name, type)` set (the NativeID encodes membership, so changing membership is a replace, not an update — that path is covered by unit tests).
- The conformance fixtures use `A` + `AAAA` records rather than `A` + `TXT`. A TXT value must be quote-wrapped, and `formae extract`'s pkl serialization currently mangles embedded quotes in listing elements, breaking the extract round-trip for reasons unrelated to this provisioner. The provisioner handles all simple record types uniformly.

Consumers' deployment roles need `route53:ChangeResourceRecordSets`, `route53:ListResourceRecordSets`, and `route53:GetChange` — the same permissions the singular RecordSet provisioner already requires.

## Validation

- `make build`, full `make test-unit`, `golangci-lint` (0 issues), `make verify-schema` all green locally.
- `debug-conformance` (`test_cases=route53-recordsetgroup`) **green** on the branch: full CRUD lifecycle + extract + sync + update + destroy + OOB-delete.
