### PR TITLE
fix(iam): embed role inline policies only when the caller manages them inline

### DIFF
--- a/formae-plugin.pkl
+++ b/formae-plugin.pkl
@@ -11,7 +11,7 @@ summary = "AWS resource plugin (CloudControl-based)"
 description = "AWS CloudControl resource plugin for Formae"
 category = "cloud"
 license = "FSL-1.1-ALv2"
-minFormaeVersion = "0.87.0"
+minFormaeVersion = "0.87.1"
 
 output {
   renderer = new JsonRenderer {}

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/evanphx/json-patch/v5 v5.9.11
 	github.com/google/uuid v1.6.0
 	github.com/platform-engineering-labs/formae/pkg/model v0.1.25-0.20260528030337-9ae690b3715c
-	github.com/platform-engineering-labs/formae/pkg/plugin v0.4.0
+	github.com/platform-engineering-labs/formae/pkg/plugin v0.4.1-0.20260716201834-f45d2f367591
 	github.com/platform-engineering-labs/formae/pkg/plugin-conformance-tests v0.2.5-0.20260528030337-9ae690b3715c
 	github.com/stretchr/testify v1.11.1
 )

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/evanphx/json-patch/v5 v5.9.11
 	github.com/google/uuid v1.6.0
 	github.com/platform-engineering-labs/formae/pkg/model v0.1.25-0.20260528030337-9ae690b3715c
-	github.com/platform-engineering-labs/formae/pkg/plugin v0.4.1-0.20260716201834-f45d2f367591
+	github.com/platform-engineering-labs/formae/pkg/plugin v0.4.1
 	github.com/platform-engineering-labs/formae/pkg/plugin-conformance-tests v0.2.5-0.20260528030337-9ae690b3715c
 	github.com/stretchr/testify v1.11.1
 )

--- a/go.sum
+++ b/go.sum
@@ -134,8 +134,8 @@ github.com/platform-engineering-labs/formae/pkg/api/model v0.1.1 h1:ZMTgKwSomy2c
 github.com/platform-engineering-labs/formae/pkg/api/model v0.1.1/go.mod h1:0ncHFCsGA6b0w1kBm6m+QwJ823qAY2vL47GvoR0BTyU=
 github.com/platform-engineering-labs/formae/pkg/model v0.1.25-0.20260528030337-9ae690b3715c h1:4RiuwTM5FLJxmuiCSZe1AwoovThRF7gGrPfxHIdCxlA=
 github.com/platform-engineering-labs/formae/pkg/model v0.1.25-0.20260528030337-9ae690b3715c/go.mod h1:1dmsFwoaJZkHevBsAIZr068CWzG7de1VNz7PFWvM3Z8=
-github.com/platform-engineering-labs/formae/pkg/plugin v0.4.0 h1:NbSOq5YmeLPpFXDxqvmQ3iBfkLL7qSANPgaTbzD126o=
-github.com/platform-engineering-labs/formae/pkg/plugin v0.4.0/go.mod h1:ZFXMfeZljHVDWQTSeJ4dj2EG3iTjdrxQjm7DpvOYUXk=
+github.com/platform-engineering-labs/formae/pkg/plugin v0.4.1-0.20260716201834-f45d2f367591 h1:f+VhyVriwnlKpbB6wv4JlyTNHgyTE9QcgLew+6Exxao=
+github.com/platform-engineering-labs/formae/pkg/plugin v0.4.1-0.20260716201834-f45d2f367591/go.mod h1:ZFXMfeZljHVDWQTSeJ4dj2EG3iTjdrxQjm7DpvOYUXk=
 github.com/platform-engineering-labs/formae/pkg/plugin-conformance-tests v0.2.5-0.20260528030337-9ae690b3715c h1:Hm+eUI17d9hgtAMYS7kqfyI7MpgQ8epjBHAeAkJ/AvI=
 github.com/platform-engineering-labs/formae/pkg/plugin-conformance-tests v0.2.5-0.20260528030337-9ae690b3715c/go.mod h1:gq591ZeRZ4jAHpdSvCyrOvi8qyALxcXQQhd0B6GRMAo=
 github.com/platform-engineering-labs/orbital v0.1.36 h1:nPMLxDbwDrjlhJoMQXAE86HtVhQHC2A6BJlWYmNM75c=

--- a/go.sum
+++ b/go.sum
@@ -134,8 +134,8 @@ github.com/platform-engineering-labs/formae/pkg/api/model v0.1.1 h1:ZMTgKwSomy2c
 github.com/platform-engineering-labs/formae/pkg/api/model v0.1.1/go.mod h1:0ncHFCsGA6b0w1kBm6m+QwJ823qAY2vL47GvoR0BTyU=
 github.com/platform-engineering-labs/formae/pkg/model v0.1.25-0.20260528030337-9ae690b3715c h1:4RiuwTM5FLJxmuiCSZe1AwoovThRF7gGrPfxHIdCxlA=
 github.com/platform-engineering-labs/formae/pkg/model v0.1.25-0.20260528030337-9ae690b3715c/go.mod h1:1dmsFwoaJZkHevBsAIZr068CWzG7de1VNz7PFWvM3Z8=
-github.com/platform-engineering-labs/formae/pkg/plugin v0.4.1-0.20260716201834-f45d2f367591 h1:f+VhyVriwnlKpbB6wv4JlyTNHgyTE9QcgLew+6Exxao=
-github.com/platform-engineering-labs/formae/pkg/plugin v0.4.1-0.20260716201834-f45d2f367591/go.mod h1:ZFXMfeZljHVDWQTSeJ4dj2EG3iTjdrxQjm7DpvOYUXk=
+github.com/platform-engineering-labs/formae/pkg/plugin v0.4.1 h1:dg8TBQVJR8DVF28bvmzAG4Ms1Id0yIr6Kd8c3UTO3iw=
+github.com/platform-engineering-labs/formae/pkg/plugin v0.4.1/go.mod h1:ZFXMfeZljHVDWQTSeJ4dj2EG3iTjdrxQjm7DpvOYUXk=
 github.com/platform-engineering-labs/formae/pkg/plugin-conformance-tests v0.2.5-0.20260528030337-9ae690b3715c h1:Hm+eUI17d9hgtAMYS7kqfyI7MpgQ8epjBHAeAkJ/AvI=
 github.com/platform-engineering-labs/formae/pkg/plugin-conformance-tests v0.2.5-0.20260528030337-9ae690b3715c/go.mod h1:gq591ZeRZ4jAHpdSvCyrOvi8qyALxcXQQhd0B6GRMAo=
 github.com/platform-engineering-labs/orbital v0.1.36 h1:nPMLxDbwDrjlhJoMQXAE86HtVhQHC2A6BJlWYmNM75c=

--- a/pkg/cfres/iam/role.go
+++ b/pkg/cfres/iam/role.go
@@ -119,22 +119,28 @@ func (r *Role) readWithClients(ctx context.Context, ccxClient roleCCXReader, iam
 		return nil, err
 	}
 
-	policies, notFound, err := listInlinePolicies(ctx, iamClient, roleName)
-	if err != nil {
-		return nil, err
-	}
-	if notFound {
-		return &resource.ReadResult{
-			ResourceType: request.ResourceType,
-			ErrorCode:    resource.OperationErrorCodeNotFound,
-		}, nil
-	}
+	// Only enrich with inline policies when the caller manages them as part of
+	// the role. A caller that manages the role's policies out-of-band (standalone
+	// AWS::IAM::RolePolicy resources) has no Policies in its model, so embedding
+	// them here would show phantom drift and could drive a destructive reconcile.
+	if callerManagesPoliciesInline(request.PriorProperties) {
+		policies, notFound, err := listInlinePolicies(ctx, iamClient, roleName)
+		if err != nil {
+			return nil, err
+		}
+		if notFound {
+			return &resource.ReadResult{
+				ResourceType: request.ResourceType,
+				ErrorCode:    resource.OperationErrorCodeNotFound,
+			}, nil
+		}
 
-	// Only inject Policies when the role actually carries inline policies. A role
-	// with none must not gain an empty Policies key: an absent actual field against
-	// an absent desired field produces no diff.
-	if len(policies) > 0 {
-		props["Policies"] = policies
+		// Only inject Policies when the role actually carries inline policies. A role
+		// with none must not gain an empty Policies key: an absent actual field against
+		// an absent desired field produces no diff.
+		if len(policies) > 0 {
+			props["Policies"] = policies
+		}
 	}
 
 	out, err := json.Marshal(props)
@@ -143,6 +149,25 @@ func (r *Role) readWithClients(ctx context.Context, ccxClient roleCCXReader, iam
 	}
 	result.Properties = string(out)
 	return result, nil
+}
+
+// callerManagesPoliciesInline reports whether the caller's prior model manages
+// the role's inline policies as part of the role (an inline `policies` block),
+// rather than out-of-band via standalone AWS::IAM::RolePolicy resources. When
+// the prior model is unknown — empty PriorProperties, as on a create/status
+// read-back or discovery — it assumes inline so that roles declaring inline
+// policies do not show phantom drift. Only a known prior model that omits
+// Policies suppresses the enrichment.
+func callerManagesPoliciesInline(priorProperties json.RawMessage) bool {
+	if len(priorProperties) == 0 {
+		return true
+	}
+	var prior map[string]any
+	if err := json.Unmarshal(priorProperties, &prior); err != nil {
+		return true
+	}
+	_, ok := prior["Policies"]
+	return ok
 }
 
 // roleNameForRead resolves the role name to query IAM with. It prefers the

--- a/pkg/cfres/iam/role_test.go
+++ b/pkg/cfres/iam/role_test.go
@@ -167,6 +167,76 @@ func TestRole_Read_NoInlinePolicies_OmitsPoliciesKey(t *testing.T) {
 	iamc.AssertNotCalled(t, "GetRolePolicy", mock.Anything, mock.Anything)
 }
 
+// readReqWithPrior builds a ReadRequest whose PriorProperties carry the caller's
+// last-known model for the role.
+func readReqWithPrior(nativeID string, prior map[string]any) *resource.ReadRequest {
+	req := readReq(nativeID)
+	if prior != nil {
+		b, _ := json.Marshal(prior)
+		req.PriorProperties = b
+	}
+	return req
+}
+
+// When the caller's prior model manages the role but declares no inline
+// Policies (e.g. it manages them as standalone AWS::IAM::RolePolicy resources),
+// Read must not embed the role's inline policies — doing so would show phantom
+// drift and could drive a destructive reconcile.
+func TestRole_Read_SuppressesPolicies_WhenPriorManagesThemStandalone(t *testing.T) {
+	ccx := &mockRoleCCXReader{}
+	ccx.On("ReadResource", mock.Anything, mock.Anything).Return(&resource.ReadResult{
+		ResourceType: roleType, Properties: rolePropsJSON(t, testRoleName),
+	}, nil)
+
+	iamc := &mockRoleClient{}
+	iamc.On("ListRolePolicies", mock.Anything, matchRoleAndNoMarker(testRoleName)).Return(
+		&iam.ListRolePoliciesOutput{PolicyNames: []string{"logs-write"}}, nil)
+
+	r := newRoleWithMocks(ccx, iamc)
+	prior := map[string]any{"RoleName": testRoleName, "Description": "managed elsewhere"}
+	res, err := r.Read(context.Background(), readReqWithPrior(testRoleName, prior))
+
+	require.NoError(t, err)
+	require.Empty(t, res.ErrorCode)
+	var props map[string]any
+	require.NoError(t, json.Unmarshal([]byte(res.Properties), &props))
+	assert.NotContains(t, props, "Policies",
+		"prior model manages the role without inline Policies, so Read must not embed them")
+	iamc.AssertNotCalled(t, "GetRolePolicy", mock.Anything, mock.Anything)
+}
+
+// When the caller's prior model declares inline Policies, Read must still embed
+// them so an inline-policy role does not show phantom drift.
+func TestRole_Read_EnrichesPolicies_WhenPriorDeclaresThemInline(t *testing.T) {
+	ccx := &mockRoleCCXReader{}
+	ccx.On("ReadResource", mock.Anything, mock.Anything).Return(&resource.ReadResult{
+		ResourceType: roleType, Properties: rolePropsJSON(t, testRoleName),
+	}, nil)
+
+	iamc := &mockRoleClient{}
+	iamc.On("ListRolePolicies", mock.Anything, matchRoleAndNoMarker(testRoleName)).Return(
+		&iam.ListRolePoliciesOutput{PolicyNames: []string{"logs-write"}}, nil)
+	iamc.On("GetRolePolicy", mock.Anything, matchGetRolePolicy(testRoleName, "logs-write")).Return(
+		&iam.GetRolePolicyOutput{
+			RoleName:       aws.String(testRoleName),
+			PolicyName:     aws.String("logs-write"),
+			PolicyDocument: escapedDoc(t, `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"logs:PutLogEvents","Resource":"*"}]}`),
+		}, nil)
+
+	r := newRoleWithMocks(ccx, iamc)
+	prior := map[string]any{
+		"RoleName": testRoleName,
+		"Policies": []map[string]any{{"PolicyName": "logs-write"}},
+	}
+	res, err := r.Read(context.Background(), readReqWithPrior(testRoleName, prior))
+
+	require.NoError(t, err)
+	require.Empty(t, res.ErrorCode)
+	policies := readEnrichedPolicies(t, res.Properties)
+	require.Len(t, policies, 1)
+	assert.Equal(t, "logs-write", policies[0]["PolicyName"])
+}
+
 func TestRole_Read_UsesPathUnescapeNotQueryUnescape(t *testing.T) {
 	ccx := &mockRoleCCXReader{}
 	ccx.On("ReadResource", mock.Anything, mock.Anything).Return(&resource.ReadResult{


### PR DESCRIPTION
## Summary

- `AWS::IAM::Role`'s custom Read enriched `Properties.Policies` with the role's
  inline policies whenever the role had any, regardless of how the caller models
  them. For a caller that manages those policies as standalone
  `AWS::IAM::RolePolicy` resources, the stored row has no `Policies` key, so the
  enriched read registered as drift — rejecting every pending update on the role,
  and (worse) risking a reconcile that wipes the sibling-managed policies since
  `Role.policies` is atomic.
- Gate the enrichment on the caller's prior model, using the SDK's new
  `ReadRequest.PriorProperties`: embed only when the prior model is unknown
  (create/status read-back, discovery) or already declares `Policies`. A known
  prior that omits `Policies` suppresses the embed.
- This preserves the no-phantom-drift behaviour for roles that declare policies
  inline, while unbreaking callers that manage them as standalone resources.
- Bumps the `pkg/plugin` SDK to the version carrying `ReadRequest.PriorProperties`.

Depends on the SDK change already merged upstream; consumed here via a
pseudo-version pending a tagged SDK release.
