### PR TITLE
feat(ec2): add custom provisioner for AWS::EC2::NetworkInterfacePermission

### DIFF
--- a/pkg/cfres/ec2/networkinterfacepermission.go
+++ b/pkg/cfres/ec2/networkinterfacepermission.go
@@ -23,11 +23,12 @@ import (
 )
 
 // errCodeNetworkInterfacePermissionNotFound is the EC2 error code returned when
-// a permission id does not exist; it is the only code that maps to NotFound.
-// EC2 is inconsistent about the "Id"/"ID" casing of this family of codes (e.g.
-// InvalidNetworkInterfaceAttachmentId.Malformed vs InvalidNetworkInterfaceID.NotFound),
-// so the match below is case-insensitive.
-const errCodeNetworkInterfacePermissionNotFound = "InvalidNetworkInterfacePermissionID.NotFound"
+// a network interface permission id does not exist; it is the only code that
+// maps to NotFound. AWS returns the short "InvalidPermissionID.NotFound" for
+// this resource (not "InvalidNetworkInterfacePermissionID.NotFound"), matching
+// what the Terraform AWS provider checks. EC2 is also inconsistent about the
+// "Id"/"ID" casing of these codes, so the match below is case-insensitive.
+const errCodeNetworkInterfacePermissionNotFound = "InvalidPermissionID.NotFound"
 
 type networkInterfacePermissionClientInterface interface {
 	CreateNetworkInterfacePermission(ctx context.Context, params *ec2sdk.CreateNetworkInterfacePermissionInput, optFns ...func(*ec2sdk.Options)) (*ec2sdk.CreateNetworkInterfacePermissionOutput, error)

--- a/pkg/cfres/ec2/networkinterfacepermission.go
+++ b/pkg/cfres/ec2/networkinterfacepermission.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	ec2sdk "github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -23,6 +24,9 @@ import (
 
 // errCodeNetworkInterfacePermissionNotFound is the EC2 error code returned when
 // a permission id does not exist; it is the only code that maps to NotFound.
+// EC2 is inconsistent about the "Id"/"ID" casing of this family of codes (e.g.
+// InvalidNetworkInterfaceAttachmentId.Malformed vs InvalidNetworkInterfaceID.NotFound),
+// so the match below is case-insensitive.
 const errCodeNetworkInterfacePermissionNotFound = "InvalidNetworkInterfacePermissionID.NotFound"
 
 type networkInterfacePermissionClientInterface interface {
@@ -63,7 +67,7 @@ func parseNetworkInterfacePermissionNativeID(nativeID string) (string, error) {
 func isNetworkInterfacePermissionNotFound(err error) bool {
 	var apiErr smithy.APIError
 	if errors.As(err, &apiErr) {
-		return apiErr.ErrorCode() == errCodeNetworkInterfacePermissionNotFound
+		return strings.EqualFold(apiErr.ErrorCode(), errCodeNetworkInterfacePermissionNotFound)
 	}
 	return false
 }

--- a/pkg/cfres/ec2/networkinterfacepermission.go
+++ b/pkg/cfres/ec2/networkinterfacepermission.go
@@ -1,0 +1,270 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package ec2
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ec2sdk "github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/smithy-go"
+
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/cfres/prov"
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/cfres/registry"
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/config"
+)
+
+// errCodeNetworkInterfacePermissionNotFound is the EC2 error code returned when
+// a permission id does not exist; it is the only code that maps to NotFound.
+const errCodeNetworkInterfacePermissionNotFound = "InvalidNetworkInterfacePermissionID.NotFound"
+
+type networkInterfacePermissionClientInterface interface {
+	CreateNetworkInterfacePermission(ctx context.Context, params *ec2sdk.CreateNetworkInterfacePermissionInput, optFns ...func(*ec2sdk.Options)) (*ec2sdk.CreateNetworkInterfacePermissionOutput, error)
+	DescribeNetworkInterfacePermissions(ctx context.Context, params *ec2sdk.DescribeNetworkInterfacePermissionsInput, optFns ...func(*ec2sdk.Options)) (*ec2sdk.DescribeNetworkInterfacePermissionsOutput, error)
+	DeleteNetworkInterfacePermission(ctx context.Context, params *ec2sdk.DeleteNetworkInterfacePermissionInput, optFns ...func(*ec2sdk.Options)) (*ec2sdk.DeleteNetworkInterfacePermissionOutput, error)
+}
+
+type NetworkInterfacePermission struct {
+	cfg *config.Config
+}
+
+var _ prov.Provisioner = &NetworkInterfacePermission{}
+
+func init() {
+	registry.Register("AWS::EC2::NetworkInterfacePermission",
+		[]resource.Operation{
+			resource.OperationCreate,
+			resource.OperationRead,
+			resource.OperationDelete,
+		},
+		func(cfg *config.Config) prov.Provisioner {
+			return &NetworkInterfacePermission{cfg: cfg}
+		})
+}
+
+// parseNetworkInterfacePermissionNativeID returns the single permission id
+// (eni-perm-...). The id is server-assigned, so there is no composite key.
+func parseNetworkInterfacePermissionNativeID(nativeID string) (string, error) {
+	if nativeID == "" {
+		return "", fmt.Errorf("invalid NativeID: permission id is empty")
+	}
+	return nativeID, nil
+}
+
+// isNetworkInterfacePermissionNotFound reports whether err is the EC2
+// "permission id does not exist" error. Every other AWS error is surfaced.
+func isNetworkInterfacePermissionNotFound(err error) bool {
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		return apiErr.ErrorCode() == errCodeNetworkInterfacePermissionNotFound
+	}
+	return false
+}
+
+func (nip *NetworkInterfacePermission) Create(ctx context.Context, request *resource.CreateRequest) (*resource.CreateResult, error) {
+	awsCfg, err := nip.cfg.ToAwsConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("loading AWS config: %w", err)
+	}
+	return nip.createWithClient(ctx, ec2sdk.NewFromConfig(awsCfg), request)
+}
+
+func (nip *NetworkInterfacePermission) createWithClient(ctx context.Context, client networkInterfacePermissionClientInterface, request *resource.CreateRequest) (*resource.CreateResult, error) {
+	var props map[string]any
+	if err := json.Unmarshal(request.Properties, &props); err != nil {
+		return nil, fmt.Errorf("parsing properties: %w", err)
+	}
+
+	networkInterfaceID, _ := props["NetworkInterfaceId"].(string)
+	if networkInterfaceID == "" {
+		return nil, fmt.Errorf("NetworkInterfaceId is required")
+	}
+	awsAccountID, _ := props["AwsAccountId"].(string)
+	if awsAccountID == "" {
+		return nil, fmt.Errorf("AwsAccountId is required")
+	}
+	permission, _ := props["Permission"].(string)
+	if permission == "" {
+		return nil, fmt.Errorf("permission is required")
+	}
+
+	// Pre-create lookup: the permission id is server-assigned, so a Create
+	// retried after a transient-but-actually-successful call has no idempotency
+	// key. Adopt an existing matching grant instead of creating a duplicate.
+	existing, err := client.DescribeNetworkInterfacePermissions(ctx, &ec2sdk.DescribeNetworkInterfacePermissionsInput{
+		Filters: []ec2types.Filter{
+			{Name: aws.String("network-interface-permission.network-interface-id"), Values: []string{networkInterfaceID}},
+			{Name: aws.String("network-interface-permission.aws-account-id"), Values: []string{awsAccountID}},
+			{Name: aws.String("network-interface-permission.permission"), Values: []string{permission}},
+		},
+	})
+	if err != nil && !isNetworkInterfacePermissionNotFound(err) {
+		return nil, fmt.Errorf("looking up existing network interface permission: %w", err)
+	}
+	if err == nil {
+		for _, p := range existing.NetworkInterfacePermissions {
+			if p.NetworkInterfacePermissionId != nil {
+				return networkInterfacePermissionResult(&p), nil
+			}
+		}
+	}
+
+	output, err := client.CreateNetworkInterfacePermission(ctx, &ec2sdk.CreateNetworkInterfacePermissionInput{
+		NetworkInterfaceId: aws.String(networkInterfaceID),
+		AwsAccountId:       aws.String(awsAccountID),
+		Permission:         ec2types.InterfacePermissionType(permission),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("creating network interface permission: %w", err)
+	}
+	if output.InterfacePermission == nil || output.InterfacePermission.NetworkInterfacePermissionId == nil {
+		return nil, fmt.Errorf("creating network interface permission: response did not include a permission id")
+	}
+
+	return networkInterfacePermissionResult(output.InterfacePermission), nil
+}
+
+// networkInterfacePermissionResult builds a successful CreateResult straight
+// from the permission, so success and the NativeID never depend on a follow-up
+// read.
+func networkInterfacePermissionResult(p *ec2types.NetworkInterfacePermission) *resource.CreateResult {
+	id := *p.NetworkInterfacePermissionId
+	resultJSON, _ := json.Marshal(networkInterfacePermissionProps(p))
+	return &resource.CreateResult{
+		ProgressResult: &resource.ProgressResult{
+			Operation:          resource.OperationCreate,
+			OperationStatus:    resource.OperationStatusSuccess,
+			NativeID:           id,
+			ResourceProperties: resultJSON,
+		},
+	}
+}
+
+func networkInterfacePermissionProps(p *ec2types.NetworkInterfacePermission) map[string]any {
+	props := map[string]any{
+		"Id":         *p.NetworkInterfacePermissionId,
+		"Permission": string(p.Permission),
+	}
+	if p.NetworkInterfaceId != nil {
+		props["NetworkInterfaceId"] = *p.NetworkInterfaceId
+	}
+	if p.AwsAccountId != nil {
+		props["AwsAccountId"] = *p.AwsAccountId
+	}
+	return props
+}
+
+func (nip *NetworkInterfacePermission) Read(ctx context.Context, request *resource.ReadRequest) (*resource.ReadResult, error) {
+	awsCfg, err := nip.cfg.ToAwsConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("loading AWS config: %w", err)
+	}
+	return nip.readWithClient(ctx, ec2sdk.NewFromConfig(awsCfg), request)
+}
+
+func (nip *NetworkInterfacePermission) readWithClient(ctx context.Context, client networkInterfacePermissionClientInterface, request *resource.ReadRequest) (*resource.ReadResult, error) {
+	id, err := parseNetworkInterfacePermissionNativeID(request.NativeID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.DescribeNetworkInterfacePermissions(ctx, &ec2sdk.DescribeNetworkInterfacePermissionsInput{
+		NetworkInterfacePermissionIds: []string{id},
+	})
+	if err != nil {
+		if isNetworkInterfacePermissionNotFound(err) {
+			return &resource.ReadResult{
+				ResourceType: request.ResourceType,
+				ErrorCode:    resource.OperationErrorCodeNotFound,
+			}, nil
+		}
+		return nil, fmt.Errorf("describing network interface permission %s: %w", id, err)
+	}
+
+	if len(resp.NetworkInterfacePermissions) == 0 {
+		return &resource.ReadResult{
+			ResourceType: request.ResourceType,
+			ErrorCode:    resource.OperationErrorCodeNotFound,
+		}, nil
+	}
+
+	p := resp.NetworkInterfacePermissions[0]
+	propsJSON, err := json.Marshal(networkInterfacePermissionProps(&p))
+	if err != nil {
+		return nil, fmt.Errorf("marshaling properties: %w", err)
+	}
+	return &resource.ReadResult{
+		ResourceType: request.ResourceType,
+		Properties:   string(propsJSON),
+	}, nil
+}
+
+func (nip *NetworkInterfacePermission) Delete(ctx context.Context, request *resource.DeleteRequest) (*resource.DeleteResult, error) {
+	awsCfg, err := nip.cfg.ToAwsConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("loading AWS config: %w", err)
+	}
+	return nip.deleteWithClient(ctx, ec2sdk.NewFromConfig(awsCfg), request)
+}
+
+func (nip *NetworkInterfacePermission) deleteWithClient(ctx context.Context, client networkInterfacePermissionClientInterface, request *resource.DeleteRequest) (*resource.DeleteResult, error) {
+	id, err := parseNetworkInterfacePermissionNativeID(request.NativeID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Read-before-delete: an already-absent grant is a successful (idempotent)
+	// delete.
+	readResult, err := nip.readWithClient(ctx, client, &resource.ReadRequest{
+		NativeID:     request.NativeID,
+		ResourceType: request.ResourceType,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if readResult.ErrorCode == resource.OperationErrorCodeNotFound {
+		return networkInterfacePermissionDeleteSuccess(request.NativeID), nil
+	}
+
+	if _, err := client.DeleteNetworkInterfacePermission(ctx, &ec2sdk.DeleteNetworkInterfacePermissionInput{
+		NetworkInterfacePermissionId: aws.String(id),
+	}); err != nil {
+		if isNetworkInterfacePermissionNotFound(err) {
+			return networkInterfacePermissionDeleteSuccess(request.NativeID), nil
+		}
+		return nil, fmt.Errorf("deleting network interface permission %s: %w", id, err)
+	}
+
+	return networkInterfacePermissionDeleteSuccess(request.NativeID), nil
+}
+
+func networkInterfacePermissionDeleteSuccess(nativeID string) *resource.DeleteResult {
+	return &resource.DeleteResult{
+		ProgressResult: &resource.ProgressResult{
+			Operation:       resource.OperationDelete,
+			OperationStatus: resource.OperationStatusSuccess,
+			NativeID:        nativeID,
+		},
+	}
+}
+
+func (nip *NetworkInterfacePermission) Update(_ context.Context, _ *resource.UpdateRequest) (*resource.UpdateResult, error) {
+	return nil, fmt.Errorf("update is not implemented for AWS::EC2::NetworkInterfacePermission: all fields are createOnly, so a change is a replace")
+}
+
+func (nip *NetworkInterfacePermission) Status(_ context.Context, _ *resource.StatusRequest) (*resource.StatusResult, error) {
+	return nil, fmt.Errorf("status check is not implemented for AWS::EC2::NetworkInterfacePermission")
+}
+
+func (nip *NetworkInterfacePermission) List(_ context.Context, _ *resource.ListRequest) (*resource.ListResult, error) {
+	return &resource.ListResult{
+		NativeIDs: []string{},
+	}, nil
+}

--- a/pkg/cfres/ec2/networkinterfacepermission_mock_test.go
+++ b/pkg/cfres/ec2/networkinterfacepermission_mock_test.go
@@ -1,0 +1,33 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package ec2
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/stretchr/testify/mock"
+)
+
+type mockNetworkInterfacePermissionClient struct {
+	mock.Mock
+}
+
+func (m *mockNetworkInterfacePermissionClient) CreateNetworkInterfacePermission(ctx context.Context, input *ec2.CreateNetworkInterfacePermissionInput, optFns ...func(*ec2.Options)) (*ec2.CreateNetworkInterfacePermissionOutput, error) {
+	args := m.Called(ctx, input)
+	return args.Get(0).(*ec2.CreateNetworkInterfacePermissionOutput), args.Error(1)
+}
+
+func (m *mockNetworkInterfacePermissionClient) DescribeNetworkInterfacePermissions(ctx context.Context, input *ec2.DescribeNetworkInterfacePermissionsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeNetworkInterfacePermissionsOutput, error) {
+	args := m.Called(ctx, input)
+	return args.Get(0).(*ec2.DescribeNetworkInterfacePermissionsOutput), args.Error(1)
+}
+
+func (m *mockNetworkInterfacePermissionClient) DeleteNetworkInterfacePermission(ctx context.Context, input *ec2.DeleteNetworkInterfacePermissionInput, optFns ...func(*ec2.Options)) (*ec2.DeleteNetworkInterfacePermissionOutput, error) {
+	args := m.Called(ctx, input)
+	return args.Get(0).(*ec2.DeleteNetworkInterfacePermissionOutput), args.Error(1)
+}

--- a/pkg/cfres/ec2/networkinterfacepermission_test.go
+++ b/pkg/cfres/ec2/networkinterfacepermission_test.go
@@ -191,6 +191,30 @@ func TestNetworkInterfacePermission_Read_NotFound_ByErrorCode(t *testing.T) {
 	client.AssertExpectations(t)
 }
 
+// EC2 returns the not-found code with inconsistent "Id"/"ID" casing across the
+// network-interface family. The lowercase-"Id" form is what a deleted permission
+// yields in practice (this is the out-of-band-delete sync path); classification
+// must be case-insensitive so sync tombstones the resource instead of erroring.
+func TestNetworkInterfacePermission_Read_NotFound_ByErrorCode_LowercaseId(t *testing.T) {
+	ctx := context.Background()
+	client := &mockNetworkInterfacePermissionClient{}
+
+	client.On("DescribeNetworkInterfacePermissions", ctx, mock.Anything).Return(
+		(*ec2sdk.DescribeNetworkInterfacePermissionsOutput)(nil),
+		&fakeNIPAPIError{code: "InvalidNetworkInterfacePermissionId.NotFound"},
+	)
+
+	nip := &NetworkInterfacePermission{}
+	result, err := nip.readWithClient(ctx, client, &resource.ReadRequest{
+		NativeID:     "eni-perm-gone",
+		ResourceType: "AWS::EC2::NetworkInterfacePermission",
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, resource.OperationErrorCodeNotFound, result.ErrorCode)
+	client.AssertExpectations(t)
+}
+
 func TestNetworkInterfacePermission_Read_NotFound_EmptyList(t *testing.T) {
 	ctx := context.Background()
 	client := &mockNetworkInterfacePermissionClient{}

--- a/pkg/cfres/ec2/networkinterfacepermission_test.go
+++ b/pkg/cfres/ec2/networkinterfacepermission_test.go
@@ -177,7 +177,7 @@ func TestNetworkInterfacePermission_Read_NotFound_ByErrorCode(t *testing.T) {
 
 	client.On("DescribeNetworkInterfacePermissions", ctx, mock.Anything).Return(
 		(*ec2sdk.DescribeNetworkInterfacePermissionsOutput)(nil),
-		&fakeNIPAPIError{code: "InvalidNetworkInterfacePermissionID.NotFound"},
+		&fakeNIPAPIError{code: "InvalidPermissionID.NotFound"},
 	)
 
 	nip := &NetworkInterfacePermission{}
@@ -201,7 +201,7 @@ func TestNetworkInterfacePermission_Read_NotFound_ByErrorCode_LowercaseId(t *tes
 
 	client.On("DescribeNetworkInterfacePermissions", ctx, mock.Anything).Return(
 		(*ec2sdk.DescribeNetworkInterfacePermissionsOutput)(nil),
-		&fakeNIPAPIError{code: "InvalidNetworkInterfacePermissionId.NotFound"},
+		&fakeNIPAPIError{code: "InvalidPermissionId.NotFound"},
 	)
 
 	nip := &NetworkInterfacePermission{}
@@ -290,7 +290,7 @@ func TestNetworkInterfacePermission_Delete_IdempotentWhenGone(t *testing.T) {
 	// Read-before-delete reports it is already gone.
 	client.On("DescribeNetworkInterfacePermissions", ctx, mock.Anything).Return(
 		(*ec2sdk.DescribeNetworkInterfacePermissionsOutput)(nil),
-		&fakeNIPAPIError{code: "InvalidNetworkInterfacePermissionID.NotFound"},
+		&fakeNIPAPIError{code: "InvalidPermissionID.NotFound"},
 	)
 
 	nip := &NetworkInterfacePermission{}

--- a/pkg/cfres/ec2/networkinterfacepermission_test.go
+++ b/pkg/cfres/ec2/networkinterfacepermission_test.go
@@ -1,0 +1,303 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package ec2
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	ec2sdk "github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/smithy-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+)
+
+// fakeNIPAPIError is a minimal smithy.APIError used to exercise the narrow
+// error classification (NotFound vs. surfaced).
+type fakeNIPAPIError struct {
+	code string
+}
+
+func (e *fakeNIPAPIError) Error() string                 { return e.code }
+func (e *fakeNIPAPIError) ErrorCode() string             { return e.code }
+func (e *fakeNIPAPIError) ErrorMessage() string          { return e.code }
+func (e *fakeNIPAPIError) ErrorFault() smithy.ErrorFault { return smithy.FaultServer }
+
+func nipCreateProps() json.RawMessage {
+	props := map[string]any{
+		"NetworkInterfaceId": "eni-123",
+		"AwsAccountId":       "123456789012",
+		"Permission":         "INSTANCE-ATTACH",
+	}
+	b, _ := json.Marshal(props)
+	return b
+}
+
+func TestNetworkInterfacePermission_Create_Success(t *testing.T) {
+	ctx := context.Background()
+	client := &mockNetworkInterfacePermissionClient{}
+
+	// Pre-create lookup finds nothing.
+	client.On("DescribeNetworkInterfacePermissions", ctx, mock.MatchedBy(func(input *ec2sdk.DescribeNetworkInterfacePermissionsInput) bool {
+		return len(input.Filters) == 3
+	})).Return(&ec2sdk.DescribeNetworkInterfacePermissionsOutput{}, nil)
+
+	client.On("CreateNetworkInterfacePermission", ctx, mock.MatchedBy(func(input *ec2sdk.CreateNetworkInterfacePermissionInput) bool {
+		return input.NetworkInterfaceId != nil && *input.NetworkInterfaceId == "eni-123" &&
+			input.AwsAccountId != nil && *input.AwsAccountId == "123456789012" &&
+			input.Permission == ec2types.InterfacePermissionTypeInstanceAttach
+	})).Return(&ec2sdk.CreateNetworkInterfacePermissionOutput{
+		InterfacePermission: &ec2types.NetworkInterfacePermission{
+			NetworkInterfacePermissionId: strPtr("eni-perm-0abc123"),
+			NetworkInterfaceId:           strPtr("eni-123"),
+			AwsAccountId:                 strPtr("123456789012"),
+			Permission:                   ec2types.InterfacePermissionTypeInstanceAttach,
+		},
+	}, nil)
+
+	nip := &NetworkInterfacePermission{}
+	result, err := nip.createWithClient(ctx, client, &resource.CreateRequest{
+		Properties:   nipCreateProps(),
+		ResourceType: "AWS::EC2::NetworkInterfacePermission",
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, resource.OperationStatusSuccess, result.ProgressResult.OperationStatus)
+	assert.Equal(t, "eni-perm-0abc123", result.ProgressResult.NativeID)
+
+	var props map[string]any
+	assert.NoError(t, json.Unmarshal(result.ProgressResult.ResourceProperties, &props))
+	assert.Equal(t, "eni-perm-0abc123", props["Id"])
+	assert.Equal(t, "eni-123", props["NetworkInterfaceId"])
+	assert.Equal(t, "123456789012", props["AwsAccountId"])
+	assert.Equal(t, "INSTANCE-ATTACH", props["Permission"])
+	client.AssertExpectations(t)
+}
+
+func TestNetworkInterfacePermission_Create_MissingRequiredField(t *testing.T) {
+	ctx := context.Background()
+	client := &mockNetworkInterfacePermissionClient{}
+
+	props := map[string]any{
+		"AwsAccountId": "123456789012",
+		"Permission":   "INSTANCE-ATTACH",
+	}
+	propsJSON, _ := json.Marshal(props)
+
+	nip := &NetworkInterfacePermission{}
+	result, err := nip.createWithClient(ctx, client, &resource.CreateRequest{
+		Properties: propsJSON,
+	})
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	// No AWS calls should be made when a required field is missing.
+	client.AssertNotCalled(t, "DescribeNetworkInterfacePermissions", mock.Anything, mock.Anything)
+	client.AssertNotCalled(t, "CreateNetworkInterfacePermission", mock.Anything, mock.Anything)
+}
+
+func TestNetworkInterfacePermission_Create_AdoptsExistingGrant(t *testing.T) {
+	ctx := context.Background()
+	client := &mockNetworkInterfacePermissionClient{}
+
+	// Pre-create lookup already finds a matching grant — adopt its id, do not
+	// create a second one.
+	client.On("DescribeNetworkInterfacePermissions", ctx, mock.MatchedBy(func(input *ec2sdk.DescribeNetworkInterfacePermissionsInput) bool {
+		return len(input.Filters) == 3
+	})).Return(&ec2sdk.DescribeNetworkInterfacePermissionsOutput{
+		NetworkInterfacePermissions: []ec2types.NetworkInterfacePermission{
+			{
+				NetworkInterfacePermissionId: strPtr("eni-perm-existing"),
+				NetworkInterfaceId:           strPtr("eni-123"),
+				AwsAccountId:                 strPtr("123456789012"),
+				Permission:                   ec2types.InterfacePermissionTypeInstanceAttach,
+			},
+		},
+	}, nil)
+
+	nip := &NetworkInterfacePermission{}
+	result, err := nip.createWithClient(ctx, client, &resource.CreateRequest{
+		Properties:   nipCreateProps(),
+		ResourceType: "AWS::EC2::NetworkInterfacePermission",
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, resource.OperationStatusSuccess, result.ProgressResult.OperationStatus)
+	assert.Equal(t, "eni-perm-existing", result.ProgressResult.NativeID)
+	client.AssertNotCalled(t, "CreateNetworkInterfacePermission", mock.Anything, mock.Anything)
+	client.AssertExpectations(t)
+}
+
+func TestNetworkInterfacePermission_Read_Found(t *testing.T) {
+	ctx := context.Background()
+	client := &mockNetworkInterfacePermissionClient{}
+
+	client.On("DescribeNetworkInterfacePermissions", ctx, mock.MatchedBy(func(input *ec2sdk.DescribeNetworkInterfacePermissionsInput) bool {
+		return len(input.NetworkInterfacePermissionIds) == 1 && input.NetworkInterfacePermissionIds[0] == "eni-perm-0abc123"
+	})).Return(&ec2sdk.DescribeNetworkInterfacePermissionsOutput{
+		NetworkInterfacePermissions: []ec2types.NetworkInterfacePermission{
+			{
+				NetworkInterfacePermissionId: strPtr("eni-perm-0abc123"),
+				NetworkInterfaceId:           strPtr("eni-123"),
+				AwsAccountId:                 strPtr("123456789012"),
+				Permission:                   ec2types.InterfacePermissionTypeInstanceAttach,
+			},
+		},
+	}, nil)
+
+	nip := &NetworkInterfacePermission{}
+	result, err := nip.readWithClient(ctx, client, &resource.ReadRequest{
+		NativeID:     "eni-perm-0abc123",
+		ResourceType: "AWS::EC2::NetworkInterfacePermission",
+	})
+
+	assert.NoError(t, err)
+	assert.Empty(t, result.ErrorCode)
+
+	var props map[string]any
+	assert.NoError(t, json.Unmarshal([]byte(result.Properties), &props))
+	assert.Equal(t, "eni-perm-0abc123", props["Id"])
+	assert.Equal(t, "eni-123", props["NetworkInterfaceId"])
+	assert.Equal(t, "123456789012", props["AwsAccountId"])
+	assert.Equal(t, "INSTANCE-ATTACH", props["Permission"])
+	client.AssertExpectations(t)
+}
+
+func TestNetworkInterfacePermission_Read_NotFound_ByErrorCode(t *testing.T) {
+	ctx := context.Background()
+	client := &mockNetworkInterfacePermissionClient{}
+
+	client.On("DescribeNetworkInterfacePermissions", ctx, mock.Anything).Return(
+		(*ec2sdk.DescribeNetworkInterfacePermissionsOutput)(nil),
+		&fakeNIPAPIError{code: "InvalidNetworkInterfacePermissionID.NotFound"},
+	)
+
+	nip := &NetworkInterfacePermission{}
+	result, err := nip.readWithClient(ctx, client, &resource.ReadRequest{
+		NativeID:     "eni-perm-gone",
+		ResourceType: "AWS::EC2::NetworkInterfacePermission",
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, resource.OperationErrorCodeNotFound, result.ErrorCode)
+	client.AssertExpectations(t)
+}
+
+func TestNetworkInterfacePermission_Read_NotFound_EmptyList(t *testing.T) {
+	ctx := context.Background()
+	client := &mockNetworkInterfacePermissionClient{}
+
+	client.On("DescribeNetworkInterfacePermissions", ctx, mock.Anything).Return(
+		&ec2sdk.DescribeNetworkInterfacePermissionsOutput{}, nil,
+	)
+
+	nip := &NetworkInterfacePermission{}
+	result, err := nip.readWithClient(ctx, client, &resource.ReadRequest{
+		NativeID:     "eni-perm-0abc123",
+		ResourceType: "AWS::EC2::NetworkInterfacePermission",
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, resource.OperationErrorCodeNotFound, result.ErrorCode)
+	client.AssertExpectations(t)
+}
+
+func TestNetworkInterfacePermission_Read_GenericErrorSurfaced(t *testing.T) {
+	ctx := context.Background()
+	client := &mockNetworkInterfacePermissionClient{}
+
+	client.On("DescribeNetworkInterfacePermissions", ctx, mock.Anything).Return(
+		(*ec2sdk.DescribeNetworkInterfacePermissionsOutput)(nil),
+		&fakeNIPAPIError{code: "UnauthorizedOperation"},
+	)
+
+	nip := &NetworkInterfacePermission{}
+	result, err := nip.readWithClient(ctx, client, &resource.ReadRequest{
+		NativeID:     "eni-perm-0abc123",
+		ResourceType: "AWS::EC2::NetworkInterfacePermission",
+	})
+
+	// A generic AWS error must be surfaced, never masked as NotFound.
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	client.AssertExpectations(t)
+}
+
+func TestNetworkInterfacePermission_Delete_Success(t *testing.T) {
+	ctx := context.Background()
+	client := &mockNetworkInterfacePermissionClient{}
+
+	// Read-before-delete finds the grant.
+	client.On("DescribeNetworkInterfacePermissions", ctx, mock.MatchedBy(func(input *ec2sdk.DescribeNetworkInterfacePermissionsInput) bool {
+		return len(input.NetworkInterfacePermissionIds) == 1 && input.NetworkInterfacePermissionIds[0] == "eni-perm-0abc123"
+	})).Return(&ec2sdk.DescribeNetworkInterfacePermissionsOutput{
+		NetworkInterfacePermissions: []ec2types.NetworkInterfacePermission{
+			{NetworkInterfacePermissionId: strPtr("eni-perm-0abc123")},
+		},
+	}, nil)
+
+	client.On("DeleteNetworkInterfacePermission", ctx, mock.MatchedBy(func(input *ec2sdk.DeleteNetworkInterfacePermissionInput) bool {
+		return input.NetworkInterfacePermissionId != nil && *input.NetworkInterfacePermissionId == "eni-perm-0abc123"
+	})).Return(&ec2sdk.DeleteNetworkInterfacePermissionOutput{}, nil)
+
+	nip := &NetworkInterfacePermission{}
+	result, err := nip.deleteWithClient(ctx, client, &resource.DeleteRequest{
+		NativeID:     "eni-perm-0abc123",
+		ResourceType: "AWS::EC2::NetworkInterfacePermission",
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, resource.OperationStatusSuccess, result.ProgressResult.OperationStatus)
+	client.AssertExpectations(t)
+}
+
+func TestNetworkInterfacePermission_Delete_IdempotentWhenGone(t *testing.T) {
+	ctx := context.Background()
+	client := &mockNetworkInterfacePermissionClient{}
+
+	// Read-before-delete reports it is already gone.
+	client.On("DescribeNetworkInterfacePermissions", ctx, mock.Anything).Return(
+		(*ec2sdk.DescribeNetworkInterfacePermissionsOutput)(nil),
+		&fakeNIPAPIError{code: "InvalidNetworkInterfacePermissionID.NotFound"},
+	)
+
+	nip := &NetworkInterfacePermission{}
+	result, err := nip.deleteWithClient(ctx, client, &resource.DeleteRequest{
+		NativeID:     "eni-perm-gone",
+		ResourceType: "AWS::EC2::NetworkInterfacePermission",
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, resource.OperationStatusSuccess, result.ProgressResult.OperationStatus)
+	client.AssertNotCalled(t, "DeleteNetworkInterfacePermission", mock.Anything, mock.Anything)
+	client.AssertExpectations(t)
+}
+
+func TestNetworkInterfacePermission_ParseNativeID(t *testing.T) {
+	id, err := parseNetworkInterfacePermissionNativeID("eni-perm-0abc123")
+	assert.NoError(t, err)
+	assert.Equal(t, "eni-perm-0abc123", id)
+
+	_, err = parseNetworkInterfacePermissionNativeID("")
+	assert.Error(t, err)
+}
+
+func TestNetworkInterfacePermission_Update_FailsLoud(t *testing.T) {
+	nip := &NetworkInterfacePermission{}
+	_, err := nip.Update(context.Background(), &resource.UpdateRequest{})
+	assert.Error(t, err)
+}
+
+func TestNetworkInterfacePermission_Status_FailsLoud(t *testing.T) {
+	nip := &NetworkInterfacePermission{}
+	_, err := nip.Status(context.Background(), &resource.StatusRequest{})
+	assert.Error(t, err)
+}

--- a/schema/pkl/ec2/networkinterface.pkl
+++ b/schema/pkl/ec2/networkinterface.pkl
@@ -39,6 +39,14 @@ open class PrivateIpAddressSpecification extends formae.SubResource {
     privateIpAddress: String
 }
 
+open class NetworkInterfaceResolvable extends formae.Resolvable {
+    hidden type = module.type
+
+    hidden id: NetworkInterfaceResolvable = (this) {
+        property = "Id"
+    }
+}
+
 @aws.ResourceHint {
     type = module.type
     identifier = "Id"
@@ -99,4 +107,11 @@ open class NetworkInterface extends formae.Resource {
         hasProviderDefault = true
     }
     tags: Listing<aws.Tag>?
+
+    local parent = this
+
+    hidden res: NetworkInterfaceResolvable = new {
+        label = parent.label
+        stack = parent.stack?.label
+    }
 }

--- a/testdata/ec2-networkinterfacepermission-replace.pkl
+++ b/testdata/ec2-networkinterfacepermission-replace.pkl
@@ -63,11 +63,7 @@ forma {
   // proves Update is correctly never registered for this all-createOnly type.
   new networkinterfacepermission.NetworkInterfacePermission {
     label = "plugin-sdk-test-eni-perm"
-    networkInterfaceId = new formae.Resolvable {
-      label = testEni.label
-      type = "AWS::EC2::NetworkInterface"
-      property = "Id"
-    }
+    networkInterfaceId = testEni.res.id
     awsAccountId = "123456789012"
     permission = "EIP-ASSOCIATE"
   }

--- a/testdata/ec2-networkinterfacepermission-replace.pkl
+++ b/testdata/ec2-networkinterfacepermission-replace.pkl
@@ -1,0 +1,74 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/ec2/vpc.pkl"
+import "@aws/ec2/subnet.pkl"
+import "@aws/ec2/networkinterface.pkl"
+import "@aws/ec2/networkinterfacepermission.pkl"
+
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local stackName = "plugin-sdk-test-ec2-networkinterfacepermission-\(testRunID)"
+
+// VPC dependency
+local testVpc = new vpc.VPC {
+  label = "test-vpc-for-eni-perm"
+  cidrBlock = "10.224.0.0/16"
+  enableDnsSupport = true
+}
+
+// Subnet dependency
+local testSubnet = new subnet.Subnet {
+  label = "test-subnet-for-eni-perm"
+  vpcId = testVpc.res.vpcId
+  cidrBlock = "10.224.1.0/24"
+  availabilityZone = "us-east-1a"
+}
+
+// NetworkInterface dependency — the permission is granted on this ENI.
+local testEni = new networkinterface.NetworkInterface {
+  label = "test-eni-for-perm"
+  subnetId = testSubnet.res.subnetId
+  description = "Test network interface for permission"
+}
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for EC2 NetworkInterfacePermission"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  testVpc
+
+  testSubnet
+
+  testEni
+
+  // NetworkInterfacePermission under test — replaced permission (createOnly
+  // field) so the harness exercises the replace path (Delete + Create), which
+  // proves Update is correctly never registered for this all-createOnly type.
+  new networkinterfacepermission.NetworkInterfacePermission {
+    label = "plugin-sdk-test-eni-perm"
+    networkInterfaceId = new formae.Resolvable {
+      label = testEni.label
+      type = "AWS::EC2::NetworkInterface"
+      property = "Id"
+    }
+    awsAccountId = "123456789012"
+    permission = "EIP-ASSOCIATE"
+  }
+}

--- a/testdata/ec2-networkinterfacepermission.pkl
+++ b/testdata/ec2-networkinterfacepermission.pkl
@@ -1,0 +1,75 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/ec2/vpc.pkl"
+import "@aws/ec2/subnet.pkl"
+import "@aws/ec2/networkinterface.pkl"
+import "@aws/ec2/networkinterfacepermission.pkl"
+
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local stackName = "plugin-sdk-test-ec2-networkinterfacepermission-\(testRunID)"
+
+// VPC dependency
+local testVpc = new vpc.VPC {
+  label = "test-vpc-for-eni-perm"
+  cidrBlock = "10.224.0.0/16"
+  enableDnsSupport = true
+}
+
+// Subnet dependency
+local testSubnet = new subnet.Subnet {
+  label = "test-subnet-for-eni-perm"
+  vpcId = testVpc.res.vpcId
+  cidrBlock = "10.224.1.0/24"
+  availabilityZone = "us-east-1a"
+}
+
+// NetworkInterface dependency — the permission is granted on this ENI.
+local testEni = new networkinterface.NetworkInterface {
+  label = "test-eni-for-perm"
+  subnetId = testSubnet.res.subnetId
+  description = "Test network interface for permission"
+}
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for EC2 NetworkInterfacePermission"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  testVpc
+
+  testSubnet
+
+  testEni
+
+  // NetworkInterfacePermission under test — leaf, singleton.
+  // The grantee must differ from the owner account; this is the AWS
+  // documentation example account id and only records a deferred-authorization
+  // grant (enforced at attach time), so it has no real blast radius.
+  new networkinterfacepermission.NetworkInterfacePermission {
+    label = "plugin-sdk-test-eni-perm"
+    networkInterfaceId = new formae.Resolvable {
+      label = testEni.label
+      type = "AWS::EC2::NetworkInterface"
+      property = "Id"
+    }
+    awsAccountId = "123456789012"
+    permission = "INSTANCE-ATTACH"
+  }
+}

--- a/testdata/ec2-networkinterfacepermission.pkl
+++ b/testdata/ec2-networkinterfacepermission.pkl
@@ -64,11 +64,7 @@ forma {
   // grant (enforced at attach time), so it has no real blast radius.
   new networkinterfacepermission.NetworkInterfacePermission {
     label = "plugin-sdk-test-eni-perm"
-    networkInterfaceId = new formae.Resolvable {
-      label = testEni.label
-      type = "AWS::EC2::NetworkInterface"
-      property = "Id"
-    }
+    networkInterfaceId = testEni.res.id
     awsAccountId = "123456789012"
     permission = "INSTANCE-ATTACH"
   }


### PR DESCRIPTION
## Summary

`AWS::EC2::NetworkInterfacePermission` is `NON_PROVISIONABLE` in the AWS Cloud Control API, so the plugin's generic CRUD path can't manage it. This adds a custom provisioner driving the EC2 API directly (`CreateNetworkInterfacePermission` / `DescribeNetworkInterfacePermissions` / `DeleteNetworkInterfacePermission`).

- Single server-assigned NativeID (`eni-perm-…`); Create/Read/Delete registered (all fields are `createOnly`, so a change is a replace; Update/Status/List are fail-loud/inert stubs).
- Create is idempotent — a pre-create describe-by-filter adopts an existing grant instead of duplicating on retry; success and the id come straight from the create response.

## Notes / fixes made to get the full lifecycle green

- **NetworkInterface now exposes a resolvable** (`res.id`). It previously had none, forcing fixtures to hand-roll a `formae.Resolvable` to reference an ENI — which `formae extract` couldn't map back (it crashed serializing the reference). NetworkInterface is now referenceable like VPC/Subnet (`someEni.res.id`), and the reference round-trips through extract.
- **Correct not-found error code.** A network interface permission that no longer exists comes back from EC2 as `InvalidPermissionID.NotFound` (the same code the Terraform AWS provider matches), not the longer `InvalidNetworkInterfacePermissionID.NotFound`. With the wrong code, a sync read of an out-of-band-deleted permission surfaced an unclassified error instead of NotFound, so it was never tombstoned. Matched case-insensitively to absorb EC2's `Id`/`ID` inconsistency; all other AWS errors are still surfaced, not masked.

Consumers' deployment roles need `ec2:CreateNetworkInterfacePermission`, `ec2:DescribeNetworkInterfacePermissions`, and `ec2:DeleteNetworkInterfacePermission` (not part of the Cloud Control permission set).

## Validation

- `make build`, full `make test-unit`, `golangci-lint` (0 issues), `make verify-schema` green locally.
- `debug-conformance` (`test_cases=ec2-networkinterfacepermission`) **green**: full CRUD + extract + sync + update + replace + destroy + out-of-band-delete detection.
