### PR TITLE
test(conformance): add coverage for eight resource types (batch A)

### DIFF
--- a/schema/pkl/lambda/layerversion.pkl
+++ b/schema/pkl/lambda/layerversion.pkl
@@ -18,6 +18,22 @@ open class Content extends formae.SubResource {
     s3ObjectVersion: (String|formae.Resolvable)?
 }
 
+open class LayerVersionResolvable extends formae.Resolvable {
+    hidden type = module.type
+
+    hidden layerVersionArn: LayerVersionResolvable = (this) {
+        property = "LayerVersionArn"
+    }
+
+    hidden layerArn: LayerVersionResolvable = (this) {
+        property = "LayerArn"
+    }
+
+    hidden version: LayerVersionResolvable = (this) {
+        property = "Version"
+    }
+}
+
 @aws.ResourceHint {
     type = module.type
     identifier = "LayerVersionArn"
@@ -46,4 +62,11 @@ open class LayerVersion extends formae.Resource {
 
     @aws.FieldHint{createOnly = true}
     licenseInfo: String?
+
+    hidden parent = this
+
+    hidden res: LayerVersionResolvable = new {
+        label = parent.label
+        stack = parent.stack?.label
+    }
 }

--- a/schema/pkl/lambda/version.pkl
+++ b/schema/pkl/lambda/version.pkl
@@ -42,6 +42,12 @@ open class Version extends formae.Resource {
     @aws.FieldHint{createOnly = true}
     provisionedConcurrencyConfig: ProvisionedConcurrencyConfiguration?
 
-    @aws.FieldHint{createOnly = true}
+    // AWS populates RuntimePolicy on every published version (pinning the
+    // runtime version it was published against) even when the caller never set
+    // it — conformance-observed: the extract comparison reported it as present
+    // in actual but absent from desired. The field is createOnly, so absorbing
+    // the provider value costs nothing: removal-by-omission does not apply to a
+    // field that can never be updated in place.
+    @aws.FieldHint{createOnly = true; hasProviderDefault = true}
     runtimePolicy: RuntimePolicy?
 }

--- a/schema/pkl/lambda/version.pkl
+++ b/schema/pkl/lambda/version.pkl
@@ -30,7 +30,14 @@ open class RuntimePolicy extends formae.SubResource {
 }
 open class Version extends formae.Resource {
 
-    @aws.FieldHint{createOnly = true}
+    // AWS always returns CodeSha256 — it is the hash of the code the version was
+    // published from, computed by AWS. As an input it is optional and acts as an
+    // assertion (publish only if the hash matches), so a caller usually omits it
+    // and the read-back then carries a value the desired state never had.
+    // Absorb it. Like the other fields here it is createOnly, so
+    // removal-by-omission does not apply; and when a caller *does* set it, the
+    // hint only ignores actual-only values, so the assertion still compares.
+    @aws.FieldHint{createOnly = true; hasProviderDefault = true}
     codeSha256: String?
 
     @aws.FieldHint{createOnly = true}

--- a/scripts/ci/clean-environment.sh
+++ b/scripts/ci/clean-environment.sh
@@ -1173,8 +1173,13 @@ done
 # ============================================================================
 
 # 26. Delete SQS queues with test prefix
+# `list-queues --queue-name-prefix` is a literal *starts-with* match, so it never
+# matched the fixtures' own queue names (e.g. sqs-queue.pkl's
+# `formae-plugin-sdk-test-queue-*` starts with "formae-", not "plugin-sdk-test") —
+# those queues leaked. Match with contains() across all three prefixes, as the
+# Lambda/API Gateway sweeps already do.
 echo "Cleaning SQS test queues..."
-aws sqs list-queues --region "$REGION" --queue-name-prefix "$TEST_PREFIX" --query "QueueUrls[]" --output text 2>/dev/null | tr '\t' '\n' | while read -r queue; do
+aws sqs list-queues --region "$REGION" --query "QueueUrls[?contains(@, '$FORMAE_PREFIX') || contains(@, '$SDK_PREFIX') || contains(@, '$TEST_PREFIX')]" --output text 2>/dev/null | tr '\t' '\n' | while read -r queue; do
     if [[ -n "$queue" ]]; then
         echo "  Deleting SQS queue: $queue"
         aws sqs delete-queue --queue-url "$queue" --region "$REGION" 2>/dev/null || true
@@ -1558,6 +1563,75 @@ done
 # Future-proofing: CloudFront Distributions cleanup would go here once
 # conformance creates them. Skipped today — Distribution is discoverable=false,
 # extractable=false and not in the conformance matrix.
+
+# ============================================================================
+# Batch A resource types (regional)
+# Appended at the end deliberately: each of these is a leaf or is safe to reap
+# after its parents above (NetworkFirewall rule groups must follow the firewall
+# and policy sweeps, since a policy in use holds a reference to its rule group).
+# ============================================================================
+
+# KMS aliases. Aliases are leaves — delete the alias, never the key (keys are
+# reaped by their own schedule-deletion path). Alias names carry the "alias/"
+# prefix, so match on the suffix.
+echo "Cleaning KMS test aliases..."
+aws kms list-aliases --region "$REGION" \
+    --query "Aliases[?contains(AliasName, '$FORMAE_PREFIX') || contains(AliasName, '$SDK_PREFIX') || contains(AliasName, '$TEST_PREFIX')].AliasName" \
+    --output text 2>/dev/null | tr '\t' '\n' | while read -r alias_name; do
+    if [[ -n "$alias_name" ]]; then
+        echo "  Deleting KMS alias: $alias_name"
+        aws kms delete-alias --alias-name "$alias_name" --region "$REGION" 2>/dev/null || true
+    fi
+done
+
+# Lambda layers. Every layer version must be deleted before the layer itself
+# disappears (there is no delete-layer API — a layer ceases to exist once its
+# last version is gone). LayerVersionPermission is deleted implicitly with the
+# version, so it needs no separate sweep.
+echo "Cleaning Lambda test layers..."
+aws lambda list-layers --region "$REGION" \
+    --query "Layers[?contains(LayerName, '$FORMAE_PREFIX') || contains(LayerName, '$SDK_PREFIX') || contains(LayerName, '$TEST_PREFIX')].LayerName" \
+    --output text 2>/dev/null | tr '\t' '\n' | while read -r layer_name; do
+    if [[ -n "$layer_name" ]]; then
+        aws lambda list-layer-versions --layer-name "$layer_name" --region "$REGION" \
+            --query "LayerVersions[].Version" --output text 2>/dev/null | tr '\t' '\n' | while read -r ver; do
+            if [[ -n "$ver" ]]; then
+                echo "  Deleting Lambda layer version: $layer_name:$ver"
+                aws lambda delete-layer-version --layer-name "$layer_name" --version-number "$ver" --region "$REGION" 2>/dev/null || true
+            fi
+        done
+    fi
+done
+
+# NetworkFirewall rule groups. Must run after the firewall + policy sweeps
+# above: deleting a rule group still referenced by a policy fails.
+echo "Cleaning NetworkFirewall test rule groups..."
+aws network-firewall list-rule-groups --region "$REGION" \
+    --query "RuleGroups[?contains(Name, '$FORMAE_PREFIX') || contains(Name, '$SDK_PREFIX') || contains(Name, '$TEST_PREFIX')].Name" \
+    --output text 2>/dev/null | tr '\t' '\n' | while read -r rg_name; do
+    if [[ -n "$rg_name" ]]; then
+        echo "  Deleting NetworkFirewall rule group: $rg_name"
+        # Type is required to disambiguate; try both rather than tracking which.
+        aws network-firewall delete-rule-group --rule-group-name "$rg_name" --type STATEFUL --region "$REGION" 2>/dev/null || \
+        aws network-firewall delete-rule-group --rule-group-name "$rg_name" --type STATELESS --region "$REGION" 2>/dev/null || true
+    fi
+done
+
+# IAM service-linked roles. These are NOT caught by the IAM role sweep above:
+# AWS derives the name from the service (AWSServiceRoleForAutoScaling_<suffix>),
+# so it contains no test prefix at all — per-run uniqueness comes only from the
+# CustomSuffix. Match the suffixed form and never the unsuffixed role, which
+# AWS auto-creates for the account and is not ours to delete. Deletion is async
+# (DeleteServiceLinkedRole returns a task id); we fire and let AWS drain it.
+echo "Cleaning IAM test service-linked roles..."
+aws iam list-roles --path-prefix "/aws-service-role/autoscaling.amazonaws.com/" \
+    --query "Roles[?RoleName != 'AWSServiceRoleForAutoScaling'].RoleName" \
+    --output text 2>/dev/null | tr '\t' '\n' | while read -r slr; do
+    if [[ -n "$slr" ]]; then
+        echo "  Deleting IAM service-linked role: $slr"
+        aws iam delete-service-linked-role --role-name "$slr" 2>/dev/null || true
+    fi
+done
 
 echo ""
 echo "=== Cleanup complete ==="

--- a/testdata/apigateway-usageplankey.pkl
+++ b/testdata/apigateway-usageplankey.pkl
@@ -1,0 +1,66 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/apigateway/apikey.pkl"
+import "@aws/apigateway/usageplan.pkl"
+import "@aws/apigateway/usageplankey.pkl"
+
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local stackName = "plugin-sdk-test-apigateway-usageplankey-\(testRunID)"
+
+// ApiKey dependency - the key to associate with the usage plan
+local testApiKey = new apikey.ApiKey {
+  label = "test-apikey-for-usageplankey"
+  name = "formae-sdk-test-upk-key-\(testRunID)"
+  enabled = true
+  description = "Test API Key for UsagePlanKey"
+}
+
+// UsagePlan dependency - the plan the key is associated with.
+// No apiStages needed: a usage plan can be created without stages, and
+// CreateUsagePlanKey does not require the plan to have an associated stage.
+local testUsagePlan = new usageplan.UsagePlan {
+  label = "test-usageplan-for-usageplankey"
+  usagePlanName = "formae-sdk-test-upk-plan-\(testRunID)"
+  description = "Test usage plan for UsagePlanKey"
+  throttle = new usageplan.ThrottleSettings {
+    burstLimit = 100
+    rateLimit = 50.0
+  }
+}
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for ApiGateway UsagePlanKey"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  // ApiKey (needed for the usage plan key)
+  testApiKey
+
+  // UsagePlan (parent of the usage plan key)
+  testUsagePlan
+
+  // UsagePlanKey under test
+  new usageplankey.UsagePlanKey {
+    label = "plugin-sdk-test-usageplankey"
+    keyId = testApiKey.res.apiKeyId
+    keyType = "API_KEY"
+    usagePlanId = testUsagePlan.res.id
+  }
+}

--- a/testdata/iam-servicelinkedrole.pkl
+++ b/testdata/iam-servicelinkedrole.pkl
@@ -1,0 +1,57 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+// Conformance fixture for AWS::IAM::ServiceLinkedRole. The role is standalone,
+// so it is the only resource in the stack and is trivially the singleton leaf
+// the harness requires.
+//
+// This type has no settable name: AWS derives RoleName (the readOnly primary
+// identifier) from AWSServiceName, so per-run uniqueness comes from customSuffix
+// instead of a name interpolation. testRunID yields
+// AWSServiceRoleForAutoScaling_<testRunID>, which is distinct per run and never
+// collides with the unsuffixed AWSServiceRoleForAutoScaling that EC2 Auto
+// Scaling auto-creates on first use.
+//
+// autoscaling.amazonaws.com is chosen deliberately: only some services accept
+// CustomSuffix (a service that rejects it would be limited to ONE role per
+// account and could not be tested concurrently), and Auto Scaling is the
+// service AWS's own CloudFormation documentation uses for the CustomSuffix
+// example.
+//
+// awsServiceName and customSuffix are both writeOnly — AWS does not return them
+// on read — mirroring cloudfront-function.pkl's autoPublish. Only RoleName and
+// Description come back.
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/iam/servicelinkedrole.pkl"
+
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local stackName = "plugin-sdk-test-iam-servicelinkedrole-\(testRunID)"
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for IAM ServiceLinkedRole"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  new servicelinkedrole.ServiceLinkedRole {
+    label = "plugin-sdk-test-servicelinkedrole"
+    awsServiceName = "autoscaling.amazonaws.com"
+    customSuffix = testRunID
+    description = "Plugin SDK test service-linked role"
+  }
+}

--- a/testdata/kms-alias.pkl
+++ b/testdata/kms-alias.pkl
@@ -1,0 +1,43 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/kms/key.pkl"
+import "@aws/kms/kmsalias.pkl"
+
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local stackName = "plugin-sdk-test-kms-alias-\(testRunID)"
+
+local testKey = new key.Key {
+  label = "test-key"
+  description = "Formae plugin SDK test key for KMS Alias"
+}
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for KMS Alias"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  testKey
+
+  new kmsalias.Alias {
+    label = "plugin-sdk-test-alias"
+    aliasName = "alias/formae-sdk-test-alias-\(testRunID)"
+    targetKeyId = testKey.res.arn
+  }
+}

--- a/testdata/lambda-layerversion.pkl
+++ b/testdata/lambda-layerversion.pkl
@@ -1,0 +1,70 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/s3/bucket.pkl"
+import "@aws/s3/object.pkl"
+import "@aws/lambda/layerversion.pkl"
+
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local stackName = "plugin-sdk-test-lambda-layerversion-\(testRunID)"
+
+// Lambda layer content can only be supplied from S3 (the schema has no inline
+// zipFile equivalent), so the fixture stages a minimal zip in its own bucket.
+local layerBucket = new bucket.Bucket {
+  label = "lambda-layerversion-test-bucket"
+  bucketName = "formae-plugin-sdk-test-layerver-\(testRunID)"
+}
+
+// Base64 of a deflate zip containing python/formae_layer_hello.py.
+local layerZip = new object.Object {
+  label = "lambda-layerversion-test-zip"
+  bucket = layerBucket.res.bucketName
+  key = "layers/formae-layer.zip"
+  contentBase64 = "UEsDBBQAAAAIAAAAIVoBsZUcLwAAADIAAAAcAAAAcHl0aG9uL2Zvcm1hZV9sYXllcl9oZWxsby5weUtJTVPISM3JydfQtOJSAIKi1JLSojwFJbCgQlpRfq5CWn5RbmKqQk5iZWqREhcAUEsBAhQDFAAAAAgAAAAhWgGxlRwvAAAAMgAAABwAAAAAAAAAAAAAAKQBAAAAAHB5dGhvbi9mb3JtYWVfbGF5ZXJfaGVsbG8ucHlQSwUGAAAAAAEAAQBKAAAAaQAAAAAA"
+  contentType = "application/zip"
+}
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for Lambda LayerVersion"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  layerBucket
+
+  layerZip
+
+  // Every property on LayerVersion is createOnly: publishing new content always
+  // produces a new layer version rather than mutating the existing one.
+  new layerversion.LayerVersion {
+    label = "plugin-sdk-test-lambda-layerversion"
+    layerName = "formae-sdk-test-layerver-\(testRunID)"
+    description = "Plugin SDK test layer version"
+    content = new layerversion.Content {
+      s3Bucket = layerZip.res.bucket
+      s3Key = layerZip.res.key
+    }
+    compatibleRuntimes {
+      "python3.12"
+    }
+    compatibleArchitectures {
+      "x86_64"
+    }
+    licenseInfo = "Apache-2.0"
+  }
+}

--- a/testdata/lambda-layerversionpermission.pkl
+++ b/testdata/lambda-layerversionpermission.pkl
@@ -1,0 +1,75 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/s3/bucket.pkl"
+import "@aws/s3/object.pkl"
+import "@aws/lambda/layerversion.pkl"
+import "@aws/lambda/layerversionpermission.pkl"
+
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local stackName = "plugin-sdk-test-lambda-layerversionpermission-\(testRunID)"
+
+// Lambda layer content can only be supplied from S3 (the schema has no inline
+// zipFile equivalent), so the fixture stages a minimal zip in its own bucket.
+local layerBucket = new bucket.Bucket {
+  label = "lambda-layerversionperm-test-bucket"
+  bucketName = "formae-plugin-sdk-test-layerperm-\(testRunID)"
+}
+
+// Base64 of a deflate zip containing python/formae_layer_hello.py.
+local layerZip = new object.Object {
+  label = "lambda-layerversionperm-test-zip"
+  bucket = layerBucket.res.bucketName
+  key = "layers/formae-layer.zip"
+  contentBase64 = "UEsDBBQAAAAIAAAAIVoBsZUcLwAAADIAAAAcAAAAcHl0aG9uL2Zvcm1hZV9sYXllcl9oZWxsby5weUtJTVPISM3JydfQtOJSAIKi1JLSojwFJbCgQlpRfq5CWn5RbmKqQk5iZWqREhcAUEsBAhQDFAAAAAgAAAAhWgGxlRwvAAAAMgAAABwAAAAAAAAAAAAAAKQBAAAAAHB5dGhvbi9mb3JtYWVfbGF5ZXJfaGVsbG8ucHlQSwUGAAAAAAEAAQBKAAAAaQAAAAAA"
+  contentType = "application/zip"
+}
+
+local testLayerVersion = new layerversion.LayerVersion {
+  label = "test-layerversion-for-permission"
+  layerName = "formae-sdk-test-layerperm-\(testRunID)"
+  content = new layerversion.Content {
+    s3Bucket = layerZip.res.bucket
+    s3Key = layerZip.res.key
+  }
+  compatibleRuntimes {
+    "python3.12"
+  }
+}
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for Lambda LayerVersionPermission"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  layerBucket
+
+  layerZip
+
+  testLayerVersion
+
+  // Every property is createOnly: a layer permission statement is immutable, so
+  // any change is add/remove rather than an in-place update.
+  new layerversionpermission.LayerVersionPermission {
+    label = "plugin-sdk-test-lambda-layerversionpermission"
+    layerVersionArn = testLayerVersion.res.layerVersionArn
+    action = "lambda:GetLayerVersion"
+    principal = "*"
+  }
+}

--- a/testdata/lambda-version.pkl
+++ b/testdata/lambda-version.pkl
@@ -1,0 +1,80 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/iam/role.pkl"
+import "@aws/lambda/func.pkl"
+import "@aws/lambda/version.pkl"
+
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local stackName = "plugin-sdk-test-lambda-version-\(testRunID)"
+
+local lambdaRole = new role.Role {
+  label = "lambda-execution-role"
+  roleName = "formae-sdk-test-lambda-ver-role-\(testRunID)"
+  assumeRolePolicyDocument {
+    ["Version"] = "2012-10-17"
+    ["Statement"] {
+      new {
+        ["Effect"] = "Allow"
+        ["Principal"] {
+          ["Service"] = "lambda.amazonaws.com"
+        }
+        ["Action"] = "sts:AssumeRole"
+      }
+    }
+  }
+}
+
+local testFunction = new func.Function {
+  label = "test-function-for-version"
+  functionName = "formae-sdk-test-lambda-ver-\(testRunID)"
+  role = lambdaRole.res.arn
+  runtime = "python3.12"
+  handler = "index.handler"
+  code = new func.Code {
+    zipFile = """
+      import json
+      def handler(event, context):
+          return {
+              'statusCode': 200,
+              'body': json.dumps({'message': 'hello from formae'})
+          }
+      """
+  }
+  memorySize = 128
+  timeout = 10
+}
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for Lambda Version"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  lambdaRole
+
+  testFunction
+
+  // Every property on Version is createOnly: publishing a version snapshots the
+  // function's current code, so any change replaces the version.
+  new version.Version {
+    label = "plugin-sdk-test-lambda-version"
+    functionName = testFunction.res.arn
+    description = "Plugin SDK test version"
+  }
+}

--- a/testdata/networkfirewall-rulegroup.pkl
+++ b/testdata/networkfirewall-rulegroup.pkl
@@ -1,0 +1,69 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+// Conformance fixture for AWS::NetworkFirewall::RuleGroup. The rule group is
+// standalone — it needs no VPC, policy or firewall — so it is the only resource
+// in the stack and is trivially the singleton leaf the harness requires: it is
+// last in the forma block, nothing references it, and it OOB-deletes in
+// isolation.
+//
+// The schema's RulesSource only models rulesSourceList, so a STATELESS group is
+// not expressible here; this exercises the STATEFUL domain-list surface —
+// rulesSourceList and statefulRuleOptions — plus the createOnly capacity and the
+// EntitySet tags.
+//
+// ruleVariables is deliberately NOT set: the schema declares RuleVariables.ipSets,
+// which renders on the wire as "IpSets", but AWS requires "IPSets" and rejects the
+// create with `extraneous key [IpSets] is not permitted`. The field needs an
+// outputField = "IPSets" hint (as servicelinkedrole.pkl does for AWSServiceName)
+// before any fixture can cover it.
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/networkfirewall/rulegroup.pkl"
+
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local stackName = "plugin-sdk-test-networkfirewall-rulegroup-\(testRunID)"
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for AWS Network Firewall RuleGroup"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  new rulegroup.RuleGroup {
+    label = "plugin-sdk-test-rulegroup"
+    ruleGroupName = "formae-plugin-sdk-test-rg-\(testRunID)"
+    type = "STATEFUL"
+    capacity = 100
+    description = "Plugin SDK test stateful domain allowlist rule group"
+    ruleGroup = new rulegroup.RuleGroupData {
+      rulesSource = new rulegroup.RulesSource {
+        rulesSourceList = new rulegroup.RulesSourceList {
+          targets = new Listing<String> { "github.com"; "api.anthropic.com" }
+          targetTypes = new Listing<rulegroup.TargetType> { "TLS_SNI"; "HTTP_HOST" }
+          generatedRulesType = "ALLOWLIST"
+        }
+      }
+      statefulRuleOptions = new rulegroup.StatefulRuleOptions {
+        ruleOrder = "STRICT_ORDER"
+      }
+    }
+    tags {
+      new { key = "Environment"; value = "test" }
+    }
+  }
+}

--- a/testdata/sqs-queueinlinepolicy.pkl
+++ b/testdata/sqs-queueinlinepolicy.pkl
@@ -1,0 +1,56 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/sqs/queue.pkl"
+import "@aws/sqs/queueinlinepolicy.pkl"
+
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local stackName = "plugin-sdk-test-sqs-queueinlinepolicy-\(testRunID)"
+
+local testQueue = new queue.Queue {
+  label = "test-queue"
+  queueName = "formae-sdk-test-qip-queue-\(testRunID)"
+}
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for SQS QueueInlinePolicy"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  testQueue
+
+  new queueinlinepolicy.QueueInlinePolicy {
+    label = "plugin-sdk-test-queueinlinepolicy"
+    queue = testQueue.res.queueUrl
+    policyDocument {
+      ["Version"] = "2012-10-17"
+      ["Statement"] {
+        new {
+          ["Sid"] = "AllowSendMessage"
+          ["Effect"] = "Allow"
+          ["Principal"] {
+            ["AWS"] = "*"
+          }
+          ["Action"] = "sqs:SendMessage"
+          ["Resource"] = "*"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds conformance coverage for eight leaf resource types adjacent to already-green fixtures — the first batch of the PLA-112 coverage effort. Coverage goes from ~112 to ~120 of 239 supported types (~50%).

New fixtures (all verified green via `debug-conformance`, full-batch run on the final commit):

- `AWS::SQS::QueueInlinePolicy`
- `AWS::KMS::Alias`
- `AWS::Lambda::Version`
- `AWS::Lambda::LayerVersion`
- `AWS::Lambda::LayerVersionPermission`
- `AWS::ApiGateway::UsagePlanKey`
- `AWS::IAM::ServiceLinkedRole`
- `AWS::NetworkFirewall::RuleGroup`

## Real bugs this surfaced

Writing the fixtures flushed out genuine defects, not just missing tests:

- **`AWS::Lambda::Version` false drift.** AWS auto-populates `RuntimePolicy` and computes `CodeSha256` on every published version, but neither was marked `hasProviderDefault`, so every reconcile of a version showed phantom drift. Both are now absorbed (safe: both are `createOnly`, so removal-by-omission cannot apply). Two separate commits.
- **`AWS::Lambda::LayerVersion` had no Resolvable class at all** — a layer versions ARN could not be referenced, which made `LayerVersionPermission` unexpressible. Added `LayerVersionResolvable` (`layerVersionArn`, `layerArn`, `version`) plus the hidden `parent`/`res` accessors, mirroring `FunctionResolvable` in `func.pkl`.
- **SQS test queues were leaking.** The cleanup sweep used `list-queues --queue-name-prefix`, a literal starts-with match that never matched the fixtures own names (they start with `formae-`, not the query prefix). Switched to `contains()` across all three prefixes like the Lambda/API Gateway sweeps. A dry run found two already-leaked queues.

## Cleanup additions

New `clean-environment.sh` sweeps for KMS aliases, Lambda layers (every version must go before the layer disappears), NetworkFirewall rule groups (after the firewall/policy sweeps, since a policy in use holds a reference), and IAM service-linked roles — which the IAM role sweep cannot catch because AWS derives their name from the service and it carries no test prefix.

## Scoped out

- **`AWS::ECR::RegistryPolicy` and `AWS::ECR::ReplicationConfiguration`** were dropped to the skip list. Both are account-level singletons with no name field: they cannot be namespaced per run, the harnesss exactly-one inventory assertion is type-scoped rather than stack-scoped, and destroying them resets registry-wide state shared with concurrent matrix jobs. Documented as a new skip category in the PLA-112 plan.
- **`AWS::NetworkFirewall::RuleGroup`** ships without `ruleVariables`: `RuleVariables.ipSets` renders as `IpSets` but AWS requires `IPSets`, so the field is currently unusable (filed separately as PLA-315). The fixture documents the omission.