### PR TITLE
feat(iam): add custom provisioner for AWS::IAM::UserToGroupAddition

### DIFF
--- a/pkg/cfres/iam/usertogroupaddition.go
+++ b/pkg/cfres/iam/usertogroupaddition.go
@@ -1,0 +1,301 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package iam
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/cfres/prov"
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/cfres/registry"
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/cfres/utils"
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/config"
+)
+
+// AWS::IAM::UserToGroupAddition is NON_PROVISIONABLE in Cloud Control, so it goes
+// through a custom provisioner driving AddUserToGroup / RemoveUserFromGroup
+// directly. It models a SINGLE membership (one user in one group); a change to
+// either field is a replace. Current state is read from the group's member list
+// via the paginated GetGroup call.
+const userToGroupAdditionType = "AWS::IAM::UserToGroupAddition"
+
+type userToGroupAdditionClientInterface interface {
+	GetGroup(ctx context.Context, params *iam.GetGroupInput, optFns ...func(*iam.Options)) (*iam.GetGroupOutput, error)
+	AddUserToGroup(ctx context.Context, params *iam.AddUserToGroupInput, optFns ...func(*iam.Options)) (*iam.AddUserToGroupOutput, error)
+	RemoveUserFromGroup(ctx context.Context, params *iam.RemoveUserFromGroupInput, optFns ...func(*iam.Options)) (*iam.RemoveUserFromGroupOutput, error)
+}
+
+type UserToGroupAddition struct {
+	cfg *config.Config
+
+	// addAttempts / readAttempts bound the eventual-consistency polls on Create;
+	// backoff is the wait between polls and sleep is injectable for tests. Both
+	// the group and the user may be created in the same apply DAG, so the Add can
+	// transiently fail with NoSuchEntity and a fresh member may not be visible to
+	// GetGroup immediately.
+	addAttempts  int
+	readAttempts int
+	backoff      time.Duration
+	sleep        func(time.Duration)
+}
+
+var _ prov.Provisioner = &UserToGroupAddition{}
+
+func init() {
+	registry.Register(userToGroupAdditionType,
+		[]resource.Operation{
+			resource.OperationCreate,
+			resource.OperationRead,
+			resource.OperationDelete,
+		},
+		func(cfg *config.Config) prov.Provisioner {
+			return &UserToGroupAddition{
+				cfg:          cfg,
+				addAttempts:  5,
+				readAttempts: 10,
+				backoff:      2 * time.Second,
+				sleep:        time.Sleep,
+			}
+		})
+}
+
+// parseUserToGroupAdditionNativeID parses the composite NativeID groupName|userName.
+// It requires exactly two non-empty parts, rejecting "", "|", "g|" and "|u". The
+// delimiter is "|" because it is not a legal character in IAM names (comma is, so
+// comma cannot be the separator).
+func parseUserToGroupAdditionNativeID(nativeID string) (groupName, userName string, err error) {
+	parts := strings.SplitN(nativeID, "|", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("invalid NativeID format: expected groupName|userName, got: %q", nativeID)
+	}
+	return parts[0], parts[1], nil
+}
+
+// isNoSuchEntity reports whether err is the AWS NoSuchEntity error (group or user
+// does not exist). Only this error is treated as not-found; any other AWS error
+// (auth, throttle, validation, outage) is surfaced.
+func isNoSuchEntity(err error) bool {
+	var noSuchEntity *iamtypes.NoSuchEntityException
+	return errors.As(err, &noSuchEntity)
+}
+
+// groupContainsUser reports whether userName is a member of groupName, paginating
+// GetGroup because the managed user may be on a later page. A missing group is
+// surfaced as (_, err) so callers can classify it; membership absence reads as
+// (false, nil).
+func groupContainsUser(ctx context.Context, client userToGroupAdditionClientInterface, groupName, userName string) (bool, error) {
+	var marker *string
+	for {
+		out, err := client.GetGroup(ctx, &iam.GetGroupInput{
+			GroupName: aws.String(groupName),
+			Marker:    marker,
+		})
+		if err != nil {
+			return false, err
+		}
+		for _, u := range out.Users {
+			if u.UserName != nil && *u.UserName == userName {
+				return true, nil
+			}
+		}
+		if !out.IsTruncated || out.Marker == nil {
+			return false, nil
+		}
+		marker = out.Marker
+	}
+}
+
+func (p *UserToGroupAddition) Create(ctx context.Context, request *resource.CreateRequest) (*resource.CreateResult, error) {
+	awsCfg, err := p.cfg.ToAwsConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("loading AWS config: %w", err)
+	}
+	return p.createWithClient(ctx, iam.NewFromConfig(awsCfg), request)
+}
+
+func (p *UserToGroupAddition) createWithClient(ctx context.Context, client userToGroupAdditionClientInterface, request *resource.CreateRequest) (*resource.CreateResult, error) {
+	var props map[string]any
+	if err := json.Unmarshal(request.Properties, &props); err != nil {
+		return nil, fmt.Errorf("parsing properties: %w", err)
+	}
+	groupName, err := utils.GetStringProperty(props, "GroupName")
+	if err != nil {
+		return nil, fmt.Errorf("invalid GroupName: %w", err)
+	}
+	userName, err := utils.GetStringProperty(props, "UserName")
+	if err != nil {
+		return nil, fmt.Errorf("invalid UserName: %w", err)
+	}
+
+	nativeID := fmt.Sprintf("%s|%s", groupName, userName)
+
+	// AddUserToGroup is idempotent for an existing member, so re-create is safe.
+	// The group or user may not be visible yet (both created in the same apply
+	// DAG, IAM is eventually consistent), so retry on NoSuchEntity a few times.
+	var addErr error
+	for attempt := 0; attempt < p.addAttempts; attempt++ {
+		_, addErr = client.AddUserToGroup(ctx, &iam.AddUserToGroupInput{
+			GroupName: aws.String(groupName),
+			UserName:  aws.String(userName),
+		})
+		if addErr == nil {
+			break
+		}
+		if !isNoSuchEntity(addErr) {
+			return nil, fmt.Errorf("adding user %s to group %s: %w", userName, groupName, addErr)
+		}
+		if attempt < p.addAttempts-1 {
+			p.sleep(p.backoff)
+		}
+	}
+	if addErr != nil {
+		return nil, fmt.Errorf("adding user %s to group %s: %w", userName, groupName, addErr)
+	}
+
+	// Read-after-add: poll GetGroup until the member list contains the user so a
+	// Read right after Create does not spuriously report NotFound.
+	for attempt := 0; attempt < p.readAttempts; attempt++ {
+		present, err := groupContainsUser(ctx, client, groupName, userName)
+		if err != nil {
+			return nil, fmt.Errorf("confirming group membership: %w", err)
+		}
+		if present {
+			break
+		}
+		if attempt < p.readAttempts-1 {
+			p.sleep(p.backoff)
+		}
+	}
+
+	resultProps, err := json.Marshal(map[string]any{
+		"GroupName": groupName,
+		"UserName":  userName,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshaling properties: %w", err)
+	}
+
+	return &resource.CreateResult{
+		ProgressResult: &resource.ProgressResult{
+			Operation:          resource.OperationCreate,
+			OperationStatus:    resource.OperationStatusSuccess,
+			NativeID:           nativeID,
+			ResourceProperties: resultProps,
+		},
+	}, nil
+}
+
+func (p *UserToGroupAddition) Read(ctx context.Context, request *resource.ReadRequest) (*resource.ReadResult, error) {
+	awsCfg, err := p.cfg.ToAwsConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("loading AWS config: %w", err)
+	}
+	return p.readWithClient(ctx, iam.NewFromConfig(awsCfg), request)
+}
+
+func (p *UserToGroupAddition) readWithClient(ctx context.Context, client userToGroupAdditionClientInterface, request *resource.ReadRequest) (*resource.ReadResult, error) {
+	groupName, userName, err := parseUserToGroupAdditionNativeID(request.NativeID)
+	if err != nil {
+		return nil, err
+	}
+
+	present, err := groupContainsUser(ctx, client, groupName, userName)
+	if err != nil {
+		// Only a missing group maps to NotFound; any other error is surfaced.
+		if isNoSuchEntity(err) {
+			return &resource.ReadResult{
+				ResourceType: request.ResourceType,
+				ErrorCode:    resource.OperationErrorCodeNotFound,
+			}, nil
+		}
+		return nil, fmt.Errorf("reading group %s: %w", groupName, err)
+	}
+	if !present {
+		return &resource.ReadResult{
+			ResourceType: request.ResourceType,
+			ErrorCode:    resource.OperationErrorCodeNotFound,
+		}, nil
+	}
+
+	propBytes, err := json.Marshal(map[string]any{
+		"GroupName": groupName,
+		"UserName":  userName,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshaling properties: %w", err)
+	}
+	return &resource.ReadResult{
+		ResourceType: request.ResourceType,
+		Properties:   string(propBytes),
+	}, nil
+}
+
+func (p *UserToGroupAddition) Delete(ctx context.Context, request *resource.DeleteRequest) (*resource.DeleteResult, error) {
+	awsCfg, err := p.cfg.ToAwsConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("loading AWS config: %w", err)
+	}
+	return p.deleteWithClient(ctx, iam.NewFromConfig(awsCfg), request)
+}
+
+func (p *UserToGroupAddition) deleteWithClient(ctx context.Context, client userToGroupAdditionClientInterface, request *resource.DeleteRequest) (*resource.DeleteResult, error) {
+	groupName, userName, err := parseUserToGroupAdditionNativeID(request.NativeID)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := client.RemoveUserFromGroup(ctx, &iam.RemoveUserFromGroupInput{
+		GroupName: aws.String(groupName),
+		UserName:  aws.String(userName),
+	}); err != nil {
+		// Idempotent: a missing group or user means the membership is already gone.
+		if isNoSuchEntity(err) {
+			return &resource.DeleteResult{
+				ProgressResult: &resource.ProgressResult{
+					Operation:       resource.OperationDelete,
+					OperationStatus: resource.OperationStatusSuccess,
+					NativeID:        request.NativeID,
+				},
+			}, nil
+		}
+		return nil, fmt.Errorf("removing user %s from group %s: %w", userName, groupName, err)
+	}
+
+	return &resource.DeleteResult{
+		ProgressResult: &resource.ProgressResult{
+			Operation:       resource.OperationDelete,
+			OperationStatus: resource.OperationStatusSuccess,
+			NativeID:        request.NativeID,
+		},
+	}, nil
+}
+
+// Update is never invoked: both schema fields are createOnly, so any change is a
+// replace (Delete then Create). The method exists only to satisfy prov.Provisioner.
+func (p *UserToGroupAddition) Update(_ context.Context, _ *resource.UpdateRequest) (*resource.UpdateResult, error) {
+	return nil, fmt.Errorf("update is not supported for %s; a change is a replace (delete then create)", userToGroupAdditionType)
+}
+
+// Status is not registered: AddUserToGroup / RemoveUserFromGroup are synchronous,
+// so Create and Delete return success directly with no status polling.
+func (p *UserToGroupAddition) Status(_ context.Context, _ *resource.StatusRequest) (*resource.StatusResult, error) {
+	return nil, fmt.Errorf("status check is not implemented for %s", userToGroupAdditionType)
+}
+
+// List is not registered: the resource is not discoverable.
+func (p *UserToGroupAddition) List(_ context.Context, _ *resource.ListRequest) (*resource.ListResult, error) {
+	return &resource.ListResult{
+		NativeIDs: []string{},
+	}, nil
+}

--- a/pkg/cfres/iam/usertogroupaddition_mock_test.go
+++ b/pkg/cfres/iam/usertogroupaddition_mock_test.go
@@ -1,0 +1,36 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package iam
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/stretchr/testify/mock"
+)
+
+type mockUserToGroupAdditionClient struct {
+	mock.Mock
+}
+
+func (m *mockUserToGroupAdditionClient) GetGroup(ctx context.Context, input *iam.GetGroupInput, optFns ...func(*iam.Options)) (*iam.GetGroupOutput, error) {
+	args := m.Called(ctx, input)
+	out, _ := args.Get(0).(*iam.GetGroupOutput)
+	return out, args.Error(1)
+}
+
+func (m *mockUserToGroupAdditionClient) AddUserToGroup(ctx context.Context, input *iam.AddUserToGroupInput, optFns ...func(*iam.Options)) (*iam.AddUserToGroupOutput, error) {
+	args := m.Called(ctx, input)
+	out, _ := args.Get(0).(*iam.AddUserToGroupOutput)
+	return out, args.Error(1)
+}
+
+func (m *mockUserToGroupAdditionClient) RemoveUserFromGroup(ctx context.Context, input *iam.RemoveUserFromGroupInput, optFns ...func(*iam.Options)) (*iam.RemoveUserFromGroupOutput, error) {
+	args := m.Called(ctx, input)
+	out, _ := args.Get(0).(*iam.RemoveUserFromGroupOutput)
+	return out, args.Error(1)
+}

--- a/pkg/cfres/iam/usertogroupaddition_test.go
+++ b/pkg/cfres/iam/usertogroupaddition_test.go
@@ -1,0 +1,309 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package iam
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/config"
+)
+
+func newTestUserToGroupAddition() *UserToGroupAddition {
+	return &UserToGroupAddition{
+		cfg:          &config.Config{},
+		addAttempts:  3,
+		readAttempts: 3,
+		backoff:      0,
+		sleep:        func(_ time.Duration) {},
+	}
+}
+
+func noSuchEntityErr() error {
+	return fmt.Errorf("api error NoSuchEntity: %w", &iamtypes.NoSuchEntityException{Message: stringPtr("not found")})
+}
+
+func userWithName(name string) iamtypes.User {
+	return iamtypes.User{UserName: stringPtr(name)}
+}
+
+func TestUserToGroupAddition_Create_Success(t *testing.T) {
+	ctx := context.Background()
+	client := &mockUserToGroupAdditionClient{}
+
+	client.On("AddUserToGroup", ctx, mock.MatchedBy(func(in *iam.AddUserToGroupInput) bool {
+		return in.GroupName != nil && *in.GroupName == "devs" && in.UserName != nil && *in.UserName == "alice"
+	})).Return(&iam.AddUserToGroupOutput{}, nil)
+	client.On("GetGroup", ctx, mock.Anything).Return(&iam.GetGroupOutput{
+		Users: []iamtypes.User{userWithName("alice")},
+	}, nil)
+
+	p := newTestUserToGroupAddition()
+	props, _ := json.Marshal(map[string]any{"GroupName": "devs", "UserName": "alice"})
+	result, err := p.createWithClient(ctx, client, &resource.CreateRequest{
+		ResourceType: userToGroupAdditionType,
+		Properties:   props,
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, resource.OperationStatusSuccess, result.ProgressResult.OperationStatus)
+	assert.Equal(t, "devs|alice", result.ProgressResult.NativeID)
+
+	var rp map[string]any
+	_ = json.Unmarshal(result.ProgressResult.ResourceProperties, &rp)
+	assert.Equal(t, "devs", rp["GroupName"])
+	assert.Equal(t, "alice", rp["UserName"])
+	client.AssertExpectations(t)
+}
+
+func TestUserToGroupAddition_Create_AlreadyMember_Idempotent(t *testing.T) {
+	ctx := context.Background()
+	client := &mockUserToGroupAdditionClient{}
+
+	// AddUserToGroup succeeds (AWS is idempotent for existing members).
+	client.On("AddUserToGroup", ctx, mock.Anything).Return(&iam.AddUserToGroupOutput{}, nil)
+	client.On("GetGroup", ctx, mock.Anything).Return(&iam.GetGroupOutput{
+		Users: []iamtypes.User{userWithName("alice")},
+	}, nil)
+
+	p := newTestUserToGroupAddition()
+	props, _ := json.Marshal(map[string]any{"GroupName": "devs", "UserName": "alice"})
+	result, err := p.createWithClient(ctx, client, &resource.CreateRequest{Properties: props})
+
+	assert.NoError(t, err)
+	assert.Equal(t, resource.OperationStatusSuccess, result.ProgressResult.OperationStatus)
+	client.AssertExpectations(t)
+}
+
+func TestUserToGroupAddition_Create_StaleThenPresent_ReadAfterAdd(t *testing.T) {
+	ctx := context.Background()
+	client := &mockUserToGroupAdditionClient{}
+
+	client.On("AddUserToGroup", ctx, mock.Anything).Return(&iam.AddUserToGroupOutput{}, nil)
+	// First GetGroup: member not yet visible; second: present.
+	client.On("GetGroup", ctx, mock.Anything).Return(&iam.GetGroupOutput{Users: []iamtypes.User{}}, nil).Once()
+	client.On("GetGroup", ctx, mock.Anything).Return(&iam.GetGroupOutput{
+		Users: []iamtypes.User{userWithName("alice")},
+	}, nil).Once()
+
+	p := newTestUserToGroupAddition()
+	props, _ := json.Marshal(map[string]any{"GroupName": "devs", "UserName": "alice"})
+	result, err := p.createWithClient(ctx, client, &resource.CreateRequest{Properties: props})
+
+	assert.NoError(t, err)
+	assert.Equal(t, resource.OperationStatusSuccess, result.ProgressResult.OperationStatus)
+	client.AssertExpectations(t)
+}
+
+func TestUserToGroupAddition_Create_TransientNoSuchEntity_Retried(t *testing.T) {
+	ctx := context.Background()
+	client := &mockUserToGroupAdditionClient{}
+
+	// First Add fails with NoSuchEntity (group/user not visible yet), then succeeds.
+	client.On("AddUserToGroup", ctx, mock.Anything).Return((*iam.AddUserToGroupOutput)(nil), noSuchEntityErr()).Once()
+	client.On("AddUserToGroup", ctx, mock.Anything).Return(&iam.AddUserToGroupOutput{}, nil).Once()
+	client.On("GetGroup", ctx, mock.Anything).Return(&iam.GetGroupOutput{
+		Users: []iamtypes.User{userWithName("alice")},
+	}, nil)
+
+	p := newTestUserToGroupAddition()
+	props, _ := json.Marshal(map[string]any{"GroupName": "devs", "UserName": "alice"})
+	result, err := p.createWithClient(ctx, client, &resource.CreateRequest{Properties: props})
+
+	assert.NoError(t, err)
+	assert.Equal(t, resource.OperationStatusSuccess, result.ProgressResult.OperationStatus)
+	client.AssertExpectations(t)
+}
+
+func TestUserToGroupAddition_Create_MissingGroupName(t *testing.T) {
+	ctx := context.Background()
+	p := newTestUserToGroupAddition()
+	props, _ := json.Marshal(map[string]any{"UserName": "alice"})
+	_, err := p.createWithClient(ctx, &mockUserToGroupAdditionClient{}, &resource.CreateRequest{Properties: props})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "GroupName")
+}
+
+func TestUserToGroupAddition_Read_Found(t *testing.T) {
+	ctx := context.Background()
+	client := &mockUserToGroupAdditionClient{}
+
+	client.On("GetGroup", ctx, mock.MatchedBy(func(in *iam.GetGroupInput) bool {
+		return in.GroupName != nil && *in.GroupName == "devs"
+	})).Return(&iam.GetGroupOutput{
+		Users: []iamtypes.User{userWithName("bob"), userWithName("alice")},
+	}, nil)
+
+	p := newTestUserToGroupAddition()
+	result, err := p.readWithClient(ctx, client, &resource.ReadRequest{
+		NativeID:     "devs|alice",
+		ResourceType: userToGroupAdditionType,
+	})
+
+	assert.NoError(t, err)
+	assert.Empty(t, result.ErrorCode)
+	var props map[string]any
+	_ = json.Unmarshal([]byte(result.Properties), &props)
+	assert.Equal(t, "devs", props["GroupName"])
+	assert.Equal(t, "alice", props["UserName"])
+	client.AssertExpectations(t)
+}
+
+func TestUserToGroupAddition_Read_NotFound_GroupMissing(t *testing.T) {
+	ctx := context.Background()
+	client := &mockUserToGroupAdditionClient{}
+
+	client.On("GetGroup", ctx, mock.Anything).Return((*iam.GetGroupOutput)(nil), noSuchEntityErr())
+
+	p := newTestUserToGroupAddition()
+	result, err := p.readWithClient(ctx, client, &resource.ReadRequest{
+		NativeID:     "gone|alice",
+		ResourceType: userToGroupAdditionType,
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, resource.OperationErrorCodeNotFound, result.ErrorCode)
+	client.AssertExpectations(t)
+}
+
+func TestUserToGroupAddition_Read_NotFound_UserAbsent(t *testing.T) {
+	ctx := context.Background()
+	client := &mockUserToGroupAdditionClient{}
+
+	client.On("GetGroup", ctx, mock.Anything).Return(&iam.GetGroupOutput{
+		Users: []iamtypes.User{userWithName("bob")},
+	}, nil)
+
+	p := newTestUserToGroupAddition()
+	result, err := p.readWithClient(ctx, client, &resource.ReadRequest{
+		NativeID:     "devs|alice",
+		ResourceType: userToGroupAdditionType,
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, resource.OperationErrorCodeNotFound, result.ErrorCode)
+	client.AssertExpectations(t)
+}
+
+func TestUserToGroupAddition_Read_Paginated_UserOnSecondPage(t *testing.T) {
+	ctx := context.Background()
+	client := &mockUserToGroupAdditionClient{}
+
+	// Page 1: truncated, user not present.
+	client.On("GetGroup", ctx, mock.MatchedBy(func(in *iam.GetGroupInput) bool {
+		return in.Marker == nil
+	})).Return(&iam.GetGroupOutput{
+		Users:       []iamtypes.User{userWithName("bob")},
+		IsTruncated: true,
+		Marker:      stringPtr("page2"),
+	}, nil)
+	// Page 2: user present.
+	client.On("GetGroup", ctx, mock.MatchedBy(func(in *iam.GetGroupInput) bool {
+		return in.Marker != nil && *in.Marker == "page2"
+	})).Return(&iam.GetGroupOutput{
+		Users: []iamtypes.User{userWithName("alice")},
+	}, nil)
+
+	p := newTestUserToGroupAddition()
+	result, err := p.readWithClient(ctx, client, &resource.ReadRequest{
+		NativeID:     "devs|alice",
+		ResourceType: userToGroupAdditionType,
+	})
+
+	assert.NoError(t, err)
+	assert.Empty(t, result.ErrorCode)
+	client.AssertExpectations(t)
+}
+
+func TestUserToGroupAddition_Read_GenericError_Surfaced(t *testing.T) {
+	ctx := context.Background()
+	client := &mockUserToGroupAdditionClient{}
+
+	client.On("GetGroup", ctx, mock.Anything).Return((*iam.GetGroupOutput)(nil), fmt.Errorf("throttling: rate exceeded"))
+
+	p := newTestUserToGroupAddition()
+	result, err := p.readWithClient(ctx, client, &resource.ReadRequest{
+		NativeID:     "devs|alice",
+		ResourceType: userToGroupAdditionType,
+	})
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "rate exceeded")
+	client.AssertExpectations(t)
+}
+
+func TestUserToGroupAddition_Delete_Success(t *testing.T) {
+	ctx := context.Background()
+	client := &mockUserToGroupAdditionClient{}
+
+	client.On("RemoveUserFromGroup", ctx, mock.MatchedBy(func(in *iam.RemoveUserFromGroupInput) bool {
+		return in.GroupName != nil && *in.GroupName == "devs" && in.UserName != nil && *in.UserName == "alice"
+	})).Return(&iam.RemoveUserFromGroupOutput{}, nil)
+
+	p := newTestUserToGroupAddition()
+	result, err := p.deleteWithClient(ctx, client, &resource.DeleteRequest{
+		NativeID:     "devs|alice",
+		ResourceType: userToGroupAdditionType,
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, resource.OperationStatusSuccess, result.ProgressResult.OperationStatus)
+	client.AssertExpectations(t)
+}
+
+func TestUserToGroupAddition_Delete_AlreadyGone_Idempotent(t *testing.T) {
+	ctx := context.Background()
+	client := &mockUserToGroupAdditionClient{}
+
+	client.On("RemoveUserFromGroup", ctx, mock.Anything).Return((*iam.RemoveUserFromGroupOutput)(nil), noSuchEntityErr())
+
+	p := newTestUserToGroupAddition()
+	result, err := p.deleteWithClient(ctx, client, &resource.DeleteRequest{
+		NativeID:     "devs|alice",
+		ResourceType: userToGroupAdditionType,
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, resource.OperationStatusSuccess, result.ProgressResult.OperationStatus)
+	client.AssertExpectations(t)
+}
+
+func TestUserToGroupAddition_ParseNativeID(t *testing.T) {
+	cases := []struct {
+		in      string
+		wantErr bool
+		group   string
+		user    string
+	}{
+		{in: "", wantErr: true},
+		{in: "|", wantErr: true},
+		{in: "g|", wantErr: true},
+		{in: "|u", wantErr: true},
+		{in: "devs|alice", wantErr: false, group: "devs", user: "alice"},
+	}
+	for _, c := range cases {
+		g, u, err := parseUserToGroupAdditionNativeID(c.in)
+		if c.wantErr {
+			assert.Error(t, err, "input %q should error", c.in)
+			continue
+		}
+		assert.NoError(t, err, "input %q", c.in)
+		assert.Equal(t, c.group, g)
+		assert.Equal(t, c.user, u)
+	}
+}

--- a/schema/pkl/iam/usertogroupaddition.pkl
+++ b/schema/pkl/iam/usertogroupaddition.pkl
@@ -18,9 +18,9 @@ const type = "AWS::IAM::UserToGroupAddition"
 }
 open class UserToGroupAddition extends formae.Resource {
 
-    @aws.FieldHint
+    @aws.FieldHint{createOnly = true}
     groupName: String|formae.Resolvable
 
-    @aws.FieldHint
-    users: Listing<String>
+    @aws.FieldHint{createOnly = true}
+    userName: String|formae.Resolvable
 }

--- a/testdata/iam-usertogroupaddition-replace.pkl
+++ b/testdata/iam-usertogroupaddition-replace.pkl
@@ -1,0 +1,63 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/iam/group.pkl"
+import "@aws/iam/user.pkl"
+import "@aws/iam/usertogroupaddition.pkl"
+
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local stackName = "plugin-sdk-test-iam-usertogroupaddition-\(testRunID)"
+
+// Group dependency
+local parentGroup = new group.Group {
+  label = "test-group-for-membership"
+  groupName = "formae-plugin-sdk-test-utga-group-\(testRunID)"
+  path = "/"
+}
+
+// Original user dependency
+local memberUser = new user.User {
+  label = "test-user-for-membership"
+  userName = "formae-plugin-sdk-test-utga-user-\(testRunID)"
+}
+
+// Second user: the membership now points here, which is a createOnly change on
+// userName and therefore exercises the replace (delete then create) path.
+local secondUser = new user.User {
+  label = "second-test-user-for-membership"
+  userName = "formae-plugin-sdk-test-utga-user2-\(testRunID)"
+}
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for IAM UserToGroupAddition (replace)"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  parentGroup
+  memberUser
+  secondUser
+
+  // UserToGroupAddition under test, now targeting the second user (createOnly
+  // change → replace).
+  new usertogroupaddition.UserToGroupAddition {
+    label = "plugin-sdk-test-usertogroupaddition"
+    groupName = parentGroup.res.groupName
+    userName = secondUser.res.userName
+  }
+}

--- a/testdata/iam-usertogroupaddition.pkl
+++ b/testdata/iam-usertogroupaddition.pkl
@@ -1,0 +1,55 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/iam/group.pkl"
+import "@aws/iam/user.pkl"
+import "@aws/iam/usertogroupaddition.pkl"
+
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local stackName = "plugin-sdk-test-iam-usertogroupaddition-\(testRunID)"
+
+// Group dependency
+local parentGroup = new group.Group {
+  label = "test-group-for-membership"
+  groupName = "formae-plugin-sdk-test-utga-group-\(testRunID)"
+  path = "/"
+}
+
+// User dependency
+local memberUser = new user.User {
+  label = "test-user-for-membership"
+  userName = "formae-plugin-sdk-test-utga-user-\(testRunID)"
+}
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for IAM UserToGroupAddition"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  parentGroup
+  memberUser
+
+  // UserToGroupAddition under test (must be the LAST resource: harness
+  // resource-under-test, a singleton leaf).
+  new usertogroupaddition.UserToGroupAddition {
+    label = "plugin-sdk-test-usertogroupaddition"
+    groupName = parentGroup.res.groupName
+    userName = memberUser.res.userName
+  }
+}


### PR DESCRIPTION
## Summary

`AWS::IAM::UserToGroupAddition` is `NON_PROVISIONABLE` in the AWS Cloud Control API, so the plugin's generic CRUD path can't manage it. This adds a custom provisioner driving `iam:AddUserToGroup` / `iam:RemoveUserFromGroup` / `iam:GetGroup` directly.

- **Modelled as a single `(groupName, userName)` membership** rather than the CloudFormation `groupName` + `users` list. This maps 1:1 to the per-pair API, yields a clean composite NativeID (`groupName|userName`), and makes each membership an independent, singleton + leaf resource — no owned set, so two additions can't churn or delete each other's members. A consumer adding N users declares N `UserToGroupAddition` resources. Because the type has never been provisionable, there is no live state in the old shape to migrate. Both fields are `createOnly`, so a change is a replace.
- **Create is idempotent and consistency-aware:** `AddUserToGroup` is idempotent for an existing member; the Add is retried on `NoSuchEntity` (the group or user may not be visible yet in the same apply DAG), then a bounded poll of the paginated `GetGroup` confirms membership before returning.
- **Read** paginates `GetGroup` (the managed user may be on a later page); only a missing group (`NoSuchEntity`) or the user being absent maps to NotFound — every other AWS error is surfaced, not masked. **Delete** treats `NoSuchEntity` as idempotent success.
- Registers Create/Read/Delete only; Update/Status/List are inert (a change is a replace, the API is synchronous, the type is not discoverable).

Consumers' deployment roles need `iam:AddUserToGroup`, `iam:RemoveUserFromGroup`, and `iam:GetGroup` (not part of the Cloud Control permission set).

## Validation

- `make build`, full `make test-unit`, `golangci-lint` (0 issues), `make verify-schema` green locally.
- `debug-conformance` (`test_cases=iam-usertogroupaddition`) **green**: full CRUD + extract + sync + update + replace + destroy + out-of-band-delete detection.
