### PR TITLE
Support MFA-guarded assume-role profiles in AWS config load

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.0
 require (
 	github.com/aws/aws-sdk-go-v2 v1.42.0
 	github.com/aws/aws-sdk-go-v2/config v1.32.16
+	github.com/aws/aws-sdk-go-v2/credentials v1.19.15
 	github.com/aws/aws-sdk-go-v2/service/acm v1.39.4
 	github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.29.14
 	github.com/aws/aws-sdk-go-v2/service/cloudfront v1.65.1
@@ -38,7 +39,6 @@ require (
 	github.com/apple/pkl-go v0.13.2 // indirect
 	github.com/asdine/storm v2.1.2+incompatible // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.9 // indirect
-	github.com/aws/aws-sdk-go-v2/credentials v1.19.15 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.22 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.10 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29 // indirect

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -7,9 +7,11 @@ package config
 import (
 	"context"
 	"encoding/json"
+	"os"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 )
 
 type Config struct {
@@ -25,7 +27,30 @@ func (c *Config) ToAwsConfig(ctx context.Context) (aws.Config, error) {
 		opts = append(opts, awsconfig.WithSharedConfigProfile(c.Profile))
 	}
 
+	// Support profiles that assume a role guarded by MFA. Without a token
+	// provider the SDK fails to load such profiles with:
+	//   "assume role with MFA enabled, but AssumeRoleTokenProvider session
+	//    option not set".
+	// Only prompt interactively when stdin is a terminal; otherwise leave the
+	// default chain untouched so headless agents keep working with statically
+	// supplied credentials (e.g. exported environment variables).
+	if isTerminal(os.Stdin) {
+		opts = append(opts, awsconfig.WithAssumeRoleCredentialOptions(func(o *stscreds.AssumeRoleOptions) {
+			o.TokenProvider = stscreds.StdinTokenProvider
+		}))
+	}
+
 	return awsconfig.LoadDefaultConfig(ctx, opts...)
+}
+
+// isTerminal reports whether f is attached to an interactive terminal. It is
+// used to decide whether MFA token codes can be prompted for on stdin.
+func isTerminal(f *os.File) bool {
+	info, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return info.Mode()&os.ModeCharDevice != 0
 }
 
 // FromTargetConfig parses the target configuration JSON into a Config struct

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,48 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package config
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFromTargetConfig_Nil(t *testing.T) {
+	c := FromTargetConfig(nil)
+	require.NotNil(t, c)
+	require.Empty(t, c.Region)
+	require.Empty(t, c.Profile)
+}
+
+func TestFromTargetConfig_ParsesRegionAndProfile(t *testing.T) {
+	raw := json.RawMessage(`{"Region":"us-west-2","Profile":"dev-role"}`)
+
+	c := FromTargetConfig(raw)
+	require.Equal(t, "us-west-2", c.Region)
+	require.Equal(t, "dev-role", c.Profile)
+}
+
+func TestToAwsConfig_SetsRegion(t *testing.T) {
+	c := &Config{Region: "eu-central-1"}
+
+	cfg, err := c.ToAwsConfig(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "eu-central-1", cfg.Region)
+}
+
+func TestIsTerminal_NonTerminalFile(t *testing.T) {
+	// A regular file is not a character device, so it is not a terminal.
+	f, err := os.CreateTemp(t.TempDir(), "not-a-tty")
+	require.NoError(t, err)
+	defer f.Close()
+
+	require.False(t, isTerminal(f))
+}


### PR DESCRIPTION
## Problem

When a target's AWS profile assumes a role protected by **MFA**, the agent cannot authenticate. `awsconfig.LoadDefaultConfig` fails with:

```
loading AWS config: assume role with MFA enabled, but AssumeRoleTokenProvider session option not set.
```

Every resource type then fails discovery/apply. This affects common enterprise setups where the dev/prod role is reached via a chained, MFA-gated `source_profile`. See platform-engineering-labs/formae#553 for the full report and the current env-var workaround.

## Fix

`pkg/config/config.go` now registers a token provider when loading AWS config:

```go
if isTerminal(os.Stdin) {
    opts = append(opts, awsconfig.WithAssumeRoleCredentialOptions(func(o *stscreds.AssumeRoleOptions) {
        o.TokenProvider = stscreds.StdinTokenProvider
    }))
}
```

This lets the SDK prompt for the MFA token code when assuming the role, which is exactly the local-agent (foreground) scenario.

## Why the terminal gate

`StdinTokenProvider` reads the code from stdin, which only makes sense interactively. Gating on `isTerminal(os.Stdin)` means **headless/containerized agents are unaffected** — they fall through to the standard credential chain (e.g. statically-supplied env credentials), so there is no behavior change or hang risk for non-interactive deployments.

## Scope / caveats

- Fixes authentication only. AWS still caps **role-chaining** sessions at 1h; this PR does not change session duration.
- No new external dependency — `aws-sdk-go-v2/credentials` (which provides `stscreds`) was already an indirect dependency; it is now promoted to direct.

## Testing

- `go build ./...` — compiles.
- `go test -tags=unit ./pkg/config/...` — new unit tests for config parsing, region propagation, and the non-terminal branch of `isTerminal`.
- `go vet -tags=unit ./pkg/config/...` — clean.

Refs platform-engineering-labs/formae#553
