### PR TITLE
feat(cloudtrail): add AWS::CloudTrail::Trail resource type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,6 +171,7 @@ conformance-test-discovery: install
 conformance-test-crud-run:
 	@echo "Running CRUD conformance tests..."
 	@FORMAE_TEST_FILTER="$(TEST)" FORMAE_TEST_TYPE=crud FORMAE_TEST_PARALLEL="$(PARALLEL)" FORMAE_TEST_TIMEOUT="$(or $(TIMEOUT),60)" \
+		FORMAE_TEST_ACCOUNT_ID=$$(aws sts get-caller-identity --query Account --output text 2>/dev/null) \
 		$(GO) test -tags=conformance -v -timeout $(or $(TIMEOUT),60)m ./...
 
 ## conformance-test-discovery-run: Run only discovery tests (no cleanup)
@@ -178,4 +179,5 @@ conformance-test-crud-run:
 conformance-test-discovery-run:
 	@echo "Running discovery conformance tests..."
 	@FORMAE_TEST_FILTER="$(TEST)" FORMAE_TEST_TYPE=discovery FORMAE_TEST_PARALLEL="$(PARALLEL)" FORMAE_TEST_TIMEOUT="$(or $(TIMEOUT),60)" \
+		FORMAE_TEST_ACCOUNT_ID=$$(aws sts get-caller-identity --query Account --output text 2>/dev/null) \
 		$(GO) test -tags=conformance -v -timeout $(or $(TIMEOUT),60)m ./...

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ API](https://docs.aws.amazon.com/cloudcontrolapi/latest/userguide/what-is-cloudc
 
 ## Supported Resources
 
-This plugin supports **209 AWS resource types** across 21 services via the
+This plugin supports **210 AWS resource types** across 22 services via the
 CloudControl API:
 
 | Service | Resources | Examples |
@@ -27,6 +27,7 @@ CloudControl API:
 | KMS | 2 | Key, Alias |
 | Secrets Manager | 4 | Secret, ResourcePolicy, RotationSchedule |
 | CloudFront | 1 | Distribution |
+| CloudTrail | 1 | Trail |
 | ELBv2 | 7 | LoadBalancer, TargetGroup, Listener, ListenerRule |
 | ECR | 6 | Repository, RegistryPolicy, ReplicationConfiguration |
 | EFS | 3 | FileSystem, MountTarget, AccessPoint |

--- a/aws.go
+++ b/aws.go
@@ -100,6 +100,8 @@ func (p *Plugin) LabelConfig() pkgmodel.LabelConfig {
 			"AWS::CertificateManager::Certificate": "$.DomainName",
 			// S3 objects use Key property
 			"AWS::S3::Object": "$.Key",
+			// CloudTrail trails have no Name tag; use the trail name as the label.
+			"AWS::CloudTrail::Trail": "$.TrailName",
 			// Resources that represent relationships use parent IDs
 			"AWS::EC2::VPCGatewayAttachment":          "$.VpcId",
 			"AWS::EC2::SubnetRouteTableAssociation":   "$.SubnetId",

--- a/schema/pkl/cloudtrail/trail.pkl
+++ b/schema/pkl/cloudtrail/trail.pkl
@@ -1,0 +1,129 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+module aws.cloudtrail.trail
+
+import "@formae/formae.pkl"
+import "../aws.pkl"
+
+const type = "AWS::CloudTrail::Trail"
+
+open class TrailResolvable extends formae.Resolvable {
+    hidden type = module.type
+
+    hidden arn: TrailResolvable = (this) {
+        property = "Arn"
+    }
+
+    hidden trailName: TrailResolvable = (this) {
+        property = "TrailName"
+    }
+}
+
+@aws.SubResourceHint
+open class DataResource extends formae.SubResource {
+    type: String?
+    values: Listing<String>?
+}
+
+@aws.SubResourceHint
+open class EventSelector extends formae.SubResource {
+    readWriteType: String?
+    includeManagementEvents: Boolean?
+    dataResources: Listing<DataResource>?
+    excludeManagementEventSources: Listing<String>?
+}
+
+@aws.SubResourceHint
+open class AdvancedFieldSelector extends formae.SubResource {
+    field: String
+    equals: Listing<String>?
+    startsWith: Listing<String>?
+    endsWith: Listing<String>?
+    notEquals: Listing<String>?
+    notStartsWith: Listing<String>?
+    notEndsWith: Listing<String>?
+}
+
+@aws.SubResourceHint
+open class AdvancedEventSelector extends formae.SubResource {
+    name: String?
+    fieldSelectors: Listing<AdvancedFieldSelector>
+}
+
+@aws.SubResourceHint
+open class InsightSelector extends formae.SubResource {
+    insightType: String?
+}
+
+@aws.ResourceHint {
+    type = module.type
+    identifier = "TrailName"
+    discoverable = true
+}
+open class Trail extends formae.Resource {
+
+    @aws.FieldHint { createOnly = true }
+    trailName: String
+
+    @aws.FieldHint
+    s3BucketName: (String|formae.Resolvable)
+
+    @aws.FieldHint
+    s3KeyPrefix: String?
+
+    @aws.FieldHint
+    isLogging: Boolean
+
+    @aws.FieldHint { hasProviderDefault = true }
+    isMultiRegionTrail: Boolean?
+
+    @aws.FieldHint { hasProviderDefault = true }
+    includeGlobalServiceEvents: Boolean?
+
+    @aws.FieldHint { hasProviderDefault = true }
+    enableLogFileValidation: Boolean?
+
+    @aws.FieldHint { hasProviderDefault = true }
+    isOrganizationTrail: Boolean?
+
+    @aws.FieldHint
+    kmsKeyId: (String|formae.Resolvable)?
+
+    @aws.FieldHint
+    snsTopicName: (String|formae.Resolvable)?
+
+    @aws.FieldHint
+    cloudWatchLogsLogGroupArn: (String|formae.Resolvable)?
+
+    @aws.FieldHint
+    cloudWatchLogsRoleArn: (String|formae.Resolvable)?
+
+    // eventSelectors and advancedEventSelectors are mutually exclusive at the
+    // CloudTrail API: a trail uses one mode or the other. Both are modelled here
+    // so that a discovered trail using either mode round-trips correctly.
+    @aws.FieldHint { updateMethod = "Atomic" }
+    eventSelectors: Listing<EventSelector>?
+
+    @aws.FieldHint { updateMethod = "Atomic" }
+    advancedEventSelectors: Listing<AdvancedEventSelector>?
+
+    @aws.FieldHint { updateMethod = "Atomic" }
+    insightSelectors: Listing<InsightSelector>?
+
+    @aws.FieldHint {
+        updateMethod = "EntitySet"
+        indexField = "Key"
+    }
+    tags: Listing<aws.Tag>?
+
+    local parent = this
+
+    hidden res: TrailResolvable = new {
+        label = parent.label
+        stack = parent.stack?.label
+    }
+}

--- a/schema/pkl/s3/bucketpolicy.pkl
+++ b/schema/pkl/s3/bucketpolicy.pkl
@@ -11,6 +11,14 @@ import "@formae/formae.pkl"
 
 const type = "AWS::S3::BucketPolicy"
 
+open class BucketPolicyResolvable extends formae.Resolvable {
+    hidden type = module.type
+
+    hidden bucket: BucketPolicyResolvable = (this) {
+        property = "Bucket"
+    }
+}
+
 @aws.ResourceHint {
     type = module.type
     identifier = "Bucket"
@@ -21,4 +29,11 @@ open class BucketPolicy extends formae.Resource {
 
     @aws.FieldHint
     policyDocument: Dynamic
+
+    local parent = this
+
+    hidden res: BucketPolicyResolvable = new {
+        label = parent.label
+        stack = parent.stack?.label
+    }
 }

--- a/scripts/ci/clean-environment.sh
+++ b/scripts/ci/clean-environment.sh
@@ -179,6 +179,13 @@ done
 echo "Cleaning S3 test buckets..."
 aws s3api list-buckets --query "Buckets[?contains(Name, '$FORMAE_PREFIX') || contains(Name, '$SDK_PREFIX') || contains(Name, '$TEST_PREFIX')].Name" --output text 2>/dev/null | tr '\t' '\n' | while read -r bucket; do
     if [[ -n "$bucket" ]]; then
+        # The CloudTrail log bucket (formae-plugin-sdk-test-ct-logs-*) is a
+        # PERSISTENT prerequisite (Option B / PLA-302) provisioned + emptied in
+        # section 8b-ct below; never delete it here.
+        if [[ "$bucket" == formae-plugin-sdk-test-ct-logs-* ]]; then
+            echo "  Skipping persistent CloudTrail log bucket: $bucket"
+            continue
+        fi
         echo "  Deleting S3 bucket: $bucket"
         # Delete bucket policy first (if any)
         aws s3api delete-bucket-policy --bucket "$bucket" --region "$REGION" 2>/dev/null || true
@@ -186,6 +193,77 @@ aws s3api list-buckets --query "Buckets[?contains(Name, '$FORMAE_PREFIX') || con
         aws s3api delete-bucket --bucket "$bucket" --region "$REGION" 2>/dev/null || true
     fi
 done
+
+# 8b-ct. Provision + empty the PERSISTENT CloudTrail log-delivery bucket.
+# This bucket is a persistent conformance prerequisite for the cloudtrail-trail
+# fixture (Option B / PLA-302): CloudTrail deposits placeholder/log objects into
+# it, and CloudControl refuses to delete a non-empty bucket, so the fixture
+# references this externally-owned bucket by name instead of managing it. We
+# therefore CREATE it if absent and EMPTY it here, but never DELETE it (unlike
+# section 8b). The self-contained forceDestroy-managed version is tracked in
+# PLA-345. Every step is guarded so it never aborts the cleanup script.
+echo "Provisioning + emptying persistent CloudTrail log bucket..."
+if acct=$(aws sts get-caller-identity --query Account --output text 2>/dev/null) && [[ -n "$acct" && "$acct" != "None" ]]; then
+    ct_bucket="formae-plugin-sdk-test-ct-logs-${acct}"
+    # Create the bucket if it does not already exist. us-east-1 must NOT pass a
+    # LocationConstraint (the API rejects it); every other region requires one.
+    if ! aws s3api head-bucket --bucket "$ct_bucket" --region "$REGION" 2>/dev/null; then
+        echo "  Creating CloudTrail log bucket: $ct_bucket"
+        if [[ "$REGION" == "us-east-1" ]]; then
+            aws s3api create-bucket --bucket "$ct_bucket" --region "$REGION" 2>/dev/null || true
+        else
+            aws s3api create-bucket --bucket "$ct_bucket" --region "$REGION" \
+                --create-bucket-configuration "LocationConstraint=$REGION" 2>/dev/null || true
+        fi
+    fi
+    # Block public access on the bucket.
+    aws s3api put-public-access-block --bucket "$ct_bucket" --region "$REGION" \
+        --public-access-block-configuration "BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=false,RestrictPublicBuckets=false" 2>/dev/null || true
+    # Attach the canonical CloudTrail bucket policy (mirrors the shape the fixture
+    # previously managed: AWSCloudTrailAclCheck = s3:GetBucketAcl on the bucket
+    # ARN, AWSCloudTrailWrite = s3:PutObject on <bucket-arn>/* with the
+    # bucket-owner-full-control ACL condition).
+    ct_policy=$(cat <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AWSCloudTrailAclCheck",
+      "Effect": "Allow",
+      "Principal": { "Service": "cloudtrail.amazonaws.com" },
+      "Action": "s3:GetBucketAcl",
+      "Resource": "arn:aws:s3:::${ct_bucket}"
+    },
+    {
+      "Sid": "AWSCloudTrailWrite",
+      "Effect": "Allow",
+      "Principal": { "Service": "cloudtrail.amazonaws.com" },
+      "Action": "s3:PutObject",
+      "Resource": "arn:aws:s3:::${ct_bucket}/*",
+      "Condition": {
+        "StringEquals": { "s3:x-amz-acl": "bucket-owner-full-control" }
+      }
+    }
+  ]
+}
+EOF
+)
+    aws s3api put-bucket-policy --bucket "$ct_bucket" --region "$REGION" --policy "$ct_policy" 2>/dev/null || true
+    # Empty the bucket (objects + versions + delete markers) WITHOUT deleting it,
+    # clearing CloudTrail placeholder/log objects left by prior runs.
+    echo "  Emptying CloudTrail log bucket: $ct_bucket"
+    aws s3 rm "s3://$ct_bucket" --recursive --region "$REGION" 2>/dev/null || true
+    # Versioned sweep in case the bucket has versioning enabled.
+    versioned=$(aws s3api list-object-versions --bucket "$ct_bucket" --region "$REGION" \
+        --output json --query '{Objects: Versions[].{Key:Key,VersionId:VersionId}, DeleteMarkers: DeleteMarkers[].{Key:Key,VersionId:VersionId}}' 2>/dev/null || echo '{}')
+    for kind in Objects DeleteMarkers; do
+        del=$(echo "$versioned" | jq -c "{Objects: (.$kind // []), Quiet: true}" 2>/dev/null || echo '{}')
+        n=$(echo "$del" | jq '.Objects | length' 2>/dev/null || echo 0)
+        if [[ -n "$n" && "$n" != "0" ]]; then
+            aws s3api delete-objects --bucket "$ct_bucket" --region "$REGION" --delete "$del" 2>/dev/null || true
+        fi
+    done
+fi
 
 # 8c. Delete S3 Storage Lens Groups with test prefix
 echo "Cleaning S3 test Storage Lens Groups..."

--- a/testdata/cloudtrail-trail-update.pkl
+++ b/testdata/cloudtrail-trail-update.pkl
@@ -1,0 +1,116 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/s3/bucket.pkl"
+import "@aws/s3/bucketpolicy.pkl"
+import "@aws/cloudtrail/trail.pkl"
+
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local stackName = "plugin-sdk-test-cloudtrail-trail-\(testRunID)"
+
+// S3 bucket to receive CloudTrail log delivery.
+// blockPublicPolicy must be false to allow the service-principal bucket policy to attach.
+local testBucket = new bucket.Bucket {
+  label = "test-ct-bucket"
+  bucketName = "formae-plugin-sdk-test-ct-\(testRunID)"
+  publicAccessBlockConfiguration = new bucket.PublicAccessBlockConfiguration {
+    blockPublicAcls = true
+    blockPublicPolicy = false
+    ignorePublicAcls = true
+    restrictPublicBuckets = false
+  }
+}
+
+// Bucket policy granting CloudTrail the access it needs to write logs.
+local testBucketPolicy = new bucketpolicy.BucketPolicy {
+  label = "test-ct-bucketpolicy"
+  bucket = testBucket.res.bucketName
+  policyDocument {
+    ["Version"] = "2012-10-17"
+    ["Statement"] {
+      new {
+        ["Sid"] = "AWSCloudTrailAclCheck"
+        ["Effect"] = "Allow"
+        ["Principal"] {
+          ["Service"] = "cloudtrail.amazonaws.com"
+        }
+        ["Action"] = "s3:GetBucketAcl"
+        ["Resource"] = "arn:aws:s3:::formae-plugin-sdk-test-ct-\(testRunID)"
+      }
+      new {
+        ["Sid"] = "AWSCloudTrailWrite"
+        ["Effect"] = "Allow"
+        ["Principal"] {
+          ["Service"] = "cloudtrail.amazonaws.com"
+        }
+        ["Action"] = "s3:PutObject"
+        ["Resource"] = "arn:aws:s3:::formae-plugin-sdk-test-ct-\(testRunID)/*"
+      }
+    }
+  }
+}
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for AWS CloudTrail Trail"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  testBucket
+  testBucketPolicy
+
+  // Update fixture: the S3 data-events selector's resources.ARN startsWith prefix is
+  // changed from /logs/ to /audit-logs/ to verify AdvancedEventSelectors update
+  // round-trips without perpetual drift.
+  new trail.Trail {
+    label = "plugin-sdk-test-cloudtrail-trail"
+    trailName = "formae-plugin-sdk-test-ct-\(testRunID)"
+    s3BucketName = testBucketPolicy.res.bucket
+    isMultiRegionTrail = true
+    enableLogFileValidation = true
+    isLogging = false
+    advancedEventSelectors = new Listing<trail.AdvancedEventSelector> {
+      new {
+        name = "Management events"
+        fieldSelectors = new Listing<trail.AdvancedFieldSelector> {
+          new {
+            field = "eventCategory"
+            equals = new Listing<String> { "Management" }
+          }
+        }
+      }
+      new {
+        name = "S3 data events"
+        fieldSelectors = new Listing<trail.AdvancedFieldSelector> {
+          new {
+            field = "eventCategory"
+            equals = new Listing<String> { "Data" }
+          }
+          new {
+            field = "resources.type"
+            equals = new Listing<String> { "AWS::S3::Object" }
+          }
+          new {
+            field = "resources.ARN"
+            startsWith = new Listing<String> { "arn:aws:s3:::formae-plugin-sdk-test-ct-data-\(testRunID)/audit-logs/" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/testdata/cloudtrail-trail-update.pkl
+++ b/testdata/cloudtrail-trail-update.pkl
@@ -9,54 +9,20 @@ import "@formae/formae.pkl"
 
 import "@aws/aws.pkl"
 
-import "@aws/s3/bucket.pkl"
-import "@aws/s3/bucketpolicy.pkl"
 import "@aws/cloudtrail/trail.pkl"
 
 local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local accountID = read("env:FORMAE_TEST_ACCOUNT_ID")
 local stackName = "plugin-sdk-test-cloudtrail-trail-\(testRunID)"
 
-// S3 bucket to receive CloudTrail log delivery.
-// blockPublicPolicy must be false to allow the service-principal bucket policy to attach.
-local testBucket = new bucket.Bucket {
-  label = "test-ct-bucket"
-  bucketName = "formae-plugin-sdk-test-ct-\(testRunID)"
-  publicAccessBlockConfiguration = new bucket.PublicAccessBlockConfiguration {
-    blockPublicAcls = true
-    blockPublicPolicy = false
-    ignorePublicAcls = true
-    restrictPublicBuckets = false
-  }
-}
-
-// Bucket policy granting CloudTrail the access it needs to write logs.
-local testBucketPolicy = new bucketpolicy.BucketPolicy {
-  label = "test-ct-bucketpolicy"
-  bucket = testBucket.res.bucketName
-  policyDocument {
-    ["Version"] = "2012-10-17"
-    ["Statement"] {
-      new {
-        ["Sid"] = "AWSCloudTrailAclCheck"
-        ["Effect"] = "Allow"
-        ["Principal"] {
-          ["Service"] = "cloudtrail.amazonaws.com"
-        }
-        ["Action"] = "s3:GetBucketAcl"
-        ["Resource"] = "arn:aws:s3:::formae-plugin-sdk-test-ct-\(testRunID)"
-      }
-      new {
-        ["Sid"] = "AWSCloudTrailWrite"
-        ["Effect"] = "Allow"
-        ["Principal"] {
-          ["Service"] = "cloudtrail.amazonaws.com"
-        }
-        ["Action"] = "s3:PutObject"
-        ["Resource"] = "arn:aws:s3:::formae-plugin-sdk-test-ct-\(testRunID)/*"
-      }
-    }
-  }
-}
+// The CloudTrail log-delivery bucket is a PERSISTENT, formae-UNMANAGED
+// prerequisite provisioned by scripts/ci/clean-environment.sh (Option B /
+// PLA-302): CloudTrail deposits placeholder objects into it, and CloudControl
+// refuses to delete a non-empty bucket, so managing the bucket here made the
+// whole-stack Destroy fail. Referencing it by name keeps it out of formae's
+// lifecycle. The self-contained forceDestroy-managed version is tracked in
+// PLA-345.
+local logBucketName = "formae-plugin-sdk-test-ct-logs-\(accountID)"
 
 forma {
   new formae.Stack {
@@ -71,16 +37,13 @@ forma {
     }
   }
 
-  testBucket
-  testBucketPolicy
-
   // Update fixture: the S3 data-events selector's resources.ARN startsWith prefix is
   // changed from /logs/ to /audit-logs/ to verify AdvancedEventSelectors update
   // round-trips without perpetual drift.
   new trail.Trail {
     label = "plugin-sdk-test-cloudtrail-trail"
     trailName = "formae-plugin-sdk-test-ct-\(testRunID)"
-    s3BucketName = testBucketPolicy.res.bucket
+    s3BucketName = logBucketName
     isMultiRegionTrail = true
     // A multi-region trail must include global service events (AWS rejects the
     // pair otherwise), mirroring the real multi-region audit trail.

--- a/testdata/cloudtrail-trail-update.pkl
+++ b/testdata/cloudtrail-trail-update.pkl
@@ -82,6 +82,9 @@ forma {
     trailName = "formae-plugin-sdk-test-ct-\(testRunID)"
     s3BucketName = testBucketPolicy.res.bucket
     isMultiRegionTrail = true
+    // A multi-region trail must include global service events (AWS rejects the
+    // pair otherwise), mirroring the real multi-region audit trail.
+    includeGlobalServiceEvents = true
     enableLogFileValidation = true
     isLogging = false
     advancedEventSelectors = new Listing<trail.AdvancedEventSelector> {

--- a/testdata/cloudtrail-trail.pkl
+++ b/testdata/cloudtrail-trail.pkl
@@ -9,54 +9,20 @@ import "@formae/formae.pkl"
 
 import "@aws/aws.pkl"
 
-import "@aws/s3/bucket.pkl"
-import "@aws/s3/bucketpolicy.pkl"
 import "@aws/cloudtrail/trail.pkl"
 
 local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local accountID = read("env:FORMAE_TEST_ACCOUNT_ID")
 local stackName = "plugin-sdk-test-cloudtrail-trail-\(testRunID)"
 
-// S3 bucket to receive CloudTrail log delivery.
-// blockPublicPolicy must be false to allow the service-principal bucket policy to attach.
-local testBucket = new bucket.Bucket {
-  label = "test-ct-bucket"
-  bucketName = "formae-plugin-sdk-test-ct-\(testRunID)"
-  publicAccessBlockConfiguration = new bucket.PublicAccessBlockConfiguration {
-    blockPublicAcls = true
-    blockPublicPolicy = false
-    ignorePublicAcls = true
-    restrictPublicBuckets = false
-  }
-}
-
-// Bucket policy granting CloudTrail the access it needs to write logs.
-local testBucketPolicy = new bucketpolicy.BucketPolicy {
-  label = "test-ct-bucketpolicy"
-  bucket = testBucket.res.bucketName
-  policyDocument {
-    ["Version"] = "2012-10-17"
-    ["Statement"] {
-      new {
-        ["Sid"] = "AWSCloudTrailAclCheck"
-        ["Effect"] = "Allow"
-        ["Principal"] {
-          ["Service"] = "cloudtrail.amazonaws.com"
-        }
-        ["Action"] = "s3:GetBucketAcl"
-        ["Resource"] = "arn:aws:s3:::formae-plugin-sdk-test-ct-\(testRunID)"
-      }
-      new {
-        ["Sid"] = "AWSCloudTrailWrite"
-        ["Effect"] = "Allow"
-        ["Principal"] {
-          ["Service"] = "cloudtrail.amazonaws.com"
-        }
-        ["Action"] = "s3:PutObject"
-        ["Resource"] = "arn:aws:s3:::formae-plugin-sdk-test-ct-\(testRunID)/*"
-      }
-    }
-  }
-}
+// The CloudTrail log-delivery bucket is a PERSISTENT, formae-UNMANAGED
+// prerequisite provisioned by scripts/ci/clean-environment.sh (Option B /
+// PLA-302): CloudTrail deposits placeholder objects into it, and CloudControl
+// refuses to delete a non-empty bucket, so managing the bucket here made the
+// whole-stack Destroy fail. Referencing it by name keeps it out of formae's
+// lifecycle. The self-contained forceDestroy-managed version is tracked in
+// PLA-345.
+local logBucketName = "formae-plugin-sdk-test-ct-logs-\(accountID)"
 
 forma {
   new formae.Stack {
@@ -71,16 +37,13 @@ forma {
     }
   }
 
-  testBucket
-  testBucketPolicy
-
   // Trail is the last resource — the conformance harness verifies it as a singleton
   // leaf and OOB-deletes it in isolation. isLogging=false keeps the bucket empty so
   // CloudControl can delete it at teardown.
   new trail.Trail {
     label = "plugin-sdk-test-cloudtrail-trail"
     trailName = "formae-plugin-sdk-test-ct-\(testRunID)"
-    s3BucketName = testBucketPolicy.res.bucket
+    s3BucketName = logBucketName
     isMultiRegionTrail = true
     // A multi-region trail must include global service events (AWS rejects the
     // pair otherwise), mirroring the real multi-region audit trail.

--- a/testdata/cloudtrail-trail.pkl
+++ b/testdata/cloudtrail-trail.pkl
@@ -82,6 +82,9 @@ forma {
     trailName = "formae-plugin-sdk-test-ct-\(testRunID)"
     s3BucketName = testBucketPolicy.res.bucket
     isMultiRegionTrail = true
+    // A multi-region trail must include global service events (AWS rejects the
+    // pair otherwise), mirroring the real multi-region audit trail.
+    includeGlobalServiceEvents = true
     enableLogFileValidation = true
     isLogging = false
     advancedEventSelectors = new Listing<trail.AdvancedEventSelector> {

--- a/testdata/cloudtrail-trail.pkl
+++ b/testdata/cloudtrail-trail.pkl
@@ -1,0 +1,116 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/s3/bucket.pkl"
+import "@aws/s3/bucketpolicy.pkl"
+import "@aws/cloudtrail/trail.pkl"
+
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local stackName = "plugin-sdk-test-cloudtrail-trail-\(testRunID)"
+
+// S3 bucket to receive CloudTrail log delivery.
+// blockPublicPolicy must be false to allow the service-principal bucket policy to attach.
+local testBucket = new bucket.Bucket {
+  label = "test-ct-bucket"
+  bucketName = "formae-plugin-sdk-test-ct-\(testRunID)"
+  publicAccessBlockConfiguration = new bucket.PublicAccessBlockConfiguration {
+    blockPublicAcls = true
+    blockPublicPolicy = false
+    ignorePublicAcls = true
+    restrictPublicBuckets = false
+  }
+}
+
+// Bucket policy granting CloudTrail the access it needs to write logs.
+local testBucketPolicy = new bucketpolicy.BucketPolicy {
+  label = "test-ct-bucketpolicy"
+  bucket = testBucket.res.bucketName
+  policyDocument {
+    ["Version"] = "2012-10-17"
+    ["Statement"] {
+      new {
+        ["Sid"] = "AWSCloudTrailAclCheck"
+        ["Effect"] = "Allow"
+        ["Principal"] {
+          ["Service"] = "cloudtrail.amazonaws.com"
+        }
+        ["Action"] = "s3:GetBucketAcl"
+        ["Resource"] = "arn:aws:s3:::formae-plugin-sdk-test-ct-\(testRunID)"
+      }
+      new {
+        ["Sid"] = "AWSCloudTrailWrite"
+        ["Effect"] = "Allow"
+        ["Principal"] {
+          ["Service"] = "cloudtrail.amazonaws.com"
+        }
+        ["Action"] = "s3:PutObject"
+        ["Resource"] = "arn:aws:s3:::formae-plugin-sdk-test-ct-\(testRunID)/*"
+      }
+    }
+  }
+}
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for AWS CloudTrail Trail"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  testBucket
+  testBucketPolicy
+
+  // Trail is the last resource — the conformance harness verifies it as a singleton
+  // leaf and OOB-deletes it in isolation. isLogging=false keeps the bucket empty so
+  // CloudControl can delete it at teardown.
+  new trail.Trail {
+    label = "plugin-sdk-test-cloudtrail-trail"
+    trailName = "formae-plugin-sdk-test-ct-\(testRunID)"
+    s3BucketName = testBucketPolicy.res.bucket
+    isMultiRegionTrail = true
+    enableLogFileValidation = true
+    isLogging = false
+    advancedEventSelectors = new Listing<trail.AdvancedEventSelector> {
+      new {
+        name = "Management events"
+        fieldSelectors = new Listing<trail.AdvancedFieldSelector> {
+          new {
+            field = "eventCategory"
+            equals = new Listing<String> { "Management" }
+          }
+        }
+      }
+      new {
+        name = "S3 data events"
+        fieldSelectors = new Listing<trail.AdvancedFieldSelector> {
+          new {
+            field = "eventCategory"
+            equals = new Listing<String> { "Data" }
+          }
+          new {
+            field = "resources.type"
+            equals = new Listing<String> { "AWS::S3::Object" }
+          }
+          new {
+            field = "resources.ARN"
+            startsWith = new Listing<String> { "arn:aws:s3:::formae-plugin-sdk-test-ct-data-\(testRunID)/logs/" }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds the `AWS::CloudTrail::Trail` resource type to the aws plugin so CloudTrail trails can be authored and discovered in PKL. Part 1 of PLA-302 (adding the type); absorbing an existing out-of-band trail into managed PKL is a separate, human-driven follow-up.

## What's included

- **`schema/pkl/cloudtrail/trail.pkl`** — the Trail type via the generic CloudControl path (FULLY_MUTABLE, `TrailName` identifier, no custom provisioner). Models management + S3 data event selectors including `AdvancedEventSelectors` (`resources.ARN StartsWith`), with `updateMethod = Atomic` on the selector lists to match `put-event-selectors`'s wholesale-replace semantics. AWS-echoed booleans (`isMultiRegionTrail`, `includeGlobalServiceEvents`, `enableLogFileValidation`, `isOrganizationTrail`) carry `hasProviderDefault` to avoid perpetual drift.
- **`aws.go`** — one `LabelConfig` override (`$.TrailName`), since trails carry no `Name` tag.
- **`schema/pkl/s3/bucketpolicy.pkl`** — adds a `BucketPolicy` Resolvable so resources can order after a bucket policy (bucket → policy → trail).
- **Conformance fixtures** (`testdata/cloudtrail-trail.pkl` + `-update.pkl`) — full CRUD + discovery, with the `-update` variant rescoping an `AdvancedEventSelector` `StartsWith` to prove the selector round-trip has no perpetual drift. Verified green via `debug-conformance` (create → read → extract → sync → idempotency → selector update → destroy).

## Conformance teardown: CI-provisioned log bucket (Option B)

`create-trail` writes 0-byte placeholder objects into the log-delivery bucket regardless of `isLogging`, and CloudControl refuses to delete a non-empty bucket — so a formae-managed delivery bucket can never tear down. Rather than ship a half-built delete-time capability, the fixture references a **persistent, CI-provisioned, formae-unmanaged** log bucket: `clean-environment.sh` creates `formae-plugin-sdk-test-ct-logs-<account>` with the CloudTrail policy and empties it each pre-cleanup (never deletes it; the generic S3 sweep skips it), the Makefile conformance targets export `FORMAE_TEST_ACCOUNT_ID` so the fixture builds the same account-qualified name, and formae manages only the Trail. Whole-stack Destroy is then clean.

The self-contained, `forceDestroy`-managed version — the Terraform/Pulumi-style opt-in that empties the bucket on delete — is deferred to a follow-up (blocked on the SDK `DeleteRequest` not carrying prior properties). That follow-up also tracks migrating this fixture back to a self-contained bucket.