### PR TITLE
fix(ci): reap orphaned internet gateways so nightly stops hitting the IGW limit

### DIFF
--- a/scripts/ci/clean-environment.sh
+++ b/scripts/ci/clean-environment.sh
@@ -343,6 +343,52 @@ aws ec2 describe-internet-gateways --region "$REGION" \
     fi
 done
 
+# 18b. Delete detached (unattached) internet gateways.
+# Fixture IGWs carry no Name tag (only a formae label), so section 18's
+# tag filter never matches them. Attached test IGWs still get reaped by
+# clean_orphan_vpc (it finds them via attachment.vpc-id), but once an IGW
+# is detached — e.g. a prior run detached it and the delete-internet-gateway
+# was then throttled — nothing finds it again: its VPC is gone, so the
+# vpc-id lookup misses it, and the Name-tag filter can't match it either.
+# Such orphans accumulate every night until the per-region IGW limit
+# (default 5) is exhausted, after which every fixture that creates an IGW
+# fails with ServiceLimitExceeded. Reaping detached IGWs closes that gap.
+# An IGW with no attachments cannot belong to live infrastructure, and this
+# is consistent with the untagged-VPC policy above (untagged == test resource);
+# cleanup runs as dedicated pre/post jobs, not concurrently with the test
+# matrix, so this cannot race a job that has just created but not yet
+# attached its IGW.
+echo "Cleaning detached (orphaned) internet gateways..."
+aws ec2 describe-internet-gateways --region "$REGION" \
+    --query "InternetGateways[?length(Attachments)==\`0\`].InternetGatewayId" --output text 2>/dev/null | tr '\t' '\n' | while read -r igw_id; do
+    if [[ -n "$igw_id" ]]; then
+        echo "  Deleting detached internet gateway: $igw_id"
+        aws ec2 delete-internet-gateway --internet-gateway-id "$igw_id" --region "$REGION" 2>/dev/null || true
+    fi
+done
+
+# 18c. Detach and delete internet gateways by formae identity tag.
+# Defense in depth: fixture IGWs have no Name tag, but formae stamps a
+# FormaeStackLabel tag on every resource it creates (the discovery identity
+# tag), and every conformance stack is named "$TEST_PREFIX-...". Matching on
+# that tag reaps leaked test IGWs precisely by their formae identity — while
+# still attached (before their orphaned VPC is swept) as well as detached —
+# without touching any fixture. Detach from any VPC first, then delete.
+echo "Cleaning internet gateways by formae identity tag..."
+aws ec2 describe-internet-gateways --region "$REGION" \
+    --filters "Name=tag:FormaeStackLabel,Values=*$TEST_PREFIX*" \
+    --query "InternetGateways[].{Id:InternetGatewayId, Attachments:Attachments}" --output json 2>/dev/null | \
+    jq -c '.[]' 2>/dev/null | while read -r igw_json; do
+    igw_id=$(echo "$igw_json" | jq -r '.Id')
+    if [[ -n "$igw_id" ]]; then
+        echo "  Deleting internet gateway (formae-tagged): $igw_id"
+        echo "$igw_json" | jq -r '.Attachments[]?.VpcId // empty' 2>/dev/null | while read -r vpc_id; do
+            [[ -n "$vpc_id" ]] && aws ec2 detach-internet-gateway --internet-gateway-id "$igw_id" --vpc-id "$vpc_id" --region "$REGION" 2>/dev/null || true
+        done
+        aws ec2 delete-internet-gateway --internet-gateway-id "$igw_id" --region "$REGION" 2>/dev/null || true
+    fi
+done
+
 # 19. Detach and delete EC2 VPN gateways with test prefix (by Name tag)
 echo "Cleaning EC2 test VPN gateways..."
 aws ec2 describe-vpn-gateways --region "$REGION" \


### PR DESCRIPTION
## Summary

The nightly conformance suite has been failing on `ec2-route`, `ec2-vpcgatewayattachment`, `ecs-service-with-lb`, and `ecs-service-with-lb-rule-routing`. All four share one root cause: the shared `us-east-1` test account has hit the per-region Internet Gateway limit (default 5), so every fixture that creates an IGW fails with `ServiceLimitExceeded` — and the ECS-with-LB fixtures then burn ~24 min timing out because their tasks can never reach steady state without an internet route.

The IGWs leak because `clean-environment.sh` could not reap them:

- **Section 18** deletes IGWs only by a `Name` tag matching `*formae-plugin-sdk-test*`. Fixture IGWs carry no `Name` tag (only a formae label), so it never matched.
- **`clean_orphan_vpc`** reaps attached IGWs, but finds them via `attachment.vpc-id`. Once an IGW is **detached** — e.g. a prior run detached it and the follow-up `delete-internet-gateway` was throttled (heavy `ThrottlingException` is visible in run logs) — its VPC is gone, so the vpc-id lookup misses it and the `Name`-tag filter still cannot match it. Those orphans accumulate every night until the limit is exhausted.

## Fix

Two new reaping passes in `clean-environment.sh`:

- **18b — detached IGWs:** delete any IGW with no attachments. An unattached IGW cannot belong to live infrastructure, consistent with the existing untagged-VPC policy.
- **18c — by formae identity tag:** formae stamps a `FormaeStackLabel` tag on every resource it creates, and every conformance stack is named `<test-prefix>-…`. Matching on that tag reaps leaked test IGWs precisely by their formae identity, whether or not they are still attached — no fixture changes required.

Cleanup runs as dedicated pre/post jobs, never concurrently with the test matrix, so neither pass can race a job that has just created but not yet attached its IGW.

Verified via `debug-conformance` with `pre_cleanup=true` on the four affected cases (the improved pre-cleanup reaps the leaked IGWs, then the cases run against a clean account).