### PR TITLE
fix(discovery): correct cross-region S3 object listing and firewall-scoped LoggingConfiguration discovery

### DIFF
--- a/pkg/cfres/networkfirewall/loggingconfiguration.go
+++ b/pkg/cfres/networkfirewall/loggingconfiguration.go
@@ -1,0 +1,131 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package networkfirewall
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/ccx"
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/cfres/prov"
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/cfres/registry"
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/config"
+)
+
+const loggingConfigurationType = "AWS::NetworkFirewall::LoggingConfiguration"
+
+// loggingConfigClient abstracts the CloudControl read this List synthesizes from,
+// so it can be mocked in unit tests. *ccx.Client satisfies this interface.
+type loggingConfigClient interface {
+	ReadResource(ctx context.Context, request *resource.ReadRequest) (*resource.ReadResult, error)
+}
+
+// LoggingConfiguration supplies a custom List for AWS::NetworkFirewall::LoggingConfiguration.
+// CloudControl does not support the LIST action for this type (ListResources returns
+// UnsupportedActionException), so discovery cannot enumerate it the generic way. A
+// logging configuration is a per-firewall singleton, though, and CloudControl's GetResource
+// (keyed by the firewall ARN) does work. Discovery scopes this List to one firewall via the
+// FirewallArn list parameter; we read that firewall's logging configuration and return its
+// identifier when destinations are configured. Only List is registered — Create/Read/Update/
+// Delete/Status fall through to the generic CloudControl path in aws.go.
+type LoggingConfiguration struct {
+	cfg *config.Config
+	// client is injectable for testing; nil means construct a real ccx.Client.
+	client loggingConfigClient
+}
+
+var _ prov.Provisioner = &LoggingConfiguration{}
+
+func init() {
+	registry.Register(loggingConfigurationType,
+		[]resource.Operation{resource.OperationList},
+		func(cfg *config.Config) prov.Provisioner {
+			return &LoggingConfiguration{cfg: cfg}
+		})
+}
+
+func (l *LoggingConfiguration) getClient() (loggingConfigClient, error) {
+	if l.client != nil {
+		return l.client, nil
+	}
+	return ccx.NewClient(l.cfg)
+}
+
+// List returns the firewall's ARN (the logging configuration's identifier) when the
+// firewall named by the FirewallArn list parameter has at least one log destination
+// configured. A firewall with no logging, or one that no longer exists, contributes
+// nothing. Discovery reads each returned identifier back through the generic Read path.
+func (l *LoggingConfiguration) List(ctx context.Context, request *resource.ListRequest) (*resource.ListResult, error) {
+	firewallArn := request.AdditionalProperties["FirewallArn"]
+	if firewallArn == "" {
+		return nil, fmt.Errorf("FirewallArn is required to list network firewall logging configurations")
+	}
+
+	client, err := l.getClient()
+	if err != nil {
+		return nil, fmt.Errorf("creating cloudcontrol client: %w", err)
+	}
+
+	result, err := client.ReadResource(ctx, &resource.ReadRequest{
+		NativeID:     firewallArn,
+		ResourceType: loggingConfigurationType,
+		TargetConfig: request.TargetConfig,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("reading logging configuration for firewall %s: %w", firewallArn, err)
+	}
+	if result.ErrorCode == resource.OperationErrorCodeNotFound {
+		return &resource.ListResult{}, nil
+	}
+	if result.ErrorCode != "" {
+		return nil, fmt.Errorf("reading logging configuration for firewall %s: %s", firewallArn, result.ErrorCode)
+	}
+	if !hasLogDestinations(result.Properties) {
+		return &resource.ListResult{}, nil
+	}
+	return &resource.ListResult{NativeIDs: []string{firewallArn}}, nil
+}
+
+// hasLogDestinations reports whether a read logging configuration has at least one
+// destination configured. An empty configuration is not a discoverable resource.
+func hasLogDestinations(properties string) bool {
+	if properties == "" {
+		return false
+	}
+	var p struct {
+		LoggingConfiguration struct {
+			LogDestinationConfigs []json.RawMessage `json:"LogDestinationConfigs"`
+		} `json:"LoggingConfiguration"`
+	}
+	if err := json.Unmarshal([]byte(properties), &p); err != nil {
+		return false
+	}
+	return len(p.LoggingConfiguration.LogDestinationConfigs) > 0
+}
+
+// The remaining Provisioner methods are unreachable: only List is registered, so
+// Create/Read/Update/Delete/Status always route to CloudControl in aws.go.
+func (l *LoggingConfiguration) Create(_ context.Context, _ *resource.CreateRequest) (*resource.CreateResult, error) {
+	return nil, fmt.Errorf("create not implemented - cloudcontrol handles this")
+}
+
+func (l *LoggingConfiguration) Read(_ context.Context, _ *resource.ReadRequest) (*resource.ReadResult, error) {
+	return nil, fmt.Errorf("read not implemented - cloudcontrol handles this")
+}
+
+func (l *LoggingConfiguration) Update(_ context.Context, _ *resource.UpdateRequest) (*resource.UpdateResult, error) {
+	return nil, fmt.Errorf("update not implemented - cloudcontrol handles this")
+}
+
+func (l *LoggingConfiguration) Delete(_ context.Context, _ *resource.DeleteRequest) (*resource.DeleteResult, error) {
+	return nil, fmt.Errorf("delete not implemented - cloudcontrol handles this")
+}
+
+func (l *LoggingConfiguration) Status(_ context.Context, _ *resource.StatusRequest) (*resource.StatusResult, error) {
+	return nil, fmt.Errorf("status not implemented - cloudcontrol handles this")
+}

--- a/pkg/cfres/networkfirewall/loggingconfiguration_test.go
+++ b/pkg/cfres/networkfirewall/loggingconfiguration_test.go
@@ -1,0 +1,85 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package networkfirewall
+
+import (
+	"context"
+	"testing"
+
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+const testFirewallArn = "arn:aws:network-firewall:us-east-1:111122223333:firewall/fw-1"
+
+func readReq(r *resource.ReadRequest) bool {
+	return r.NativeID == testFirewallArn && r.ResourceType == loggingConfigurationType
+}
+
+func TestLoggingConfigurationList_ReturnsFirewallArnWhenLoggingConfigured(t *testing.T) {
+	ctx := context.Background()
+	client := &mockCCXClient{}
+	client.On("ReadResource", ctx, mock.MatchedBy(readReq)).Return(&resource.ReadResult{
+		Properties: `{"FirewallArn":"` + testFirewallArn + `","LoggingConfiguration":{"LogDestinationConfigs":[` +
+			`{"LogType":"FLOW","LogDestinationType":"CloudWatchLogs","LogDestination":{"logGroup":"/x"}}]}}`,
+	}, nil)
+
+	l := &LoggingConfiguration{client: client}
+	result, err := l.List(ctx, &resource.ListRequest{
+		ResourceType:         loggingConfigurationType,
+		AdditionalProperties: map[string]string{"FirewallArn": testFirewallArn},
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, []string{testFirewallArn}, result.NativeIDs)
+	client.AssertExpectations(t)
+}
+
+func TestLoggingConfigurationList_EmptyWhenNoDestinations(t *testing.T) {
+	ctx := context.Background()
+	client := &mockCCXClient{}
+	client.On("ReadResource", ctx, mock.MatchedBy(readReq)).Return(&resource.ReadResult{
+		Properties: `{"FirewallArn":"` + testFirewallArn + `","LoggingConfiguration":{"LogDestinationConfigs":[]}}`,
+	}, nil)
+
+	l := &LoggingConfiguration{client: client}
+	result, err := l.List(ctx, &resource.ListRequest{
+		ResourceType:         loggingConfigurationType,
+		AdditionalProperties: map[string]string{"FirewallArn": testFirewallArn},
+	})
+
+	require.NoError(t, err)
+	require.Empty(t, result.NativeIDs)
+	client.AssertExpectations(t)
+}
+
+func TestLoggingConfigurationList_EmptyWhenFirewallNotFound(t *testing.T) {
+	ctx := context.Background()
+	client := &mockCCXClient{}
+	client.On("ReadResource", ctx, mock.MatchedBy(readReq)).Return(&resource.ReadResult{
+		ErrorCode: resource.OperationErrorCodeNotFound,
+	}, nil)
+
+	l := &LoggingConfiguration{client: client}
+	result, err := l.List(ctx, &resource.ListRequest{
+		ResourceType:         loggingConfigurationType,
+		AdditionalProperties: map[string]string{"FirewallArn": testFirewallArn},
+	})
+
+	require.NoError(t, err)
+	require.Empty(t, result.NativeIDs)
+	client.AssertExpectations(t)
+}
+
+func TestLoggingConfigurationList_ErrorsWithoutFirewallArn(t *testing.T) {
+	l := &LoggingConfiguration{}
+	_, err := l.List(context.Background(), &resource.ListRequest{
+		ResourceType: loggingConfigurationType,
+	})
+	require.Error(t, err)
+}

--- a/pkg/cfres/s3/object.go
+++ b/pkg/cfres/s3/object.go
@@ -20,6 +20,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
 
 	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/cfres/prov"
 	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/cfres/registry"
@@ -70,9 +71,9 @@ func parseNativeID(nativeID string) (bucket, key string, err error) {
 }
 
 const (
-	maxDownloadBytes    = 256 << 20
+	maxDownloadBytes     = 256 << 20
 	maxDecompressedBytes = 256 << 20
-	fetchTimeout        = 5 * time.Minute
+	fetchTimeout         = 5 * time.Minute
 )
 
 // resolveBodyWithCloser returns an io.Reader for the object body and a closer function.
@@ -576,6 +577,24 @@ func (o *Object) List(ctx context.Context, request *resource.ListRequest) (*reso
 	return o.listWithClient(ctx, client, request)
 }
 
+// bucketRegionFromRedirect returns the bucket's home region when err is an S3
+// 301 PermanentRedirect that carries an x-amz-bucket-region header, so the
+// caller can retry the request against the correct region.
+func bucketRegionFromRedirect(err error) (string, bool) {
+	var respErr *smithyhttp.ResponseError
+	if !errors.As(err, &respErr) {
+		return "", false
+	}
+	if respErr.HTTPStatusCode() != http.StatusMovedPermanently || respErr.Response == nil {
+		return "", false
+	}
+	region := respErr.Response.Header.Get("x-amz-bucket-region")
+	if region == "" {
+		return "", false
+	}
+	return region, true
+}
+
 func (o *Object) listWithClient(ctx context.Context, client s3ObjectClient, request *resource.ListRequest) (*resource.ListResult, error) {
 	if request.AdditionalProperties == nil {
 		return nil, fmt.Errorf("BucketName required for listing S3 objects")
@@ -595,7 +614,16 @@ func (o *Object) listWithClient(ctx context.Context, client s3ObjectClient, requ
 
 	resp, err := client.ListObjectsV2(ctx, input)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list objects in bucket %s: %w", bucketName, err)
+		// The S3 bucket namespace is global but ListObjectsV2 must be addressed
+		// to the bucket's home region. A bucket in another region than the
+		// configured client answers with a 301 PermanentRedirect carrying the
+		// real region in the x-amz-bucket-region header; retry there.
+		if region, ok := bucketRegionFromRedirect(err); ok {
+			resp, err = client.ListObjectsV2(ctx, input, func(o *s3.Options) { o.Region = region })
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to list objects in bucket %s: %w", bucketName, err)
+		}
 	}
 
 	var nativeIDs []string

--- a/pkg/cfres/s3/object_mock_test.go
+++ b/pkg/cfres/s3/object_mock_test.go
@@ -15,6 +15,9 @@ import (
 
 type mockS3ObjectClient struct {
 	mock.Mock
+	// listRegions records the region applied (via option functions) on each
+	// ListObjectsV2 call, so tests can assert cross-region redirect handling.
+	listRegions []string
 }
 
 func (m *mockS3ObjectClient) PutObject(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
@@ -33,6 +36,11 @@ func (m *mockS3ObjectClient) DeleteObject(ctx context.Context, params *s3.Delete
 }
 
 func (m *mockS3ObjectClient) ListObjectsV2(ctx context.Context, params *s3.ListObjectsV2Input, optFns ...func(*s3.Options)) (*s3.ListObjectsV2Output, error) {
+	opts := s3.Options{}
+	for _, fn := range optFns {
+		fn(&opts)
+	}
+	m.listRegions = append(m.listRegions, opts.Region)
 	args := m.Called(ctx, params)
 	return args.Get(0).(*s3.ListObjectsV2Output), args.Error(1)
 }

--- a/pkg/cfres/s3/object_test.go
+++ b/pkg/cfres/s3/object_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -550,6 +551,50 @@ func TestList_WithPagination(t *testing.T) {
 	require.Len(t, result.NativeIDs, 1)
 	require.NotNil(t, result.NextPageToken)
 	assert.Equal(t, "next-page", *result.NextPageToken)
+
+	client.AssertExpectations(t)
+}
+
+func TestList_CrossRegionBucket_RetriesWithRedirectedRegion(t *testing.T) {
+	ctx := context.Background()
+	client := &mockS3ObjectClient{}
+
+	// A bucket that lives in a different region than the client's configured
+	// region answers ListObjectsV2 with a 301 PermanentRedirect whose
+	// x-amz-bucket-region header names the bucket's home region.
+	redirect := &smithyhttp.ResponseError{
+		Response: &smithyhttp.Response{Response: &http.Response{
+			StatusCode: http.StatusMovedPermanently,
+			Header:     http.Header{"X-Amz-Bucket-Region": []string{"eu-west-1"}},
+		}},
+		Err: errors.New("api error PermanentRedirect: The bucket you are attempting to access must be addressed using the specified endpoint."),
+	}
+
+	// First attempt (default region) redirects; retry (redirected region) succeeds.
+	client.On("ListObjectsV2", ctx, mock.MatchedBy(func(input *s3.ListObjectsV2Input) bool {
+		return *input.Bucket == "out-of-region-bucket"
+	})).Return((*s3.ListObjectsV2Output)(nil), redirect).Once()
+	client.On("ListObjectsV2", ctx, mock.MatchedBy(func(input *s3.ListObjectsV2Input) bool {
+		return *input.Bucket == "out-of-region-bucket"
+	})).Return(&s3.ListObjectsV2Output{
+		Contents:    []s3types.Object{{Key: aws.String("file1.txt")}},
+		IsTruncated: aws.Bool(false),
+	}, nil).Once()
+
+	o := &Object{}
+	result, err := o.listWithClient(ctx, client, &resource.ListRequest{
+		ResourceType: "AWS::S3::Object",
+		PageSize:     100,
+		AdditionalProperties: map[string]string{
+			"BucketName": "out-of-region-bucket",
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, []string{"out-of-region-bucket|file1.txt"}, result.NativeIDs)
+	// First call used the default region; the retry targeted the redirected region.
+	assert.Equal(t, []string{"", "eu-west-1"}, client.listRegions)
 
 	client.AssertExpectations(t)
 }

--- a/schema/pkl/networkfirewall/loggingconfiguration.pkl
+++ b/schema/pkl/networkfirewall/loggingconfiguration.pkl
@@ -27,9 +27,17 @@ open class LoggingConfigurationData extends formae.SubResource {
     logDestinationConfigs: Listing<LogDestinationConfig>
 }
 
+// CloudControl does not support the LIST action for this type (ListResources
+// returns "UnsupportedActionException: ... does not support LIST action"), so the
+// AWS plugin registers a custom List that synthesizes it from a per-firewall
+// GetResource. Discovery scopes that List to each firewall via the FirewallArn
+// list parameter below; the Firewall is the parent, so discovery iterates
+// firewalls and lists each one's logging configuration.
 @aws.ResourceHint {
     type = module.type
     identifier = "FirewallArn"
+    parent = "AWS::NetworkFirewall::Firewall"
+    listParam = new formae.ListProperty { parentProperty = "FirewallArn" listParameter = "FirewallArn" }
 }
 open class LoggingConfiguration extends formae.Resource {
 

--- a/testdata/networkfirewall-loggingconfiguration.pkl
+++ b/testdata/networkfirewall-loggingconfiguration.pkl
@@ -1,0 +1,151 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/ec2/vpc.pkl"
+import "@aws/ec2/subnet.pkl"
+import "@aws/logs/loggroup.pkl"
+import "@aws/networkfirewall/rulegroup.pkl"
+import "@aws/networkfirewall/firewallpolicy.pkl"
+import "@aws/networkfirewall/firewall.pkl"
+import "@aws/networkfirewall/loggingconfiguration.pkl"
+
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local stackName = "plugin-sdk-test-nfw-logging-\(testRunID)"
+local azA = "us-east-1a"
+local azB = "us-east-1b"
+
+local testVpc = new vpc.VPC {
+  label = "nfwlog-vpc"
+  cidrBlock = "10.0.0.0/16"
+  enableDnsSupport = true
+  enableDnsHostnames = true
+}
+
+// Dedicated firewall subnets, one per AZ.
+local fwSubnetA = new subnet.Subnet {
+  label = "nfwlog-fw-subnet-a"
+  vpcId = testVpc.res.vpcId
+  cidrBlock = "10.0.0.0/28"
+  availabilityZone = azA
+  tags = new Listing<aws.Tag> { new { key = "Name"; value = "nfwlog-fw-subnet-a" } }
+}
+local fwSubnetB = new subnet.Subnet {
+  label = "nfwlog-fw-subnet-b"
+  vpcId = testVpc.res.vpcId
+  cidrBlock = "10.0.0.16/28"
+  availabilityZone = azB
+  tags = new Listing<aws.Tag> { new { key = "Name"; value = "nfwlog-fw-subnet-b" } }
+}
+
+// Stateful domain-allowlist rule group (the FQDN allowlist).
+local allowlist = new rulegroup.RuleGroup {
+  label = "nfwlog-allowlist"
+  ruleGroupName = "nfwlog-allowlist-\(testRunID)"
+  type = "STATEFUL"
+  capacity = 100
+  ruleGroup = new rulegroup.RuleGroupData {
+    rulesSource = new rulegroup.RulesSource {
+      rulesSourceList = new rulegroup.RulesSourceList {
+        targets = new Listing<String> { "github.com"; "api.anthropic.com" }
+        targetTypes = new Listing<String> { "TLS_SNI"; "HTTP_HOST" }
+        generatedRulesType = "ALLOWLIST"
+      }
+    }
+    statefulRuleOptions = new rulegroup.StatefulRuleOptions {
+      ruleOrder = "STRICT_ORDER"
+    }
+  }
+}
+
+// Firewall policy referencing the allowlist rule group.
+local policy = new firewallpolicy.FirewallPolicy {
+  label = "nfwlog-policy"
+  firewallPolicyName = "nfwlog-policy-\(testRunID)"
+  firewallPolicy = new firewallpolicy.FirewallPolicyData {
+    statelessDefaultActions = new Listing<String> { "aws:forward_to_sfe" }
+    statelessFragmentDefaultActions = new Listing<String> { "aws:forward_to_sfe" }
+    statefulDefaultActions = new Listing<String> { "aws:drop_established" }
+    statefulEngineOptions = new firewallpolicy.StatefulEngineOptions {
+      ruleOrder = "STRICT_ORDER"
+    }
+    statefulRuleGroupReferences = new Listing<firewallpolicy.StatefulRuleGroupReference> {
+      new {
+        resourceArn = allowlist.res.arn
+        // STRICT_ORDER requires an explicit evaluation priority per reference.
+        priority = 1
+      }
+    }
+  }
+}
+
+// Firewall spanning both AZs.
+local fw = new firewall.Firewall {
+  label = "nfwlog-firewall"
+  firewallName = "nfwlog-firewall-\(testRunID)"
+  firewallPolicyArn = policy.res.arn
+  vpcId = testVpc.res.vpcId
+  subnetMappings = new Listing<firewall.SubnetMapping> {
+    new { subnetId = fwSubnetA.res.subnetId }
+    new { subnetId = fwSubnetB.res.subnetId }
+  }
+}
+
+// CloudWatch Logs destination for the firewall's flow logs.
+local logGroup = new loggroup.LogGroup {
+  label = "nfwlog-log-group"
+  logGroupName = "/formae/nfw/plugin-sdk-test-\(testRunID)"
+  retentionInDays = 1
+}
+
+// Logging configuration attaching flow logging to the firewall. Listed last in
+// the forma block: the conformance harness verifies the final resource in the
+// fixture and OOB-deletes it in isolation, so it must be a leaf (nothing
+// references it) and a singleton. CloudControl can't LIST this type, so the
+// plugin supplies a custom firewall-scoped List (see the schema); this fixture
+// exercises both the CRUD and discovery lifecycles.
+local logging = new loggingconfiguration.LoggingConfiguration {
+  label = "nfwlog-logging"
+  firewallArn = fw.res.arn
+  loggingConfiguration = new loggingconfiguration.LoggingConfigurationData {
+    logDestinationConfigs = new Listing<loggingconfiguration.LogDestinationConfig> {
+      new {
+        logType = "FLOW"
+        logDestinationType = "CloudWatchLogs"
+        logDestination = new Mapping<String, String|formae.Resolvable> {
+          ["logGroup"] = logGroup.res.logGroupName
+        }
+      }
+    }
+  }
+}
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for AWS Network Firewall LoggingConfiguration"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  testVpc
+  fwSubnetA
+  fwSubnetB
+  allowlist
+  policy
+  fw
+  logGroup
+  logging
+}


### PR DESCRIPTION
## Summary

Two independent discovery-path bugs were surfacing as recurring errors in the agent log; both are fixed here.

### S3 objects in cross-region buckets
Discovery enumerates every bucket in the account, but `ListObjectsV2` must be addressed to the bucket's home region. A bucket in a different region than the configured client answered with a `301 PermanentRedirect`, so discovery logged a list error and skipped that bucket's objects entirely.

The list path now catches the redirect, reads the bucket's real region from the `x-amz-bucket-region` response header, and retries `ListObjectsV2` against that region. No new dependency.

### Network Firewall LoggingConfiguration discovery
The CloudControl list handler for `AWS::NetworkFirewall::LoggingConfiguration` is firewall-scoped: it requires a `ResourceModel` carrying `FirewallName` (or `FlowArn`). The resource hint declared neither a parent nor a `listParam`, so discovery called `ListResources` with an empty model and AWS rejected it with a `400 InvalidRequestException` on every cycle.

The schema now declares the Firewall as the parent and passes `FirewallName` as the list parameter, mirroring how other parent-scoped resources are discovered. A new conformance fixture with `LoggingConfiguration` as the leaf resource under test exercises the firewall-scoped discovery path, which was previously uncovered.