### PR TITLE
feat: mark secret fields opaque + cut stable 0.1.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,211 @@
+# Changelog
+
+All notable changes to the formae AWS plugin are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Install with `sudo formae plugin install aws` on the host that runs the
+formae agent.
+
+## [0.1.13]
+
+### Added
+
+- AWS EventBridge support: `AWS::Events::EventBus`, `AWS::Events::Archive`, and `AWS::Events::Rule`. You can now manage custom event buses, their archives, and their rules, including the full rule target tree, declaratively. A rule wires to its bus and its targets through the resource graph, and each bus exposes its ARN as a resolvable (`eventBus.res.arn`), so a producer's `events:PutEvents` permission can reference the bus directly. Rules are modelled as children of their event bus so that rules on a custom bus are discovered correctly.
+- DynamoDB `Table` now exposes resolvables, `table.res.arn`, `table.res.streamArn`, and `table.res.tableName`. A table's **stream ARN** can be wired straight into a `Lambda::EventSourceMapping`'s `eventSourceArn`, so a stream-triggered Lambda no longer needs a hand-constructed stream ARN, previously there was no way to reference it at all.
+- ApiGateway `RestApi` now exposes an **execute-api ARN** resolvable, `api.res.executeApiArn`. A `Lambda::Permission` that lets API Gateway invoke a function can source its `sourceArn` from the API itself (`api.res.executeApiArn`) instead of a hand-built, account-scoped wildcard ARN. The plugin derives the ARN, which CloudControl doesn't return, and fills in the partition and account.
+- `AWS::IAM::ServerCertificate` now exposes resolvables, `serverCertificate.res.arn` and `serverCertificate.res.serverCertificateName`. Other resources (for example an HTTPS load balancer listener) can now reference an uploaded server certificate through the resource graph instead of a hand-written ARN.
+- `AWS::S3::Object` support. You can now manage S3 objects declaratively, including shipping a local file as the object's body: the CLI reads the file relative to the apply working directory and uploads it. Object tags round-trip on create and update.
+- An `AWS::S3::Object` can now fetch its body from a URL. Instead of inline content, the object's `source` can be a structured remote source, the agent downloads the body over HTTPS at apply time, so the bytes never pass through the CLI. The fetch can send request headers (to pull an **authenticated** artifact; the header value is write-only and is not stored in cleartext) and can **extract a named file from a downloaded zip archive**. A typical use is delivering a Lambda deployment package from a versioned build artifact: point the object at a release URL templated by version and resolve the function's `Code` from the object's version. Publishing a new build then redeploys the function, while re-applying the same version is a no-op, no phantom redeploys. The fetch is restricted to HTTPS and refuses to reach loopback, private-network, or instance-metadata addresses. A full walkthrough, handler, release, deploy, and the redeploy loop, is in the [`lambda-http-source` example](https://github.com/platform-engineering-labs/formae-plugin-aws/tree/main/examples/lambda-http-source).
+- A CloudFront `Function`'s `functionCode` can now embed references to other resources. Using formae 0.87.0's `formae.embed`, a function's JavaScript body can splice in another resource's generated value (for example a Key Value Store's Id) at apply time, instead of applying the store, copying the Id by hand, and re-applying the function.
+- `AWS::EC2::VPNGatewayRoutePropagation` support. You can now manage VPN gateway route propagation declaratively, having a virtual private gateway automatically propagate its learned routes into a route table, and removing that propagation again. This type can't be provisioned through CloudControl, so it previously couldn't be managed at all; the plugin now drives it directly through the EC2 API.
+- `AWS::EC2::NetworkInterfacePermission` support. You can now grant (and revoke) another AWS account permission to attach or associate one of your network interfaces. This type can't be provisioned through CloudControl, so it previously couldn't be managed at all; the plugin now drives it directly through the EC2 API. A network interface can also now be referenced by other resources through the resource graph (`someInterface.res.id`).
+- `AWS::Route53::RecordSetGroup` support. You can now manage a group of Route 53 records that are created, updated, and deleted together in a single atomic change, useful when a set of records must always change as a unit. This type can't be provisioned through CloudControl, so it previously couldn't be managed at all; the plugin now applies the whole group through one Route 53 change batch. Scope is simple records (name, type, TTL, values, and alias targets); weighted, latency, geolocation, and other routing-policy records are rejected with a clear error rather than silently dropped.
+- `AWS::IAM::UserToGroupAddition` support. You can now manage an IAM group membership, adding a user to a group and removing it again, declaratively. This type can't be provisioned through CloudControl, so it previously couldn't be managed at all; the plugin now drives it directly through the IAM API. Each resource models one user-in-group membership, so to add several users to a group you declare one `UserToGroupAddition` per user.
+
+### Changed
+
+- Requires formae 0.87.0 or newer. This release uses two capabilities added in formae 0.87.0: embedding resolvables inside text fields (used by CloudFront `Function.functionCode`, above), and the new field hint for values a provider drops unless they are re-sent on every update. Secret- and configuration-class fields that need that treatment (an OIDC client secret, several ECS service-configuration fields, EC2 Launch Template write-only fields, and an IAM user's initial console password) are now annotated so they keep applying on update under 0.87.0's revised write-only behaviour. `minFormaeVersion` is bumped to 0.87.0 accordingly.
+- Network Firewall enum fields (such as a rule group's rule order and a firewall policy's stateful default actions) are now constrained to their valid values at `pkl eval` time, so an invalid value is caught when the forma is evaluated rather than rejected deep in the apply by AWS.
+
+### Fixed
+
+- An IAM `Role` with inline `policies` no longer shows a phantom update on every reconcile. AWS stores a role's inline policies separately and CloudControl's read doesn't return them, so formae re-proposed adding them on every reconcile even though they were already present. A role's inline policies are now read back, so a role that hasn't changed reconciles as a no-op. Note: manage a role's inline policies through `policies` **or** as standalone `AWS::IAM::RolePolicy` resources, not both on the same role.
+- A `Lambda::EventSourceMapping` no longer plans a destructive replace on every reconcile. Its `FunctionName` was incorrectly treated as immutable; because AWS reads the field back as the function's full ARN while a forma typically declares the short name, every reconcile saw a "change" to an immutable field and planned a destroy-and-recreate of the mapping. `FunctionName` is now correctly mutable (AWS updates it in place), so the mapping reconciles without a replace. Reference the target function by its ARN (`someFunction.res.arn`) for a clean no-op.
+- An ApiGateway `Method` with a Lambda-proxy integration no longer shows a phantom `Integration` update on every reconcile. The function reference is written into the integration as an invocation URI, but the read didn't translate it back, so the stored integration never matched what the forma declared. The read now restores the function reference from the invocation URI, and the same translation is applied when the integration is updated, so re-pointing a method at a different Lambda applies as an in-place update instead of failing.
+
+## [0.1.12]
+
+### Added
+
+- AWS Network Firewall support: `AWS::NetworkFirewall::Firewall`, `AWS::NetworkFirewall::FirewallPolicy`, `AWS::NetworkFirewall::RuleGroup`, and `AWS::NetworkFirewall::LoggingConfiguration`. You can now manage Network Firewall egress controls declaratively, including FQDN-allowlisting outbound traffic from private subnets. Rule groups, policies, and the firewall wire together through the resource graph (policy and rule-group ARNs, the firewall ARN, VPC and subnet IDs, and the log group are all Resolvables). The firewall exposes its per-AZ endpoints as a resolvable map, `firewall.res.endpointIds.at("<az>")`, so a route table can send `0.0.0.0/0` through the firewall endpoint in its own availability zone; existing EC2 routes accept a VPC-endpoint target unchanged. The firewall withholds create/update success until those per-AZ endpoints have propagated, so routes that depend on them don't resolve against an endpoint that isn't ready yet.
+
+### Changed
+
+- Requires formae 0.86.2 or newer. Updating a Network Firewall `FirewallPolicy`'s default-action lists relies on the whole-list replace behaviour added in formae 0.86.2; on earlier agents the update sends the old and new actions together and AWS rejects them as mutually exclusive. `minFormaeVersion` is bumped to 0.86.2 accordingly.
+- Applies are more resilient to AWS CloudControl API throttling. When many resources are created or updated at once, status reads that AWS throttled could previously exhaust their retry budget and fail an otherwise-healthy apply; the budget is widened so they ride out throttling bursts.
+- Plugin log lines now appear at their true severity in the agent log and carry per-operation attributes (namespace, operation, resource type, label). Previously, benign `INFO`/`WARN` lines, such as recoverable CloudControl throttling retries, surfaced as `ERROR` and carried none of those attributes, making the agent log noisier and harder to filter by resource.
+
+### Fixed
+
+- Route 53 records whose value is a hostname no longer show a phantom update on every reconcile, and no longer risk blocking the stack. AWS canonicalises domain-name record values with a trailing dot, so a `CNAME`, `DNAME`, `NS`, `PTR`, `MX`, or `SRV` record (or an `ALIAS` target) declared without the trailing dot read back dotted and produced a perpetual no-op diff. Because record-set updates are applied as delete-then-create, that mismatch could also fail with `InvalidChangeBatch` and block the apply. formae now normalises the trailing dot on read for these record types, so a dot-less declaration reconciles as a no-op. `TXT` and `SPF` values (quoted character strings) and `A`/`AAAA` (IP addresses) are left untouched.
+- ACM certificate DNS-validation records now reconcile cleanly. The validation `CNAME`'s value is sourced from the certificate via `cert.res.validationRecords`, and AWS returns it with a trailing dot while the record set read it back without one, leaving a phantom update on every reconcile. The certificate-sourced value is now normalised the same way, so the validation record settles as a no-op.
+- `secret.res.arn` on `AWS::SecretsManager::Secret` now resolves to the secret's ARN. It previously failed to resolve at all, so any resource referencing a secret's ARN that way errored out before any AWS call was made. `secret.res.arn`, `secret.res.id`, and `secret.res.ref` all now resolve to the ARN.
+- A secret's value now writes through. Changing `secretString` on `AWS::SecretsManager::Secret` previously had no effect, the value never reached AWS, so the secret didn't rotate. It's now applied, and `opaque.setOnce` is honoured so an unrelated edit won't re-write a set-once value. Requires formae 0.86.2, this release's floor.
+- `AWS::SES::EmailIdentity` updates now apply reliably. CloudControl's asynchronous update handler for this type can fail with `GeneralServiceException` ("The security token included in the request is invalid"), failing an otherwise-valid update. The plugin now applies EmailIdentity updates directly through the SES v2 API, MAIL FROM, DKIM signing, feedback forwarding, configuration set, and tags, instead of routing through CloudControl, mirroring how its Read is already handled.
+- `AWS::EKS::Cluster` no longer shows a phantom update on every reconcile. Newer Kubernetes versions (1.32 and later) return a control-plane egress mode that AWS populates itself, which formae previously treated as unexpected drift. It is now recognised as a provider-managed default, so a cluster that hasn't changed reconciles as a no-op.
+
+## [0.1.11]
+
+### Added
+
+- Seven new resource types bring fully-managed CloudFront stacks to formae, distributions, their policies, edge functions, and the ACM certificates they depend on, all wired together through the resource graph. The set is `AWS::CertificateManager::Certificate`, `AWS::CloudFront::Function`, `AWS::CloudFront::KeyValueStore`, `AWS::CloudFront::CachePolicy`, `AWS::CloudFront::OriginRequestPolicy`, `AWS::CloudFront::ResponseHeadersPolicy`, and `AWS::CloudFront::OriginAccessControl`. ACM certs ship with a full custom provisioner that talks to the ACM API directly (the resource type is non-provisionable through CloudControl); `cert.res.validationRecords` exposes the DNS validation CNAMEs ACM publishes, so a `Route53::RecordSet` (or any other DNS-publisher resource) can wire them through the resource graph instead of being filled in by hand. CloudFront Distributions can now reference all of the above through Resolvable links, cache policy ID, origin-request policy ID, response-headers policy ID, origin access control ID, function ARN, lambda ARN, and ACM cert ARN, and formae orders creates and destroys correctly based on those references.
+- `AWS::ECS::Service` now exposes an `endpoints` resolvable (`service.res.endpoints.at("containerName:containerPort")`) so downstream resources can wire their config URL through the service itself instead of through the listener. Because the endpoint resolves only once the service is operationally stable (the deployment-stability gating added in 0.1.10), anything consuming it waits until tasks are actually serving traffic. This closes the fresh-apply race where a listener URL resolved seconds before the tasks behind it were healthy, leaving consumers pointed at an endpoint returning 503s. Alongside this, `AWS::ElasticLoadBalancingV2::ListenerRule` now exposes its target group ARN so consumers of rule-routed services get correct ordering instead of racing the rule, and a load balancer `name` longer than the AWS 32-character limit is now rejected at `pkl eval` time rather than deep in apply. Listener-rule path/host routing, weighted target groups, and NLB endpoints are deferred follow-ups.
+- When a CloudControl operation fails with an error code formae doesn't already handle, the plugin now logs the full progress event: operation, error code, status message, resource type, request token, and identifier. Previously these failures flowed back with no record of the underlying AWS error code, making resource-type-specific timeout and stabilization failures (such as the occasional ECS Service delete that fails once and succeeds on retry) hard to diagnose. The line is emitted once per genuine failure, so it doesn't add noise to the many in-progress polls during long-running operations.
+
+### Changed
+
+- Requires formae 0.86.0 or newer. This release marks 60 provider-immutable fields across 13 services (AppRunner, EC2, ECR, ECS, EKS, Elastic Beanstalk, ELBv2, KMS, Lambda, RDS, Route 53, S3, SageMaker) as `createOnly`, to line up with the new planning behaviour in formae 0.86.0. Under 0.86.0, fields that aren't explicitly immutable are treated as mutable and updated in place rather than triggering a replace. Any field AWS actually rejects on update needs to be marked immutable, or the apply fails at the provider. With this release every such field is annotated correctly, so the 0.86.0 in-place-update behaviour lands without surprise provider rejections. `minFormaeVersion` is bumped to 0.86.0 accordingly.
+
+### Fixed
+
+- Security group rules are now destroyed *after* the workloads that sit behind the security group, instead of in the first destroy wave. Previously `AWS::EC2::SecurityGroupIngress` and `AWS::EC2::SecurityGroupEgress` had no incoming edges in the destroy graph, so they were torn down first, severing ALB-to-task health checks, task-to-EFS NFS, and task-to-internet connectivity, which then cascade-failed the rest of the teardown. The destroy order is now workloads, then the security group rules, then the security group itself.
+- `AWS::Lambda::EventInvokeConfig` no longer fails intermittently on create. CloudControl injects an empty `DestinationConfig` (with empty `OnFailure`/`OnSuccess` sub-objects) into every read of this resource, even when you never set one. formae's required-field validation then walked into the injected empty object and reported a missing `Destination`, surfacing as a flaky apply failure. The empty sub-objects are now stripped on read; genuine user-set destinations are non-empty and pass through untouched.
+- An EFS file system's mount targets are now torn down ahead of the file system itself, so destroying a stack that mounts EFS into ECS tasks no longer strands resources or fails on dependency-still-attached errors. This is driven by typed edge annotations (`runtimeDependency`) that pull the mount targets into the destroy ordering ahead of their file system.
+
+## [0.1.10]
+
+### Added
+
+- `AWS::ECS::Service` now reports success only once the deployment is operationally stable: the rollout has completed, the running task count matches the desired count, and at least one healthy target exists behind each attached target group. Previously the service reported success as soon as CloudControl acknowledged the request, so any downstream resource reachable through the load balancer (for example a Grafana target driving its config through the listener URL) frequently hit 503s before the tasks were serving traffic. Non-standard service shapes (`CODE_DEPLOY` and `EXTERNAL` deployment controllers, the `DAEMON` scheduling strategy, classic-ELB attachments without a target group ARN, and `desiredCount = 0`) fall through to safe defaults rather than waiting on target health.
+
+## [0.1.9]
+
+### Fixed
+
+- ELBv2 target groups no longer produce phantom drift that blocks `formae apply`. The target group's `Targets` field is populated at runtime by ECS Services (and anything else calling the register-targets API), and `LoadBalancerArns` is populated when a listener attaches the target group to a load balancer; neither is meaningfully user-settable. Tracking them in formae state meant the periodic synchronizer rewrote the resource on every ECS task placement and every listener attach, after which reconcile rejected the next apply with the stacks-have-been-modified error even though the forma hadn't changed, forcing operators into force mode or extract-and-absorb on every reconcile. Both fields are now dropped from the schema and stripped from the AWS read response before they reach formae state.
+
+## [0.1.8]
+
+### Fixed
+
+- ECS `Service` creation no longer fails with `target group <arn> does not have an associated load balancer` when the Service and its Listener are scheduled together in the same apply. The plugin now treats that specific CloudControl error (`InvalidRequest` + matching message text, on Create operations only) as a transient in-progress state; the PluginOperator's existing status-poll loop absorbs the race until the Listener finishes wiring the target group to the load balancer. No PKL change needed, direct `tg.res.targetGroupArn` references keep working and don't have to be rewritten through `listener.res.targetGroupArn` to avoid the race.
+- Inverts the destroy edge between an ECS Service and its target groups via `attachesTo` field hints on `Service.LoadBalancer.targetGroupArn` and `Service.VpcLatticeConfiguration.targetGroupArn`. AWS rejects target-group deletion while a Service is still attached; without the annotation, the Service tore down in parallel with the listener chain, and any plugin-target driving CRUD through the Service's listener URL (Grafana, Loki, Tempo, and similar) wedged mid-tear-down with no URL backing it. With the annotation, the Service is destroyed before its target group. Requires formae 0.85.0 or newer to take effect: 0.84.0 agents silently ignore the annotation (the plugin still installs and every other fix applies, but the destroy-edge inversion no-ops). The plugin's `minFormaeVersion` stays at 0.84.0 deliberately, sibling plugins built against the same SDK family work fine on 0.84.0 and forcing an agent upgrade for one annotation isn't worth the disruption.
+- Transient `CloudControl` errors are no longer silently terminal. Synchronous errors from CCAPI on `Create`, `Update`, and `Delete` were previously surfaced to the agent as bare Go errors, which the agent classified as `UnforeseenError`, a non-recoverable code that bypasses the retry pipeline entirely. Even errors that AWS itself flags as recoverable (`Throttling`, `NotStabilized`, `ResourceConflict`, …) ended up as terminal failures. The plugin now translates these into the typed `OperationErrorCode` formae's PluginOperator understands, so the agent retries recoverable conditions instead of failing the whole apply.
+- `AWS::RDS::DBSubnetGroup` no longer fails non-deterministically when its subnets are created in the same forma. AWS RDS rejected freshly-created EC2 subnets with `InvalidRequestException: Some input subnets ... are invalid` until RDS's internal subnet cache caught up, a classic cross-service eventual-consistency window between EC2 and RDS. The plugin recognises this specific class of `InvalidRequest` as a recoverable race, so the agent retries through the propagation gap and the subnet group lands on the first apply.
+- `AWS::SES::ConfigurationSetEventDestination` updates now succeed. Previously, any update to an event destination (toggling `enabled`, changing `matchingEventTypes`, switching destination targets) failed within milliseconds with no AWS API round-trip. CCAPI rejects this resource's composite `<csName>|<edName>` identifier on Update with `ValidationException: not valid for identifier [/properties/Id]`, the same limitation that affected Read in 0.1.7. Updates now route through `sesv2.UpdateConfigurationSetEventDestination` directly.
+- `AWS::SES::ConfigurationSetEventDestination` deletes now succeed. Same CCAPI composite-identifier limitation as Update. The most user-visible symptom was that `formae destroy` failed on any stack containing an event destination, and replace flows (when the parent `ConfigurationSet.name` changes) failed at the destroy step. Deletes now go through `sesv2.DeleteConfigurationSetEventDestination`, with a missing-destination error treated as a successful no-op so retried destroys are idempotent.
+- Discovery of `AWS::SES::ConfigurationSetEventDestination` now correctly surfaces existing event destinations as unmanaged resources. CCAPI's `ListResources` returns bare `EventDestinationName`s (`"bounces"`) instead of the composite `<csName>|<edName>` the resource's Read path requires, so every discovered destination failed its per-resource Read and never made it into the inventory. The plugin's List now walks `ListConfigurationSets` → `GetConfigurationSetEventDestinations` and emits properly-formed composite identifiers.
+
+## [0.1.7]
+
+### Added
+
+- Amazon SES support for outbound transactional email. `AWS::SES::EmailIdentity` covers verified sending domains or addresses (with bundled MAIL FROM, feedback, and Easy DKIM attributes). `AWS::SES::ConfigurationSet` and `AWS::SES::ConfigurationSetEventDestination` route bounce/complaint/delivery events to SNS, Kinesis Firehose, EventBridge, or CloudWatch, exactly one of the four destination types is enforced at PKL evaluation time, so bad shapes fail at `pkl eval` rather than at apply time. `AWS::SES::EmailIdentityVerification` is a polling gate downstream consumers depend on for send-readiness; it sits between the identity (and the DNS records that verify it) and any resource that needs to send mail, breaking the apply-time deadlock where verification needs DNS, DNS depends on the identity, and the identity can't wait on either.
+- `EmailIdentity.res.requiredDnsRecords` is a typed listing resolvable that exposes the DNS records SES expects, 3 DKIM CNAMEs, plus an MX and SPF TXT for MAIL FROM when configured. A forma drives Route53 (or any DNS plugin) directly off `id.res.requiredDnsRecords.at(N).name` and `.values`, with no manual token extraction. See `examples/ses-basic/main.pkl` in the plugin repo for the full pattern. Terraform, Pulumi, and Crossplane all force users to extract `verification_token`/`dkim_tokens[]` strings and hand-author the records; this is the first IaC tool to wire them automatically.
+
+### Fixed
+
+- `AWS::EC2::PlacementGroup`'s `spreadLevel` is now marked `hasProviderDefault`. AWS auto-populates `SpreadLevel` after a `partition`-strategy create even when not specified, which previously caused replace flows (where the user switches `strategy` from `spread` to `partition`) to fail with `Property SpreadLevel is not expected and not a provider default`. The field stays `createOnly`.
+- Container-level changes on `AWS::ECS::TaskDefinition` are no longer silently dropped from the diff. 19 user-canonical sub-fields on `ContainerDefinition`, including `environment`, `portMappings`, `mountPoints`, `secrets`, `command`, `entryPoint`, `dependsOn`, `extraHosts`, and `dockerLabels`, were previously annotated `hasProviderDefault`, which symmetrically stripped them from both the desired and actual sides before comparison. Any real change to those fields produced an empty plan on `formae apply`, forcing operators into out-of-band `aws ecs register-task-definition` workarounds (which then showed up as drift on the next reconcile). The annotation is now scoped to the genuinely cloud-defaulted scalars (`cpu`, `essential`, `versionConsistency`).
+- `AWS::Lambda::LayerVersion`'s `compatibleArchitectures`, `compatibleRuntimes`, and `description` are now marked `hasProviderDefault`. AWS Read returns empty values for these when the user omits them in PKL, and because every `LayerVersion` field is `createOnly`, the resulting phantom drift would schedule a destroy + create on every reapply.
+
+## [0.1.6]
+
+### Fixed
+
+- Updating an `AWS::Lambda::EventInvokeConfig` no longer fails with `Model validation failed: required key [Destination] not found`. CloudControl's update handler for this resource type re-validates the full server-side state on every patch, even fields the patch doesn't touch, and AWS materialises empty `DestinationConfig.OnFailure` / `OnSuccess` sub-objects into the response on Read whether or not the caller ever set them, which then fail the schema's "if present, `Destination` is required" rule. Updates that only changed `MaximumRetryAttempts` or `MaximumEventAgeInSeconds` would still get rejected on the server side. Updates now route through the Lambda `UpdateFunctionEventInvokeConfig` API directly, which has no such cross-field re-validation.
+- ELBv2 `Listener.defaultActions[*].forwardConfig` and ECS `Cluster.clusterSettings` are now marked `hasProviderDefault`. ELBv2 derives `ForwardConfig` (target groups + stickiness defaults) on Read from the action's `TargetGroupArn` when the user specifies a simple forward target, and ECS populates `clusterSettings` with default entries like `containerInsights: disabled` when none are configured. Without the annotations, every reapply emitted a no-op patch on these fields that surfaced as a spurious update.
+
+## [0.1.5]
+
+### Added
+
+- Complete EKS resource coverage. `Addon`, `AccessEntry`, `FargateProfile`, `PodIdentityAssociation`, and `IdentityProviderConfig` are now first-class resources alongside `Cluster` and `Nodegroup`, enabling end-to-end EKS cluster management (including discovery of cluster-child resources) from a single forma.
+- ECS `ExpressGatewayService` support. Express Gateway services can now be managed through formae. Uses the native ECS SDK because the CloudControl handler for this type is broken server-side.
+- ALB Listener URL resolvable, Listeners now expose a computed `url` property that combines the parent ALB's DNS name with the Listener's protocol and port. Use `listener.res.url` to wire load balancer endpoints into target configs without manual URL construction.
+- ~225 reference-bearing properties (IDs, ARNs, names) across 77 schema files now accept `formae.Resolvable`, and all resources with Resolvable classes now have `hidden res` wired up.
+
+### Changed
+
+- The `profile` field is now mutable, changing it updates the target in place without recreating resources. The `region` field remains immutable; changing it triggers a full target replace as before. See Per-field config mutability for details.
+
+### Fixed
+
+- ECS `Service` and `TaskSet` discovery no longer spam `InvalidRequestException: Missing Or Invalid ResourceModel property` errors on every cycle. Service is now discovered as a child of Cluster (its list handler requires a `Cluster` filter), and TaskSet is enumerated via the ECS SDK's `DescribeServices` because its CloudControl list handler demands an `Id` and is effectively a Read.
+- TaskDefinition was missing its resolvable wiring, `taskDef.res.taskDefinitionArn` now works as expected, enabling ECS Services to reference task definitions via resolvables.
+- `EFSVolumeConfiguration.filesystemId` now accepts resolvable references, so ECS tasks can reference EFS filesystems created in the same forma.
+- VPCGatewayAttachment now exposes resolvable references (`igwAttach.res.internetGatewayId`). Routes should reference the gateway ID through the attachment, not the gateway directly, to ensure correct destroy ordering. Without this, destroying a stack with Routes and an IGW attachment could hang for hours because formae tried to detach the IGW before deleting the routes that use it.
+- Listener now exposes `listener.res.targetGroupArn`, resolving to the target-group ARN attached via the listener's first default action. ECS Services (and any other consumer that needs the target group already wired to the load balancer) should reference this instead of `tg.res.targetGroupArn`. Without it, AWS rejects ECS service creation with "target group does not have an associated load balancer" when formae schedules the service before the listener attaches the TG. Same pattern as `igwAttach.res.internetGatewayId` for routes/IGW.
+- Patch-mode updates to resources with optional nested objects (for example, Lambda `EventInvokeConfig.DestinationConfig`) could fail with CloudControl errors like `required key [Destination] not found` when the nested object was empty. The plugin now strips empty sub-objects from `replace` operations the same way it already did for `add` operations, so these updates succeed.
+- Reapplying an unchanged forma containing an ECS Service no longer spuriously replaces the service. AWS fills in default port-mapping values on `awsvpc` tasks that the user didn't set, which previously made the planner think the task definition had changed. Those fields are now recognised as provider-populated and ignored during comparison. Requires formae 0.84.0.
+- `EFSVolumeConfiguration.rootDirectory` no longer causes phantom replacements. CloudControl returns `RootDirectory` as `"/"` even when it was never set, which made the planner see a change on every reapply.
+- ECS Service and TaskSet no longer produce spurious replacements when the Cluster field is referenced via ARN. CloudControl normalises the Cluster to a short name on Read, which flipped the `createOnly` field and triggered a full replace. ARN-vs-short-name differences are now normalised before comparison.
+- TaskSet updates no longer hang indefinitely. CloudControl's update handler for TaskSet Scale never returns; a custom ECS SDK update provisioner is used instead.
+
+## [0.1.4]
+
+### Fixed
+
+- Route53 RecordSets with the same name but different types (e.g., SOA and NS for the same domain) were discovered with identical labels, causing duplicate entries that churned on every sync cycle. Labels now include the record type, producing unique entries like `example.com.-SOA` and `example.com.-NS`.
+- Resources with composite CloudControl identifiers (e.g., ECS Services, Lambda EventInvokeConfigs) could show up as duplicates in inventory, one from the initial create and another from discovery. This happened because AWS CloudControl returns full ARNs during create but short names during list. Identifiers are now normalized so the resource created by apply and the resource found by discovery are correctly recognized as the same thing.
+- Discovery of subnet route table associations could cause apply commands to get permanently stuck. AWS returns VPC-level (main) route table associations in discovery results that cannot be read, which triggered a cascade of internal failures. These associations are now filtered out during discovery.
+- Updates to resources with provider-default nested objects (e.g. Lambda EventInvokeConfig destination config) could fail with CloudControl validation errors. Empty nested objects left behind after stripping unused fields were not being removed, causing required-field violations.
+
+## [0.1.3]
+
+### Added
+
+- Conformance test coverage for 88 resource types across EC2, ECS, EKS, ELBv2, Elastic Beanstalk, Lambda, API Gateway, RDS, Route53, S3, SQS, IAM, KMS, EFS, ECR, CloudWatch Logs, Secrets Manager, and DynamoDB, validating the full create, read, update, delete, sync, and discovery lifecycle.
+- Cross-resource references: TransitGateway, FlowLog, ResourcePolicy, ConfigurationTemplate, NetworkAclEntry, and TargetGroupTuple fields now support resolvable references, enabling correct dependency ordering during apply.
+
+### Fixed
+
+- Several resource types had broken operations through AWS CloudControl that are now fixed:
+  - S3 BucketPolicy: reads were broken, now works correctly
+  - S3 StorageLensGroup: updates were missing resource properties in the response
+  - SQS QueuePolicy: was not provisionable through CloudControl, now works via direct SQS API
+  - IAM Policy: was not provisionable through CloudControl, now works via direct IAM API
+  - IAM AccessKey: was not provisionable through CloudControl, now works via direct IAM API
+  - IAM InstanceProfile: suffered from a 60-second propagation delay through CloudControl, now works via direct IAM API
+  - EC2 NetworkAclEntry: was not supported through CloudControl, now works via direct EC2 API
+  - Elastic Beanstalk ConfigurationTemplate: updates through CloudControl injected CloudFormation references, now works via direct EB API
+- Spurious diffs during updates and synchronization for resources where AWS populates default values (e.g. LoadBalancer attributes, ECS container defaults, Lambda runtime settings). Over 130 fields across 54 resource schemas now correctly distinguish user-specified values from provider defaults.
+- Newly created resources could appear with missing identifiers or properties in the inventory until the next sync.
+- Empty optional fields could cause apply failures with CloudControl validation errors (e.g. Lambda Architectures, ECS container definitions). Optional fields that are not set are now correctly omitted.
+- Elastic Beanstalk ConfigurationTemplates deleted outside of formae were not correctly detected during synchronization.
+- CloudControl status polling now correctly handles ELBv2 update semantics and prevents extract crashes on resources with complex nested properties.
+
+## [0.1.2]
+
+### Added
+
+- Phase 1 conformance tests covering 32 standalone resources, validating the full CRUD and discovery lifecycle.
+- Expanded Route53 HealthCheck schema with fully typed `HealthCheckConfig` and `AlarmIdentifier` sub-resources, enabling richer health check definitions in Pkl.
+- Added `ResourceLifecycleConfig` fields to ElasticBeanstalk environments and configuration templates.
+- Added an AppRunner example demonstrating a simple web service deployment.
+
+### Changed
+
+- Renamed `apprunner/service.pkl` to `apprunner/apprunnerservice.pkl` for consistency with the naming convention used across other resource schemas.
+
+### Fixed
+
+- Extract now correctly filters `ListResults`, preventing unrelated resources from appearing in extracted Pkl output.
+
+## [0.1.1]
+
+### Added
+
+- Added support for AppRunner resources (`AWS::AppRunner::Service`), enabling management of AppRunner web services through formae.
+
+### Fixed
+
+- Added missing `af-south-1` availability zone pattern. The `Region` typealias already included `af-south-1`, but the `AvailabilityZone` constraint was missing it, causing Pkl evaluation failures for resources in that region.
+
+## [0.1.0]
+
+### Added
+
+- Initial release of the AWS plugin as a standalone package built on the formae Plugin SDK.

--- a/Makefile
+++ b/Makefile
@@ -171,6 +171,7 @@ conformance-test-discovery: install
 conformance-test-crud-run:
 	@echo "Running CRUD conformance tests..."
 	@FORMAE_TEST_FILTER="$(TEST)" FORMAE_TEST_TYPE=crud FORMAE_TEST_PARALLEL="$(PARALLEL)" FORMAE_TEST_TIMEOUT="$(or $(TIMEOUT),60)" \
+		FORMAE_TEST_ACCOUNT_ID=$$(aws sts get-caller-identity --query Account --output text 2>/dev/null) \
 		$(GO) test -tags=conformance -v -timeout $(or $(TIMEOUT),60)m ./...
 
 ## conformance-test-discovery-run: Run only discovery tests (no cleanup)
@@ -178,4 +179,5 @@ conformance-test-crud-run:
 conformance-test-discovery-run:
 	@echo "Running discovery conformance tests..."
 	@FORMAE_TEST_FILTER="$(TEST)" FORMAE_TEST_TYPE=discovery FORMAE_TEST_PARALLEL="$(PARALLEL)" FORMAE_TEST_TIMEOUT="$(or $(TIMEOUT),60)" \
+		FORMAE_TEST_ACCOUNT_ID=$$(aws sts get-caller-identity --query Account --output text 2>/dev/null) \
 		$(GO) test -tags=conformance -v -timeout $(or $(TIMEOUT),60)m ./...

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ API](https://docs.aws.amazon.com/cloudcontrolapi/latest/userguide/what-is-cloudc
 
 ## Supported Resources
 
-This plugin supports **209 AWS resource types** across 21 services via the
+This plugin supports **210 AWS resource types** across 22 services via the
 CloudControl API:
 
 | Service | Resources | Examples |
@@ -27,6 +27,7 @@ CloudControl API:
 | KMS | 2 | Key, Alias |
 | Secrets Manager | 4 | Secret, ResourcePolicy, RotationSchedule |
 | CloudFront | 1 | Distribution |
+| CloudTrail | 1 | Trail |
 | ELBv2 | 7 | LoadBalancer, TargetGroup, Listener, ListenerRule |
 | ECR | 6 | Repository, RegistryPolicy, ReplicationConfiguration |
 | EFS | 3 | FileSystem, MountTarget, AccessPoint |

--- a/aws.go
+++ b/aws.go
@@ -100,6 +100,8 @@ func (p *Plugin) LabelConfig() pkgmodel.LabelConfig {
 			"AWS::CertificateManager::Certificate": "$.DomainName",
 			// S3 objects use Key property
 			"AWS::S3::Object": "$.Key",
+			// CloudTrail trails have no Name tag; use the trail name as the label.
+			"AWS::CloudTrail::Trail": "$.TrailName",
 			// Resources that represent relationships use parent IDs
 			"AWS::EC2::VPCGatewayAttachment":          "$.VpcId",
 			"AWS::EC2::SubnetRouteTableAssociation":   "$.SubnetId",

--- a/examples/PklProject
+++ b/examples/PklProject
@@ -6,6 +6,6 @@ dependencies {
 
   // Formae schema - fetched from public registry
   ["formae"] {
-    uri = "package://hub.platform.engineering/plugins/pkl/schema/pkl/formae/formae@0.87.0"
+    uri = "package://hub.platform.engineering/plugins/pkl/schema/pkl/formae/formae@0.88.0"
   }
 }

--- a/formae-plugin.pkl
+++ b/formae-plugin.pkl
@@ -5,13 +5,13 @@
  */
 
 name = "aws"
-version = "0.1.13-dev.0"
+version = "0.1.13-dev.1"
 namespace = "AWS"
 summary = "AWS resource plugin (CloudControl-based)"
 description = "AWS CloudControl resource plugin for Formae"
 category = "cloud"
 license = "FSL-1.1-ALv2"
-minFormaeVersion = "0.87.1"
+minFormaeVersion = "0.88.0"
 
 output {
   renderer = new JsonRenderer {}

--- a/formae-plugin.pkl
+++ b/formae-plugin.pkl
@@ -5,7 +5,7 @@
  */
 
 name = "aws"
-version = "0.1.13-dev.1"
+version = "0.1.13-dev.2"
 namespace = "AWS"
 summary = "AWS resource plugin (CloudControl-based)"
 description = "AWS CloudControl resource plugin for Formae"

--- a/formae-plugin.pkl
+++ b/formae-plugin.pkl
@@ -5,7 +5,7 @@
  */
 
 name = "aws"
-version = "0.1.13-dev.2"
+version = "0.1.15"
 namespace = "AWS"
 summary = "AWS resource plugin (CloudControl-based)"
 description = "AWS CloudControl resource plugin for Formae"

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/aws/smithy-go v1.27.1
 	github.com/evanphx/json-patch/v5 v5.9.11
 	github.com/google/uuid v1.6.0
-	github.com/platform-engineering-labs/formae/pkg/model v0.1.26-0.20260723233823-5d2d78366521
+	github.com/platform-engineering-labs/formae/pkg/model v0.1.26
 	github.com/platform-engineering-labs/formae/pkg/plugin v0.4.1
 	github.com/platform-engineering-labs/formae/pkg/plugin-conformance-tests v0.2.5-0.20260528030337-9ae690b3715c
 	github.com/stretchr/testify v1.11.1

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/aws/smithy-go v1.27.1
 	github.com/evanphx/json-patch/v5 v5.9.11
 	github.com/google/uuid v1.6.0
-	github.com/platform-engineering-labs/formae/pkg/model v0.1.25-0.20260528030337-9ae690b3715c
+	github.com/platform-engineering-labs/formae/pkg/model v0.1.26-0.20260723233823-5d2d78366521
 	github.com/platform-engineering-labs/formae/pkg/plugin v0.4.1
 	github.com/platform-engineering-labs/formae/pkg/plugin-conformance-tests v0.2.5-0.20260528030337-9ae690b3715c
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -140,6 +140,8 @@ github.com/platform-engineering-labs/formae/pkg/model v0.1.25-0.20260528030337-9
 github.com/platform-engineering-labs/formae/pkg/model v0.1.25-0.20260528030337-9ae690b3715c/go.mod h1:1dmsFwoaJZkHevBsAIZr068CWzG7de1VNz7PFWvM3Z8=
 github.com/platform-engineering-labs/formae/pkg/model v0.1.26-0.20260723233823-5d2d78366521 h1:qvg0Hy1CqaE8ZyWK91Sd3YVVjzCIv+kelFnsLE5K+fc=
 github.com/platform-engineering-labs/formae/pkg/model v0.1.26-0.20260723233823-5d2d78366521/go.mod h1:1dmsFwoaJZkHevBsAIZr068CWzG7de1VNz7PFWvM3Z8=
+github.com/platform-engineering-labs/formae/pkg/model v0.1.26 h1:80p843bmz9sLTtUFveMGWYeGcpRjvceyVxUgPvlApqs=
+github.com/platform-engineering-labs/formae/pkg/model v0.1.26/go.mod h1:1dmsFwoaJZkHevBsAIZr068CWzG7de1VNz7PFWvM3Z8=
 github.com/platform-engineering-labs/formae/pkg/plugin v0.4.1 h1:dg8TBQVJR8DVF28bvmzAG4Ms1Id0yIr6Kd8c3UTO3iw=
 github.com/platform-engineering-labs/formae/pkg/plugin v0.4.1/go.mod h1:ZFXMfeZljHVDWQTSeJ4dj2EG3iTjdrxQjm7DpvOYUXk=
 github.com/platform-engineering-labs/formae/pkg/plugin-conformance-tests v0.2.5-0.20260528030337-9ae690b3715c h1:Hm+eUI17d9hgtAMYS7kqfyI7MpgQ8epjBHAeAkJ/AvI=

--- a/go.sum
+++ b/go.sum
@@ -138,6 +138,8 @@ github.com/platform-engineering-labs/formae/pkg/api/model v0.1.1 h1:ZMTgKwSomy2c
 github.com/platform-engineering-labs/formae/pkg/api/model v0.1.1/go.mod h1:0ncHFCsGA6b0w1kBm6m+QwJ823qAY2vL47GvoR0BTyU=
 github.com/platform-engineering-labs/formae/pkg/model v0.1.25-0.20260528030337-9ae690b3715c h1:4RiuwTM5FLJxmuiCSZe1AwoovThRF7gGrPfxHIdCxlA=
 github.com/platform-engineering-labs/formae/pkg/model v0.1.25-0.20260528030337-9ae690b3715c/go.mod h1:1dmsFwoaJZkHevBsAIZr068CWzG7de1VNz7PFWvM3Z8=
+github.com/platform-engineering-labs/formae/pkg/model v0.1.26-0.20260723233823-5d2d78366521 h1:qvg0Hy1CqaE8ZyWK91Sd3YVVjzCIv+kelFnsLE5K+fc=
+github.com/platform-engineering-labs/formae/pkg/model v0.1.26-0.20260723233823-5d2d78366521/go.mod h1:1dmsFwoaJZkHevBsAIZr068CWzG7de1VNz7PFWvM3Z8=
 github.com/platform-engineering-labs/formae/pkg/plugin v0.4.1 h1:dg8TBQVJR8DVF28bvmzAG4Ms1Id0yIr6Kd8c3UTO3iw=
 github.com/platform-engineering-labs/formae/pkg/plugin v0.4.1/go.mod h1:ZFXMfeZljHVDWQTSeJ4dj2EG3iTjdrxQjm7DpvOYUXk=
 github.com/platform-engineering-labs/formae/pkg/plugin-conformance-tests v0.2.5-0.20260528030337-9ae690b3715c h1:Hm+eUI17d9hgtAMYS7kqfyI7MpgQ8epjBHAeAkJ/AvI=

--- a/pkg/cfres/networkfirewall/loggingconfiguration.go
+++ b/pkg/cfres/networkfirewall/loggingconfiguration.go
@@ -1,0 +1,131 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+package networkfirewall
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/ccx"
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/cfres/prov"
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/cfres/registry"
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/config"
+)
+
+const loggingConfigurationType = "AWS::NetworkFirewall::LoggingConfiguration"
+
+// loggingConfigClient abstracts the CloudControl read this List synthesizes from,
+// so it can be mocked in unit tests. *ccx.Client satisfies this interface.
+type loggingConfigClient interface {
+	ReadResource(ctx context.Context, request *resource.ReadRequest) (*resource.ReadResult, error)
+}
+
+// LoggingConfiguration supplies a custom List for AWS::NetworkFirewall::LoggingConfiguration.
+// CloudControl does not support the LIST action for this type (ListResources returns
+// UnsupportedActionException), so discovery cannot enumerate it the generic way. A
+// logging configuration is a per-firewall singleton, though, and CloudControl's GetResource
+// (keyed by the firewall ARN) does work. Discovery scopes this List to one firewall via the
+// FirewallArn list parameter; we read that firewall's logging configuration and return its
+// identifier when destinations are configured. Only List is registered — Create/Read/Update/
+// Delete/Status fall through to the generic CloudControl path in aws.go.
+type LoggingConfiguration struct {
+	cfg *config.Config
+	// client is injectable for testing; nil means construct a real ccx.Client.
+	client loggingConfigClient
+}
+
+var _ prov.Provisioner = &LoggingConfiguration{}
+
+func init() {
+	registry.Register(loggingConfigurationType,
+		[]resource.Operation{resource.OperationList},
+		func(cfg *config.Config) prov.Provisioner {
+			return &LoggingConfiguration{cfg: cfg}
+		})
+}
+
+func (l *LoggingConfiguration) getClient() (loggingConfigClient, error) {
+	if l.client != nil {
+		return l.client, nil
+	}
+	return ccx.NewClient(l.cfg)
+}
+
+// List returns the firewall's ARN (the logging configuration's identifier) when the
+// firewall named by the FirewallArn list parameter has at least one log destination
+// configured. A firewall with no logging, or one that no longer exists, contributes
+// nothing. Discovery reads each returned identifier back through the generic Read path.
+func (l *LoggingConfiguration) List(ctx context.Context, request *resource.ListRequest) (*resource.ListResult, error) {
+	firewallArn := request.AdditionalProperties["FirewallArn"]
+	if firewallArn == "" {
+		return nil, fmt.Errorf("FirewallArn is required to list network firewall logging configurations")
+	}
+
+	client, err := l.getClient()
+	if err != nil {
+		return nil, fmt.Errorf("creating cloudcontrol client: %w", err)
+	}
+
+	result, err := client.ReadResource(ctx, &resource.ReadRequest{
+		NativeID:     firewallArn,
+		ResourceType: loggingConfigurationType,
+		TargetConfig: request.TargetConfig,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("reading logging configuration for firewall %s: %w", firewallArn, err)
+	}
+	if result.ErrorCode == resource.OperationErrorCodeNotFound {
+		return &resource.ListResult{}, nil
+	}
+	if result.ErrorCode != "" {
+		return nil, fmt.Errorf("reading logging configuration for firewall %s: %s", firewallArn, result.ErrorCode)
+	}
+	if !hasLogDestinations(result.Properties) {
+		return &resource.ListResult{}, nil
+	}
+	return &resource.ListResult{NativeIDs: []string{firewallArn}}, nil
+}
+
+// hasLogDestinations reports whether a read logging configuration has at least one
+// destination configured. An empty configuration is not a discoverable resource.
+func hasLogDestinations(properties string) bool {
+	if properties == "" {
+		return false
+	}
+	var p struct {
+		LoggingConfiguration struct {
+			LogDestinationConfigs []json.RawMessage `json:"LogDestinationConfigs"`
+		} `json:"LoggingConfiguration"`
+	}
+	if err := json.Unmarshal([]byte(properties), &p); err != nil {
+		return false
+	}
+	return len(p.LoggingConfiguration.LogDestinationConfigs) > 0
+}
+
+// The remaining Provisioner methods are unreachable: only List is registered, so
+// Create/Read/Update/Delete/Status always route to CloudControl in aws.go.
+func (l *LoggingConfiguration) Create(_ context.Context, _ *resource.CreateRequest) (*resource.CreateResult, error) {
+	return nil, fmt.Errorf("create not implemented - cloudcontrol handles this")
+}
+
+func (l *LoggingConfiguration) Read(_ context.Context, _ *resource.ReadRequest) (*resource.ReadResult, error) {
+	return nil, fmt.Errorf("read not implemented - cloudcontrol handles this")
+}
+
+func (l *LoggingConfiguration) Update(_ context.Context, _ *resource.UpdateRequest) (*resource.UpdateResult, error) {
+	return nil, fmt.Errorf("update not implemented - cloudcontrol handles this")
+}
+
+func (l *LoggingConfiguration) Delete(_ context.Context, _ *resource.DeleteRequest) (*resource.DeleteResult, error) {
+	return nil, fmt.Errorf("delete not implemented - cloudcontrol handles this")
+}
+
+func (l *LoggingConfiguration) Status(_ context.Context, _ *resource.StatusRequest) (*resource.StatusResult, error) {
+	return nil, fmt.Errorf("status not implemented - cloudcontrol handles this")
+}

--- a/pkg/cfres/networkfirewall/loggingconfiguration_test.go
+++ b/pkg/cfres/networkfirewall/loggingconfiguration_test.go
@@ -1,0 +1,85 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package networkfirewall
+
+import (
+	"context"
+	"testing"
+
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+const testFirewallArn = "arn:aws:network-firewall:us-east-1:111122223333:firewall/fw-1"
+
+func readReq(r *resource.ReadRequest) bool {
+	return r.NativeID == testFirewallArn && r.ResourceType == loggingConfigurationType
+}
+
+func TestLoggingConfigurationList_ReturnsFirewallArnWhenLoggingConfigured(t *testing.T) {
+	ctx := context.Background()
+	client := &mockCCXClient{}
+	client.On("ReadResource", ctx, mock.MatchedBy(readReq)).Return(&resource.ReadResult{
+		Properties: `{"FirewallArn":"` + testFirewallArn + `","LoggingConfiguration":{"LogDestinationConfigs":[` +
+			`{"LogType":"FLOW","LogDestinationType":"CloudWatchLogs","LogDestination":{"logGroup":"/x"}}]}}`,
+	}, nil)
+
+	l := &LoggingConfiguration{client: client}
+	result, err := l.List(ctx, &resource.ListRequest{
+		ResourceType:         loggingConfigurationType,
+		AdditionalProperties: map[string]string{"FirewallArn": testFirewallArn},
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, []string{testFirewallArn}, result.NativeIDs)
+	client.AssertExpectations(t)
+}
+
+func TestLoggingConfigurationList_EmptyWhenNoDestinations(t *testing.T) {
+	ctx := context.Background()
+	client := &mockCCXClient{}
+	client.On("ReadResource", ctx, mock.MatchedBy(readReq)).Return(&resource.ReadResult{
+		Properties: `{"FirewallArn":"` + testFirewallArn + `","LoggingConfiguration":{"LogDestinationConfigs":[]}}`,
+	}, nil)
+
+	l := &LoggingConfiguration{client: client}
+	result, err := l.List(ctx, &resource.ListRequest{
+		ResourceType:         loggingConfigurationType,
+		AdditionalProperties: map[string]string{"FirewallArn": testFirewallArn},
+	})
+
+	require.NoError(t, err)
+	require.Empty(t, result.NativeIDs)
+	client.AssertExpectations(t)
+}
+
+func TestLoggingConfigurationList_EmptyWhenFirewallNotFound(t *testing.T) {
+	ctx := context.Background()
+	client := &mockCCXClient{}
+	client.On("ReadResource", ctx, mock.MatchedBy(readReq)).Return(&resource.ReadResult{
+		ErrorCode: resource.OperationErrorCodeNotFound,
+	}, nil)
+
+	l := &LoggingConfiguration{client: client}
+	result, err := l.List(ctx, &resource.ListRequest{
+		ResourceType:         loggingConfigurationType,
+		AdditionalProperties: map[string]string{"FirewallArn": testFirewallArn},
+	})
+
+	require.NoError(t, err)
+	require.Empty(t, result.NativeIDs)
+	client.AssertExpectations(t)
+}
+
+func TestLoggingConfigurationList_ErrorsWithoutFirewallArn(t *testing.T) {
+	l := &LoggingConfiguration{}
+	_, err := l.List(context.Background(), &resource.ListRequest{
+		ResourceType: loggingConfigurationType,
+	})
+	require.Error(t, err)
+}

--- a/pkg/cfres/s3/object.go
+++ b/pkg/cfres/s3/object.go
@@ -20,6 +20,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
 
 	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/cfres/prov"
 	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/cfres/registry"
@@ -70,9 +71,9 @@ func parseNativeID(nativeID string) (bucket, key string, err error) {
 }
 
 const (
-	maxDownloadBytes    = 256 << 20
+	maxDownloadBytes     = 256 << 20
 	maxDecompressedBytes = 256 << 20
-	fetchTimeout        = 5 * time.Minute
+	fetchTimeout         = 5 * time.Minute
 )
 
 // resolveBodyWithCloser returns an io.Reader for the object body and a closer function.
@@ -576,6 +577,24 @@ func (o *Object) List(ctx context.Context, request *resource.ListRequest) (*reso
 	return o.listWithClient(ctx, client, request)
 }
 
+// bucketRegionFromRedirect returns the bucket's home region when err is an S3
+// 301 PermanentRedirect that carries an x-amz-bucket-region header, so the
+// caller can retry the request against the correct region.
+func bucketRegionFromRedirect(err error) (string, bool) {
+	var respErr *smithyhttp.ResponseError
+	if !errors.As(err, &respErr) {
+		return "", false
+	}
+	if respErr.HTTPStatusCode() != http.StatusMovedPermanently || respErr.Response == nil {
+		return "", false
+	}
+	region := respErr.Response.Header.Get("x-amz-bucket-region")
+	if region == "" {
+		return "", false
+	}
+	return region, true
+}
+
 func (o *Object) listWithClient(ctx context.Context, client s3ObjectClient, request *resource.ListRequest) (*resource.ListResult, error) {
 	if request.AdditionalProperties == nil {
 		return nil, fmt.Errorf("BucketName required for listing S3 objects")
@@ -595,7 +614,16 @@ func (o *Object) listWithClient(ctx context.Context, client s3ObjectClient, requ
 
 	resp, err := client.ListObjectsV2(ctx, input)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list objects in bucket %s: %w", bucketName, err)
+		// The S3 bucket namespace is global but ListObjectsV2 must be addressed
+		// to the bucket's home region. A bucket in another region than the
+		// configured client answers with a 301 PermanentRedirect carrying the
+		// real region in the x-amz-bucket-region header; retry there.
+		if region, ok := bucketRegionFromRedirect(err); ok {
+			resp, err = client.ListObjectsV2(ctx, input, func(o *s3.Options) { o.Region = region })
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to list objects in bucket %s: %w", bucketName, err)
+		}
 	}
 
 	var nativeIDs []string

--- a/pkg/cfres/s3/object_mock_test.go
+++ b/pkg/cfres/s3/object_mock_test.go
@@ -15,6 +15,9 @@ import (
 
 type mockS3ObjectClient struct {
 	mock.Mock
+	// listRegions records the region applied (via option functions) on each
+	// ListObjectsV2 call, so tests can assert cross-region redirect handling.
+	listRegions []string
 }
 
 func (m *mockS3ObjectClient) PutObject(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
@@ -33,6 +36,11 @@ func (m *mockS3ObjectClient) DeleteObject(ctx context.Context, params *s3.Delete
 }
 
 func (m *mockS3ObjectClient) ListObjectsV2(ctx context.Context, params *s3.ListObjectsV2Input, optFns ...func(*s3.Options)) (*s3.ListObjectsV2Output, error) {
+	opts := s3.Options{}
+	for _, fn := range optFns {
+		fn(&opts)
+	}
+	m.listRegions = append(m.listRegions, opts.Region)
 	args := m.Called(ctx, params)
 	return args.Get(0).(*s3.ListObjectsV2Output), args.Error(1)
 }

--- a/pkg/cfres/s3/object_test.go
+++ b/pkg/cfres/s3/object_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -550,6 +551,50 @@ func TestList_WithPagination(t *testing.T) {
 	require.Len(t, result.NativeIDs, 1)
 	require.NotNil(t, result.NextPageToken)
 	assert.Equal(t, "next-page", *result.NextPageToken)
+
+	client.AssertExpectations(t)
+}
+
+func TestList_CrossRegionBucket_RetriesWithRedirectedRegion(t *testing.T) {
+	ctx := context.Background()
+	client := &mockS3ObjectClient{}
+
+	// A bucket that lives in a different region than the client's configured
+	// region answers ListObjectsV2 with a 301 PermanentRedirect whose
+	// x-amz-bucket-region header names the bucket's home region.
+	redirect := &smithyhttp.ResponseError{
+		Response: &smithyhttp.Response{Response: &http.Response{
+			StatusCode: http.StatusMovedPermanently,
+			Header:     http.Header{"X-Amz-Bucket-Region": []string{"eu-west-1"}},
+		}},
+		Err: errors.New("api error PermanentRedirect: The bucket you are attempting to access must be addressed using the specified endpoint."),
+	}
+
+	// First attempt (default region) redirects; retry (redirected region) succeeds.
+	client.On("ListObjectsV2", ctx, mock.MatchedBy(func(input *s3.ListObjectsV2Input) bool {
+		return *input.Bucket == "out-of-region-bucket"
+	})).Return((*s3.ListObjectsV2Output)(nil), redirect).Once()
+	client.On("ListObjectsV2", ctx, mock.MatchedBy(func(input *s3.ListObjectsV2Input) bool {
+		return *input.Bucket == "out-of-region-bucket"
+	})).Return(&s3.ListObjectsV2Output{
+		Contents:    []s3types.Object{{Key: aws.String("file1.txt")}},
+		IsTruncated: aws.Bool(false),
+	}, nil).Once()
+
+	o := &Object{}
+	result, err := o.listWithClient(ctx, client, &resource.ListRequest{
+		ResourceType: "AWS::S3::Object",
+		PageSize:     100,
+		AdditionalProperties: map[string]string{
+			"BucketName": "out-of-region-bucket",
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, []string{"out-of-region-bucket|file1.txt"}, result.NativeIDs)
+	// First call used the default region; the retry targeted the redirected region.
+	assert.Equal(t, []string{"", "eu-west-1"}, client.listRegions)
 
 	client.AssertExpectations(t)
 }

--- a/schema/pkl/PklProject
+++ b/schema/pkl/PklProject
@@ -2,7 +2,7 @@ amends "pkl:Project"
 
 dependencies {
   ["formae"] {
-    uri = "package://hub.platform.engineering/plugins/pkl/schema/pkl/formae/formae@0.87.0"
+    uri = "package://hub.platform.engineering/plugins/pkl/schema/pkl/formae/formae@0.88.0"
   }
 }
 

--- a/schema/pkl/cloudtrail/trail.pkl
+++ b/schema/pkl/cloudtrail/trail.pkl
@@ -1,0 +1,129 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+module aws.cloudtrail.trail
+
+import "@formae/formae.pkl"
+import "../aws.pkl"
+
+const type = "AWS::CloudTrail::Trail"
+
+open class TrailResolvable extends formae.Resolvable {
+    hidden type = module.type
+
+    hidden arn: TrailResolvable = (this) {
+        property = "Arn"
+    }
+
+    hidden trailName: TrailResolvable = (this) {
+        property = "TrailName"
+    }
+}
+
+@aws.SubResourceHint
+open class DataResource extends formae.SubResource {
+    type: String?
+    values: Listing<String>?
+}
+
+@aws.SubResourceHint
+open class EventSelector extends formae.SubResource {
+    readWriteType: String?
+    includeManagementEvents: Boolean?
+    dataResources: Listing<DataResource>?
+    excludeManagementEventSources: Listing<String>?
+}
+
+@aws.SubResourceHint
+open class AdvancedFieldSelector extends formae.SubResource {
+    field: String
+    equals: Listing<String>?
+    startsWith: Listing<String>?
+    endsWith: Listing<String>?
+    notEquals: Listing<String>?
+    notStartsWith: Listing<String>?
+    notEndsWith: Listing<String>?
+}
+
+@aws.SubResourceHint
+open class AdvancedEventSelector extends formae.SubResource {
+    name: String?
+    fieldSelectors: Listing<AdvancedFieldSelector>
+}
+
+@aws.SubResourceHint
+open class InsightSelector extends formae.SubResource {
+    insightType: String?
+}
+
+@aws.ResourceHint {
+    type = module.type
+    identifier = "TrailName"
+    discoverable = true
+}
+open class Trail extends formae.Resource {
+
+    @aws.FieldHint { createOnly = true }
+    trailName: String
+
+    @aws.FieldHint
+    s3BucketName: (String|formae.Resolvable)
+
+    @aws.FieldHint
+    s3KeyPrefix: String?
+
+    @aws.FieldHint
+    isLogging: Boolean
+
+    @aws.FieldHint { hasProviderDefault = true }
+    isMultiRegionTrail: Boolean?
+
+    @aws.FieldHint { hasProviderDefault = true }
+    includeGlobalServiceEvents: Boolean?
+
+    @aws.FieldHint { hasProviderDefault = true }
+    enableLogFileValidation: Boolean?
+
+    @aws.FieldHint { hasProviderDefault = true }
+    isOrganizationTrail: Boolean?
+
+    @aws.FieldHint
+    kmsKeyId: (String|formae.Resolvable)?
+
+    @aws.FieldHint
+    snsTopicName: (String|formae.Resolvable)?
+
+    @aws.FieldHint
+    cloudWatchLogsLogGroupArn: (String|formae.Resolvable)?
+
+    @aws.FieldHint
+    cloudWatchLogsRoleArn: (String|formae.Resolvable)?
+
+    // eventSelectors and advancedEventSelectors are mutually exclusive at the
+    // CloudTrail API: a trail uses one mode or the other. Both are modelled here
+    // so that a discovered trail using either mode round-trips correctly.
+    @aws.FieldHint { updateMethod = "Atomic" }
+    eventSelectors: Listing<EventSelector>?
+
+    @aws.FieldHint { updateMethod = "Atomic" }
+    advancedEventSelectors: Listing<AdvancedEventSelector>?
+
+    @aws.FieldHint { updateMethod = "Atomic" }
+    insightSelectors: Listing<InsightSelector>?
+
+    @aws.FieldHint {
+        updateMethod = "EntitySet"
+        indexField = "Key"
+    }
+    tags: Listing<aws.Tag>?
+
+    local parent = this
+
+    hidden res: TrailResolvable = new {
+        label = parent.label
+        stack = parent.stack?.label
+    }
+}

--- a/schema/pkl/ec2/verifiedaccesstrustprovider.pkl
+++ b/schema/pkl/ec2/verifiedaccesstrustprovider.pkl
@@ -24,7 +24,7 @@ open class OidcOptions extends formae.SubResource {
     clientId: (String|formae.Resolvable)?
 
     @aws.FieldHint{writeOnly = true; requiredOnUpdate = true}
-    clientSecret: (String|formae.Resolvable)?
+    clientSecret: (String|formae.Resolvable|formae.Value|formae.SecretValue)?
 
     issuer: (String|formae.Resolvable)?
     scope: String?

--- a/schema/pkl/ec2/vpnconnection.pkl
+++ b/schema/pkl/ec2/vpnconnection.pkl
@@ -93,7 +93,7 @@ open class VpnTunnelOptionsSpecification extends formae.SubResource {
     phase2LifetimeSeconds: Int?
 
     @aws.FieldHint{writeOnly = true}
-    preSharedKey: String?
+    preSharedKey: (String|formae.Resolvable|formae.Value|formae.SecretValue)?
 
     rekeyFuzzPercentage: Int?
     rekeyMarginTimeSeconds: Int?

--- a/schema/pkl/elasticloadbalancingv2/listener.pkl
+++ b/schema/pkl/elasticloadbalancingv2/listener.pkl
@@ -48,7 +48,7 @@ open class AuthenticateOidcConfig extends formae.SubResource {
     authorizationEndpoint: String
     clientId: String
     @aws.FieldHint{writeOnly = true; requiredOnUpdate = true}
-    clientSecret: (String|formae.Resolvable)?
+    clientSecret: (String|formae.Resolvable|formae.Value|formae.SecretValue)?
     issuer: String
     onUnauthenticatedRequest: String?
     scope: String?

--- a/schema/pkl/elasticloadbalancingv2/listenerrule.pkl
+++ b/schema/pkl/elasticloadbalancingv2/listenerrule.pkl
@@ -16,6 +16,10 @@ open class Action extends formae.SubResource {
     authenticateCognitoConfig: AuthenticateCognitoConfig?
     authenticateOidcConfig: AuthenticateOidcConfig?
     fixedResponseConfig: FixedResponseConfig?
+    // AWS derives ForwardConfig from a plain targetGroupArn on a forward action
+    // and returns it on read even when the caller only set targetGroupArn, so
+    // absorb it as a provider default (this mirrors the Listener schema's Action).
+    @aws.FieldHint{hasProviderDefault = true}
     forwardConfig: ForwardConfig?
     order: Int?
     redirectConfig: RedirectConfig?
@@ -117,6 +121,11 @@ open class Condition extends formae.SubResource {
     pathPatternConfig: PathPatternConfig?
     queryStringConfig: QueryStringConfig?
     sourceIpConfig: SourceIpConfig?
+    // AWS mirrors a host-header/path-pattern condition's typed config into the
+    // legacy flat Values list and returns both on read, even when the caller set
+    // only the typed config (e.g. pathPatternConfig), so absorb Values as a
+    // provider default to avoid perpetual false drift.
+    @aws.FieldHint{hasProviderDefault = true}
     values: Listing<String>?
 }
 

--- a/schema/pkl/elasticloadbalancingv2/listenerrule.pkl
+++ b/schema/pkl/elasticloadbalancingv2/listenerrule.pkl
@@ -45,7 +45,7 @@ open class AuthenticateOidcConfig extends formae.SubResource {
     authorizationEndpoint: String
     clientId: String
     @aws.FieldHint{writeOnly = true; requiredOnUpdate = true}
-    clientSecret: (String|formae.Resolvable)?
+    clientSecret: (String|formae.Resolvable|formae.Value|formae.SecretValue)?
     issuer: String
     onUnauthenticatedRequest: String?
     scope: String?

--- a/schema/pkl/iam/servercertificate.pkl
+++ b/schema/pkl/iam/servercertificate.pkl
@@ -48,7 +48,7 @@ open class ServerCertificate extends formae.Resource {
         createOnly = true
         writeOnly = true
     }
-    privateKey: String(matches(Regex(#"[\u0009\u000A\u000D\u0020-\u00FF]+"#)))?
+    privateKey: (String(matches(Regex(#"[\u0009\u000A\u000D\u0020-\u00FF]+"#)))|formae.Resolvable|formae.Value|formae.SecretValue)?
 
     @aws.FieldHint{createOnly = true}
     serverCertificateName: String(matches(Regex(#"[\w+=,.@-]+"#)))?

--- a/schema/pkl/iam/user.pkl
+++ b/schema/pkl/iam/user.pkl
@@ -14,7 +14,7 @@ const type = "AWS::IAM::User"
 @aws.SubResourceHint
 open class UserLoginProfile extends formae.SubResource {
     @aws.FieldHint{writeOnly = true; requiredOnUpdate = true}
-    password: (String|formae.Value)?
+    password: (String|formae.Value|formae.SecretValue)?
     passwordResetRequired: Boolean?
 }
 

--- a/schema/pkl/lambda/layerversion.pkl
+++ b/schema/pkl/lambda/layerversion.pkl
@@ -18,6 +18,22 @@ open class Content extends formae.SubResource {
     s3ObjectVersion: (String|formae.Resolvable)?
 }
 
+open class LayerVersionResolvable extends formae.Resolvable {
+    hidden type = module.type
+
+    hidden layerVersionArn: LayerVersionResolvable = (this) {
+        property = "LayerVersionArn"
+    }
+
+    hidden layerArn: LayerVersionResolvable = (this) {
+        property = "LayerArn"
+    }
+
+    hidden version: LayerVersionResolvable = (this) {
+        property = "Version"
+    }
+}
+
 @aws.ResourceHint {
     type = module.type
     identifier = "LayerVersionArn"
@@ -46,4 +62,11 @@ open class LayerVersion extends formae.Resource {
 
     @aws.FieldHint{createOnly = true}
     licenseInfo: String?
+
+    hidden parent = this
+
+    hidden res: LayerVersionResolvable = new {
+        label = parent.label
+        stack = parent.stack?.label
+    }
 }

--- a/schema/pkl/lambda/permission.pkl
+++ b/schema/pkl/lambda/permission.pkl
@@ -26,7 +26,7 @@ open class Permission extends formae.Resource {
     action: String(matches(Regex(#"^(lambda:[*]|lambda:[a-zA-Z]+|[*])$"#)))
 
     @aws.FieldHint{createOnly = true}
-    eventSourceToken: (String(matches(Regex(#"^[a-zA-Z0-9._\-]+$"#))))?
+    eventSourceToken: (String(matches(Regex(#"^[a-zA-Z0-9._\-]+$"#)))|formae.Resolvable|formae.Value|formae.SecretValue)?
 
     @aws.FieldHint{createOnly = true}
     functionName: String(matches(Regex(#"^(arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\d{1}:)?(\d{12}:)?(function:)?([a-zA-Z0-9-_]+)(:(\$LATEST|[a-zA-Z0-9-_]+))?$"#)))|formae.Resolvable

--- a/schema/pkl/lambda/version.pkl
+++ b/schema/pkl/lambda/version.pkl
@@ -30,7 +30,14 @@ open class RuntimePolicy extends formae.SubResource {
 }
 open class Version extends formae.Resource {
 
-    @aws.FieldHint{createOnly = true}
+    // AWS always returns CodeSha256 — it is the hash of the code the version was
+    // published from, computed by AWS. As an input it is optional and acts as an
+    // assertion (publish only if the hash matches), so a caller usually omits it
+    // and the read-back then carries a value the desired state never had.
+    // Absorb it. Like the other fields here it is createOnly, so
+    // removal-by-omission does not apply; and when a caller *does* set it, the
+    // hint only ignores actual-only values, so the assertion still compares.
+    @aws.FieldHint{createOnly = true; hasProviderDefault = true}
     codeSha256: String?
 
     @aws.FieldHint{createOnly = true}
@@ -42,6 +49,12 @@ open class Version extends formae.Resource {
     @aws.FieldHint{createOnly = true}
     provisionedConcurrencyConfig: ProvisionedConcurrencyConfiguration?
 
-    @aws.FieldHint{createOnly = true}
+    // AWS populates RuntimePolicy on every published version (pinning the
+    // runtime version it was published against) even when the caller never set
+    // it — conformance-observed: the extract comparison reported it as present
+    // in actual but absent from desired. The field is createOnly, so absorbing
+    // the provider value costs nothing: removal-by-omission does not apply to a
+    // field that can never be updated in place.
+    @aws.FieldHint{createOnly = true; hasProviderDefault = true}
     runtimePolicy: RuntimePolicy?
 }

--- a/schema/pkl/networkfirewall/loggingconfiguration.pkl
+++ b/schema/pkl/networkfirewall/loggingconfiguration.pkl
@@ -27,9 +27,17 @@ open class LoggingConfigurationData extends formae.SubResource {
     logDestinationConfigs: Listing<LogDestinationConfig>
 }
 
+// CloudControl does not support the LIST action for this type (ListResources
+// returns "UnsupportedActionException: ... does not support LIST action"), so the
+// AWS plugin registers a custom List that synthesizes it from a per-firewall
+// GetResource. Discovery scopes that List to each firewall via the FirewallArn
+// list parameter below; the Firewall is the parent, so discovery iterates
+// firewalls and lists each one's logging configuration.
 @aws.ResourceHint {
     type = module.type
     identifier = "FirewallArn"
+    parent = "AWS::NetworkFirewall::Firewall"
+    listParam = new formae.ListProperty { parentProperty = "FirewallArn" listParameter = "FirewallArn" }
 }
 open class LoggingConfiguration extends formae.Resource {
 

--- a/schema/pkl/rds/dbcluster.pkl
+++ b/schema/pkl/rds/dbcluster.pkl
@@ -202,7 +202,7 @@ open class DBCluster extends formae.Resource {
     manageMasterUserPassword: Boolean?
 
     @aws.FieldHint
-    masterUserPassword: (String|formae.Resolvable|formae.Value)?
+    masterUserPassword: (String|formae.Resolvable|formae.Value|formae.SecretValue)?
 
     @aws.FieldHint
     masterUserSecret: MasterUserSecret?

--- a/schema/pkl/rds/dbinstance.pkl
+++ b/schema/pkl/rds/dbinstance.pkl
@@ -262,7 +262,7 @@ open class DBInstance extends formae.Resource {
     manageMasterUserPassword: Boolean?
 
     @aws.FieldHint{writeOnly = true}
-    masterUserPassword: (String|formae.Resolvable|formae.Value)?
+    masterUserPassword: (String|formae.Resolvable|formae.Value|formae.SecretValue)?
 
     @aws.FieldHint{hasProviderDefault = true}
     masterUserSecret: MasterUserSecret?
@@ -362,7 +362,7 @@ open class DBInstance extends formae.Resource {
     tdeCredentialArn: (String|formae.Resolvable)?
 
     @aws.FieldHint{writeOnly = true}
-    tdeCredentialPassword: String?
+    tdeCredentialPassword: (String|formae.Resolvable|formae.Value|formae.SecretValue)?
 
     @aws.FieldHint{createOnly = true}
     timezone: String?

--- a/schema/pkl/s3/bucketpolicy.pkl
+++ b/schema/pkl/s3/bucketpolicy.pkl
@@ -11,6 +11,14 @@ import "@formae/formae.pkl"
 
 const type = "AWS::S3::BucketPolicy"
 
+open class BucketPolicyResolvable extends formae.Resolvable {
+    hidden type = module.type
+
+    hidden bucket: BucketPolicyResolvable = (this) {
+        property = "Bucket"
+    }
+}
+
 @aws.ResourceHint {
     type = module.type
     identifier = "Bucket"
@@ -21,4 +29,11 @@ open class BucketPolicy extends formae.Resource {
 
     @aws.FieldHint
     policyDocument: Dynamic
+
+    local parent = this
+
+    hidden res: BucketPolicyResolvable = new {
+        label = parent.label
+        stack = parent.stack?.label
+    }
 }

--- a/schema/pkl/secretsmanager/secret.pkl
+++ b/schema/pkl/secretsmanager/secret.pkl
@@ -92,7 +92,7 @@ open class Secret extends formae.Resource {
     @aws.FieldHint {
         writeOnly = true
     }
-    secretString: (formae.Value|String)?
+    secretString: (String|formae.Value|formae.SecretValue)?
 
     @aws.FieldHint {
         updateMethod = "EntitySet"

--- a/scripts/ci/clean-environment.sh
+++ b/scripts/ci/clean-environment.sh
@@ -542,6 +542,18 @@ aws elbv2 describe-target-groups --region "$REGION" \
     fi
 done
 
+# --- ELBv2 trust stores (mTLS). Deleting a trust store removes its revocations
+# implicitly, so no separate revocation sweep is needed. A trust store not
+# attached to any listener deletes cleanly; test fixtures never attach one.
+echo "Cleaning ELBv2 test trust stores..."
+aws elbv2 describe-trust-stores --region "$REGION" \
+    --query "TrustStores[?contains(Name, '$FORMAE_PREFIX') || contains(Name, '$SDK_PREFIX') || contains(Name, '$TEST_PREFIX')].TrustStoreArn" --output text 2>/dev/null | tr '\t' '\n' | while read -r ts_arn; do
+    if [[ -n "$ts_arn" ]]; then
+        echo "  Deleting ELBv2 trust store: $ts_arn"
+        aws elbv2 delete-trust-store --trust-store-arn "$ts_arn" --region "$REGION" 2>/dev/null || true
+    fi
+done
+
 # --- EC2 NAT gateways (before subnets/VPCs, slow to delete)
 echo "Cleaning EC2 test NAT gateways..."
 aws ec2 describe-nat-gateways --region "$REGION" \

--- a/scripts/ci/clean-environment.sh
+++ b/scripts/ci/clean-environment.sh
@@ -1173,8 +1173,13 @@ done
 # ============================================================================
 
 # 26. Delete SQS queues with test prefix
+# `list-queues --queue-name-prefix` is a literal *starts-with* match, so it never
+# matched the fixtures' own queue names (e.g. sqs-queue.pkl's
+# `formae-plugin-sdk-test-queue-*` starts with "formae-", not "plugin-sdk-test") —
+# those queues leaked. Match with contains() across all three prefixes, as the
+# Lambda/API Gateway sweeps already do.
 echo "Cleaning SQS test queues..."
-aws sqs list-queues --region "$REGION" --queue-name-prefix "$TEST_PREFIX" --query "QueueUrls[]" --output text 2>/dev/null | tr '\t' '\n' | while read -r queue; do
+aws sqs list-queues --region "$REGION" --query "QueueUrls[?contains(@, '$FORMAE_PREFIX') || contains(@, '$SDK_PREFIX') || contains(@, '$TEST_PREFIX')]" --output text 2>/dev/null | tr '\t' '\n' | while read -r queue; do
     if [[ -n "$queue" ]]; then
         echo "  Deleting SQS queue: $queue"
         aws sqs delete-queue --queue-url "$queue" --region "$REGION" 2>/dev/null || true
@@ -1558,6 +1563,75 @@ done
 # Future-proofing: CloudFront Distributions cleanup would go here once
 # conformance creates them. Skipped today — Distribution is discoverable=false,
 # extractable=false and not in the conformance matrix.
+
+# ============================================================================
+# Batch A resource types (regional)
+# Appended at the end deliberately: each of these is a leaf or is safe to reap
+# after its parents above (NetworkFirewall rule groups must follow the firewall
+# and policy sweeps, since a policy in use holds a reference to its rule group).
+# ============================================================================
+
+# KMS aliases. Aliases are leaves — delete the alias, never the key (keys are
+# reaped by their own schedule-deletion path). Alias names carry the "alias/"
+# prefix, so match on the suffix.
+echo "Cleaning KMS test aliases..."
+aws kms list-aliases --region "$REGION" \
+    --query "Aliases[?contains(AliasName, '$FORMAE_PREFIX') || contains(AliasName, '$SDK_PREFIX') || contains(AliasName, '$TEST_PREFIX')].AliasName" \
+    --output text 2>/dev/null | tr '\t' '\n' | while read -r alias_name; do
+    if [[ -n "$alias_name" ]]; then
+        echo "  Deleting KMS alias: $alias_name"
+        aws kms delete-alias --alias-name "$alias_name" --region "$REGION" 2>/dev/null || true
+    fi
+done
+
+# Lambda layers. Every layer version must be deleted before the layer itself
+# disappears (there is no delete-layer API — a layer ceases to exist once its
+# last version is gone). LayerVersionPermission is deleted implicitly with the
+# version, so it needs no separate sweep.
+echo "Cleaning Lambda test layers..."
+aws lambda list-layers --region "$REGION" \
+    --query "Layers[?contains(LayerName, '$FORMAE_PREFIX') || contains(LayerName, '$SDK_PREFIX') || contains(LayerName, '$TEST_PREFIX')].LayerName" \
+    --output text 2>/dev/null | tr '\t' '\n' | while read -r layer_name; do
+    if [[ -n "$layer_name" ]]; then
+        aws lambda list-layer-versions --layer-name "$layer_name" --region "$REGION" \
+            --query "LayerVersions[].Version" --output text 2>/dev/null | tr '\t' '\n' | while read -r ver; do
+            if [[ -n "$ver" ]]; then
+                echo "  Deleting Lambda layer version: $layer_name:$ver"
+                aws lambda delete-layer-version --layer-name "$layer_name" --version-number "$ver" --region "$REGION" 2>/dev/null || true
+            fi
+        done
+    fi
+done
+
+# NetworkFirewall rule groups. Must run after the firewall + policy sweeps
+# above: deleting a rule group still referenced by a policy fails.
+echo "Cleaning NetworkFirewall test rule groups..."
+aws network-firewall list-rule-groups --region "$REGION" \
+    --query "RuleGroups[?contains(Name, '$FORMAE_PREFIX') || contains(Name, '$SDK_PREFIX') || contains(Name, '$TEST_PREFIX')].Name" \
+    --output text 2>/dev/null | tr '\t' '\n' | while read -r rg_name; do
+    if [[ -n "$rg_name" ]]; then
+        echo "  Deleting NetworkFirewall rule group: $rg_name"
+        # Type is required to disambiguate; try both rather than tracking which.
+        aws network-firewall delete-rule-group --rule-group-name "$rg_name" --type STATEFUL --region "$REGION" 2>/dev/null || \
+        aws network-firewall delete-rule-group --rule-group-name "$rg_name" --type STATELESS --region "$REGION" 2>/dev/null || true
+    fi
+done
+
+# IAM service-linked roles. These are NOT caught by the IAM role sweep above:
+# AWS derives the name from the service (AWSServiceRoleForAutoScaling_<suffix>),
+# so it contains no test prefix at all — per-run uniqueness comes only from the
+# CustomSuffix. Match the suffixed form and never the unsuffixed role, which
+# AWS auto-creates for the account and is not ours to delete. Deletion is async
+# (DeleteServiceLinkedRole returns a task id); we fire and let AWS drain it.
+echo "Cleaning IAM test service-linked roles..."
+aws iam list-roles --path-prefix "/aws-service-role/autoscaling.amazonaws.com/" \
+    --query "Roles[?RoleName != 'AWSServiceRoleForAutoScaling'].RoleName" \
+    --output text 2>/dev/null | tr '\t' '\n' | while read -r slr; do
+    if [[ -n "$slr" ]]; then
+        echo "  Deleting IAM service-linked role: $slr"
+        aws iam delete-service-linked-role --role-name "$slr" 2>/dev/null || true
+    fi
+done
 
 echo ""
 echo "=== Cleanup complete ==="

--- a/scripts/ci/clean-environment.sh
+++ b/scripts/ci/clean-environment.sh
@@ -179,6 +179,13 @@ done
 echo "Cleaning S3 test buckets..."
 aws s3api list-buckets --query "Buckets[?contains(Name, '$FORMAE_PREFIX') || contains(Name, '$SDK_PREFIX') || contains(Name, '$TEST_PREFIX')].Name" --output text 2>/dev/null | tr '\t' '\n' | while read -r bucket; do
     if [[ -n "$bucket" ]]; then
+        # The CloudTrail log bucket (formae-plugin-sdk-test-ct-logs-*) is a
+        # PERSISTENT prerequisite (Option B / PLA-302) provisioned + emptied in
+        # section 8b-ct below; never delete it here.
+        if [[ "$bucket" == formae-plugin-sdk-test-ct-logs-* ]]; then
+            echo "  Skipping persistent CloudTrail log bucket: $bucket"
+            continue
+        fi
         echo "  Deleting S3 bucket: $bucket"
         # Delete bucket policy first (if any)
         aws s3api delete-bucket-policy --bucket "$bucket" --region "$REGION" 2>/dev/null || true
@@ -186,6 +193,77 @@ aws s3api list-buckets --query "Buckets[?contains(Name, '$FORMAE_PREFIX') || con
         aws s3api delete-bucket --bucket "$bucket" --region "$REGION" 2>/dev/null || true
     fi
 done
+
+# 8b-ct. Provision + empty the PERSISTENT CloudTrail log-delivery bucket.
+# This bucket is a persistent conformance prerequisite for the cloudtrail-trail
+# fixture (Option B / PLA-302): CloudTrail deposits placeholder/log objects into
+# it, and CloudControl refuses to delete a non-empty bucket, so the fixture
+# references this externally-owned bucket by name instead of managing it. We
+# therefore CREATE it if absent and EMPTY it here, but never DELETE it (unlike
+# section 8b). The self-contained forceDestroy-managed version is tracked in
+# PLA-345. Every step is guarded so it never aborts the cleanup script.
+echo "Provisioning + emptying persistent CloudTrail log bucket..."
+if acct=$(aws sts get-caller-identity --query Account --output text 2>/dev/null) && [[ -n "$acct" && "$acct" != "None" ]]; then
+    ct_bucket="formae-plugin-sdk-test-ct-logs-${acct}"
+    # Create the bucket if it does not already exist. us-east-1 must NOT pass a
+    # LocationConstraint (the API rejects it); every other region requires one.
+    if ! aws s3api head-bucket --bucket "$ct_bucket" --region "$REGION" 2>/dev/null; then
+        echo "  Creating CloudTrail log bucket: $ct_bucket"
+        if [[ "$REGION" == "us-east-1" ]]; then
+            aws s3api create-bucket --bucket "$ct_bucket" --region "$REGION" 2>/dev/null || true
+        else
+            aws s3api create-bucket --bucket "$ct_bucket" --region "$REGION" \
+                --create-bucket-configuration "LocationConstraint=$REGION" 2>/dev/null || true
+        fi
+    fi
+    # Block public access on the bucket.
+    aws s3api put-public-access-block --bucket "$ct_bucket" --region "$REGION" \
+        --public-access-block-configuration "BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=false,RestrictPublicBuckets=false" 2>/dev/null || true
+    # Attach the canonical CloudTrail bucket policy (mirrors the shape the fixture
+    # previously managed: AWSCloudTrailAclCheck = s3:GetBucketAcl on the bucket
+    # ARN, AWSCloudTrailWrite = s3:PutObject on <bucket-arn>/* with the
+    # bucket-owner-full-control ACL condition).
+    ct_policy=$(cat <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AWSCloudTrailAclCheck",
+      "Effect": "Allow",
+      "Principal": { "Service": "cloudtrail.amazonaws.com" },
+      "Action": "s3:GetBucketAcl",
+      "Resource": "arn:aws:s3:::${ct_bucket}"
+    },
+    {
+      "Sid": "AWSCloudTrailWrite",
+      "Effect": "Allow",
+      "Principal": { "Service": "cloudtrail.amazonaws.com" },
+      "Action": "s3:PutObject",
+      "Resource": "arn:aws:s3:::${ct_bucket}/*",
+      "Condition": {
+        "StringEquals": { "s3:x-amz-acl": "bucket-owner-full-control" }
+      }
+    }
+  ]
+}
+EOF
+)
+    aws s3api put-bucket-policy --bucket "$ct_bucket" --region "$REGION" --policy "$ct_policy" 2>/dev/null || true
+    # Empty the bucket (objects + versions + delete markers) WITHOUT deleting it,
+    # clearing CloudTrail placeholder/log objects left by prior runs.
+    echo "  Emptying CloudTrail log bucket: $ct_bucket"
+    aws s3 rm "s3://$ct_bucket" --recursive --region "$REGION" 2>/dev/null || true
+    # Versioned sweep in case the bucket has versioning enabled.
+    versioned=$(aws s3api list-object-versions --bucket "$ct_bucket" --region "$REGION" \
+        --output json --query '{Objects: Versions[].{Key:Key,VersionId:VersionId}, DeleteMarkers: DeleteMarkers[].{Key:Key,VersionId:VersionId}}' 2>/dev/null || echo '{}')
+    for kind in Objects DeleteMarkers; do
+        del=$(echo "$versioned" | jq -c "{Objects: (.$kind // []), Quiet: true}" 2>/dev/null || echo '{}')
+        n=$(echo "$del" | jq '.Objects | length' 2>/dev/null || echo 0)
+        if [[ -n "$n" && "$n" != "0" ]]; then
+            aws s3api delete-objects --bucket "$ct_bucket" --region "$REGION" --delete "$del" 2>/dev/null || true
+        fi
+    done
+fi
 
 # 8c. Delete S3 Storage Lens Groups with test prefix
 echo "Cleaning S3 test Storage Lens Groups..."

--- a/testdata/PklProject
+++ b/testdata/PklProject
@@ -6,6 +6,6 @@ dependencies {
 
   // Formae schema - fetched from public registry
   ["formae"] {
-    uri = "package://hub.platform.engineering/plugins/pkl/schema/pkl/formae/formae@0.87.0"
+    uri = "package://hub.platform.engineering/plugins/pkl/schema/pkl/formae/formae@0.88.0"
   }
 }

--- a/testdata/apigateway-usageplankey.pkl
+++ b/testdata/apigateway-usageplankey.pkl
@@ -1,0 +1,66 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/apigateway/apikey.pkl"
+import "@aws/apigateway/usageplan.pkl"
+import "@aws/apigateway/usageplankey.pkl"
+
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local stackName = "plugin-sdk-test-apigateway-usageplankey-\(testRunID)"
+
+// ApiKey dependency - the key to associate with the usage plan
+local testApiKey = new apikey.ApiKey {
+  label = "test-apikey-for-usageplankey"
+  name = "formae-sdk-test-upk-key-\(testRunID)"
+  enabled = true
+  description = "Test API Key for UsagePlanKey"
+}
+
+// UsagePlan dependency - the plan the key is associated with.
+// No apiStages needed: a usage plan can be created without stages, and
+// CreateUsagePlanKey does not require the plan to have an associated stage.
+local testUsagePlan = new usageplan.UsagePlan {
+  label = "test-usageplan-for-usageplankey"
+  usagePlanName = "formae-sdk-test-upk-plan-\(testRunID)"
+  description = "Test usage plan for UsagePlanKey"
+  throttle = new usageplan.ThrottleSettings {
+    burstLimit = 100
+    rateLimit = 50.0
+  }
+}
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for ApiGateway UsagePlanKey"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  // ApiKey (needed for the usage plan key)
+  testApiKey
+
+  // UsagePlan (parent of the usage plan key)
+  testUsagePlan
+
+  // UsagePlanKey under test
+  new usageplankey.UsagePlanKey {
+    label = "plugin-sdk-test-usageplankey"
+    keyId = testApiKey.res.apiKeyId
+    keyType = "API_KEY"
+    usagePlanId = testUsagePlan.res.id
+  }
+}

--- a/testdata/cloudtrail-trail-update.pkl
+++ b/testdata/cloudtrail-trail-update.pkl
@@ -1,0 +1,82 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/cloudtrail/trail.pkl"
+
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local accountID = read("env:FORMAE_TEST_ACCOUNT_ID")
+local stackName = "plugin-sdk-test-cloudtrail-trail-\(testRunID)"
+
+// The CloudTrail log-delivery bucket is a PERSISTENT, formae-UNMANAGED
+// prerequisite provisioned by scripts/ci/clean-environment.sh (Option B /
+// PLA-302): CloudTrail deposits placeholder objects into it, and CloudControl
+// refuses to delete a non-empty bucket, so managing the bucket here made the
+// whole-stack Destroy fail. Referencing it by name keeps it out of formae's
+// lifecycle. The self-contained forceDestroy-managed version is tracked in
+// PLA-345.
+local logBucketName = "formae-plugin-sdk-test-ct-logs-\(accountID)"
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for AWS CloudTrail Trail"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  // Update fixture: the S3 data-events selector's resources.ARN startsWith prefix is
+  // changed from /logs/ to /audit-logs/ to verify AdvancedEventSelectors update
+  // round-trips without perpetual drift.
+  new trail.Trail {
+    label = "plugin-sdk-test-cloudtrail-trail"
+    trailName = "formae-plugin-sdk-test-ct-\(testRunID)"
+    s3BucketName = logBucketName
+    isMultiRegionTrail = true
+    // A multi-region trail must include global service events (AWS rejects the
+    // pair otherwise), mirroring the real multi-region audit trail.
+    includeGlobalServiceEvents = true
+    enableLogFileValidation = true
+    isLogging = false
+    advancedEventSelectors = new Listing<trail.AdvancedEventSelector> {
+      new {
+        name = "Management events"
+        fieldSelectors = new Listing<trail.AdvancedFieldSelector> {
+          new {
+            field = "eventCategory"
+            equals = new Listing<String> { "Management" }
+          }
+        }
+      }
+      new {
+        name = "S3 data events"
+        fieldSelectors = new Listing<trail.AdvancedFieldSelector> {
+          new {
+            field = "eventCategory"
+            equals = new Listing<String> { "Data" }
+          }
+          new {
+            field = "resources.type"
+            equals = new Listing<String> { "AWS::S3::Object" }
+          }
+          new {
+            field = "resources.ARN"
+            startsWith = new Listing<String> { "arn:aws:s3:::formae-plugin-sdk-test-ct-data-\(testRunID)/audit-logs/" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/testdata/cloudtrail-trail.pkl
+++ b/testdata/cloudtrail-trail.pkl
@@ -1,0 +1,82 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/cloudtrail/trail.pkl"
+
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local accountID = read("env:FORMAE_TEST_ACCOUNT_ID")
+local stackName = "plugin-sdk-test-cloudtrail-trail-\(testRunID)"
+
+// The CloudTrail log-delivery bucket is a PERSISTENT, formae-UNMANAGED
+// prerequisite provisioned by scripts/ci/clean-environment.sh (Option B /
+// PLA-302): CloudTrail deposits placeholder objects into it, and CloudControl
+// refuses to delete a non-empty bucket, so managing the bucket here made the
+// whole-stack Destroy fail. Referencing it by name keeps it out of formae's
+// lifecycle. The self-contained forceDestroy-managed version is tracked in
+// PLA-345.
+local logBucketName = "formae-plugin-sdk-test-ct-logs-\(accountID)"
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for AWS CloudTrail Trail"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  // Trail is the last resource — the conformance harness verifies it as a singleton
+  // leaf and OOB-deletes it in isolation. isLogging=false keeps the bucket empty so
+  // CloudControl can delete it at teardown.
+  new trail.Trail {
+    label = "plugin-sdk-test-cloudtrail-trail"
+    trailName = "formae-plugin-sdk-test-ct-\(testRunID)"
+    s3BucketName = logBucketName
+    isMultiRegionTrail = true
+    // A multi-region trail must include global service events (AWS rejects the
+    // pair otherwise), mirroring the real multi-region audit trail.
+    includeGlobalServiceEvents = true
+    enableLogFileValidation = true
+    isLogging = false
+    advancedEventSelectors = new Listing<trail.AdvancedEventSelector> {
+      new {
+        name = "Management events"
+        fieldSelectors = new Listing<trail.AdvancedFieldSelector> {
+          new {
+            field = "eventCategory"
+            equals = new Listing<String> { "Management" }
+          }
+        }
+      }
+      new {
+        name = "S3 data events"
+        fieldSelectors = new Listing<trail.AdvancedFieldSelector> {
+          new {
+            field = "eventCategory"
+            equals = new Listing<String> { "Data" }
+          }
+          new {
+            field = "resources.type"
+            equals = new Listing<String> { "AWS::S3::Object" }
+          }
+          new {
+            field = "resources.ARN"
+            startsWith = new Listing<String> { "arn:aws:s3:::formae-plugin-sdk-test-ct-data-\(testRunID)/logs/" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/testdata/elasticloadbalancingv2-listener.pkl
+++ b/testdata/elasticloadbalancingv2-listener.pkl
@@ -1,0 +1,114 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/ec2/vpc.pkl"
+import "@aws/ec2/subnet.pkl"
+import "@aws/ec2/securitygroup.pkl"
+import "@aws/elasticloadbalancingv2/loadbalancer.pkl"
+import "@aws/elasticloadbalancingv2/targetgroup.pkl"
+import "@aws/elasticloadbalancingv2/listener.pkl"
+
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local stackName = "plugin-sdk-test-elbv2-listener-\(testRunID)"
+
+// VPC + two Subnets in different AZs (an ALB requires at least two subnets in
+// different AZs).
+local testVpc = new vpc.VPC {
+  label = "test-vpc-for-elbv2-listener"
+  cidrBlock = "10.233.0.0/16"
+  enableDnsSupport = true
+}
+
+local testSubnetA = new subnet.Subnet {
+  label = "test-subnet-a-for-elbv2-listener"
+  vpcId = testVpc.res.vpcId
+  cidrBlock = "10.233.1.0/24"
+  availabilityZone = "us-east-1a"
+}
+
+local testSubnetB = new subnet.Subnet {
+  label = "test-subnet-b-for-elbv2-listener"
+  vpcId = testVpc.res.vpcId
+  cidrBlock = "10.233.2.0/24"
+  availabilityZone = "us-east-1b"
+}
+
+// Security group for the ALB.
+local albSG = new securitygroup.SecurityGroup {
+  label = "test-alb-sg-for-elbv2-listener"
+  groupDescription = "Allow HTTP to ALB for ELBv2 Listener conformance test"
+  groupName = "fmae-sdk-lsnr-sg-\(testRunID)"
+  vpcId = testVpc.res.vpcId
+}
+
+// Internal ALB across the two subnets.
+local testALB = new loadbalancer.LoadBalancer {
+  label = "test-alb-for-elbv2-listener"
+  name = "formae-sdk-test-lb-\(testRunID)"
+  scheme = "internal"
+  type = "application"
+  subnets {
+    testSubnetA.res.subnetId
+    testSubnetB.res.subnetId
+  }
+  securityGroups {
+    albSG.res.groupId
+  }
+}
+
+// Target Group the listener's default action forwards to.
+local testTG = new targetgroup.TargetGroup {
+  label = "test-tg-for-elbv2-listener"
+  name = "formae-sdk-test-tg-\(testRunID)"
+  port = 80
+  protocol = "HTTP"
+  targetType = "ip"
+  vpcId = testVpc.res.vpcId
+}
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for ELBv2 Listener"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  // Network plumbing.
+  testVpc
+  testSubnetA
+  testSubnetB
+  albSG
+
+  // Load balancer + target group the listener wires together.
+  testALB
+  testTG
+
+  // Listener under test -- :80/HTTP with a single default action forwarding to
+  // the target group.
+  new listener.Listener {
+    label = "plugin-sdk-test-elbv2-listener"
+    loadBalancerArn = testALB.res.loadBalancerArn
+    port = 80
+    protocol = "HTTP"
+    defaultActions {
+      new listener.Action {
+        type = "forward"
+        targetGroupArn = testTG.res.targetGroupArn
+      }
+    }
+  }
+}

--- a/testdata/elasticloadbalancingv2-listenerrule.pkl
+++ b/testdata/elasticloadbalancingv2-listenerrule.pkl
@@ -1,0 +1,140 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/ec2/vpc.pkl"
+import "@aws/ec2/subnet.pkl"
+import "@aws/ec2/securitygroup.pkl"
+import "@aws/elasticloadbalancingv2/loadbalancer.pkl"
+import "@aws/elasticloadbalancingv2/targetgroup.pkl"
+import "@aws/elasticloadbalancingv2/listener.pkl"
+import "@aws/elasticloadbalancingv2/listenerrule.pkl"
+
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local stackName = "plugin-sdk-test-elbv2-rule-\(testRunID)"
+
+// VPC + two Subnets in different AZs (an ALB requires at least two subnets in
+// different AZs).
+local testVpc = new vpc.VPC {
+  label = "test-vpc-for-elbv2-rule"
+  cidrBlock = "10.234.0.0/16"
+  enableDnsSupport = true
+}
+
+local testSubnetA = new subnet.Subnet {
+  label = "test-subnet-a-for-elbv2-rule"
+  vpcId = testVpc.res.vpcId
+  cidrBlock = "10.234.1.0/24"
+  availabilityZone = "us-east-1a"
+}
+
+local testSubnetB = new subnet.Subnet {
+  label = "test-subnet-b-for-elbv2-rule"
+  vpcId = testVpc.res.vpcId
+  cidrBlock = "10.234.2.0/24"
+  availabilityZone = "us-east-1b"
+}
+
+// Security group for the ALB.
+local albSG = new securitygroup.SecurityGroup {
+  label = "test-alb-sg-for-elbv2-rule"
+  groupDescription = "Allow HTTP to ALB for ELBv2 ListenerRule conformance test"
+  groupName = "fmae-sdk-rule-sg-\(testRunID)"
+  vpcId = testVpc.res.vpcId
+}
+
+// Internal ALB across the two subnets.
+local testALB = new loadbalancer.LoadBalancer {
+  label = "test-alb-for-elbv2-rule"
+  name = "formae-sdk-test-lb-\(testRunID)"
+  scheme = "internal"
+  type = "application"
+  subnets {
+    testSubnetA.res.subnetId
+    testSubnetB.res.subnetId
+  }
+  securityGroups {
+    albSG.res.groupId
+  }
+}
+
+// Target Group both the listener default action and the rule forward to.
+local testTG = new targetgroup.TargetGroup {
+  label = "test-tg-for-elbv2-rule"
+  name = "formae-sdk-test-tg-\(testRunID)"
+  port = 80
+  protocol = "HTTP"
+  targetType = "ip"
+  vpcId = testVpc.res.vpcId
+}
+
+// Listener the rule attaches to (:80/HTTP, default forward to the TG).
+local testListener = new listener.Listener {
+  label = "test-listener-for-elbv2-rule"
+  loadBalancerArn = testALB.res.loadBalancerArn
+  port = 80
+  protocol = "HTTP"
+  defaultActions {
+    new listener.Action {
+      type = "forward"
+      targetGroupArn = testTG.res.targetGroupArn
+    }
+  }
+}
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for ELBv2 ListenerRule"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  // Network plumbing.
+  testVpc
+  testSubnetA
+  testSubnetB
+  albSG
+
+  // Load balancer + target group + listener the rule hangs off of.
+  testALB
+  testTG
+  testListener
+
+  // ListenerRule under test -- priority + a path-pattern condition + a forward
+  // action to the target group. References the listener ARN so it is created
+  // after the listener exists.
+  new listenerrule.ListenerRule {
+    label = "plugin-sdk-test-elbv2-listenerrule"
+    listenerArn = testListener.res.listenerArn
+    priority = 10
+    conditions {
+      new listenerrule.Condition {
+        field = "path-pattern"
+        pathPatternConfig = new listenerrule.PathPatternConfig {
+          values {
+            "/conformance/*"
+          }
+        }
+      }
+    }
+    actions {
+      new listenerrule.Action {
+        type = "forward"
+        targetGroupArn = testTG.res.targetGroupArn
+      }
+    }
+  }
+}

--- a/testdata/elasticloadbalancingv2-loadbalancer.pkl
+++ b/testdata/elasticloadbalancingv2-loadbalancer.pkl
@@ -1,0 +1,85 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/ec2/vpc.pkl"
+import "@aws/ec2/subnet.pkl"
+import "@aws/ec2/securitygroup.pkl"
+import "@aws/elasticloadbalancingv2/loadbalancer.pkl"
+
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local stackName = "plugin-sdk-test-elbv2-lb-\(testRunID)"
+
+// VPC + two Subnets in different AZs (an ALB requires at least two subnets in
+// different AZs).
+local testVpc = new vpc.VPC {
+  label = "test-vpc-for-elbv2-lb"
+  cidrBlock = "10.232.0.0/16"
+  enableDnsSupport = true
+}
+
+local testSubnetA = new subnet.Subnet {
+  label = "test-subnet-a-for-elbv2-lb"
+  vpcId = testVpc.res.vpcId
+  cidrBlock = "10.232.1.0/24"
+  availabilityZone = "us-east-1a"
+}
+
+local testSubnetB = new subnet.Subnet {
+  label = "test-subnet-b-for-elbv2-lb"
+  vpcId = testVpc.res.vpcId
+  cidrBlock = "10.232.2.0/24"
+  availabilityZone = "us-east-1b"
+}
+
+// Security group for the ALB.
+local albSG = new securitygroup.SecurityGroup {
+  label = "test-alb-sg-for-elbv2-lb"
+  groupDescription = "Allow HTTP to ALB for ELBv2 LoadBalancer conformance test"
+  groupName = "fmae-sdk-lb-sg-\(testRunID)"
+  vpcId = testVpc.res.vpcId
+}
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for ELBv2 LoadBalancer"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  // Network plumbing.
+  testVpc
+  testSubnetA
+  testSubnetB
+  albSG
+
+  // Application Load Balancer under test -- a bare internal ALB with no
+  // listener creates and deletes cleanly. Name capped at 32 chars (AWS hard
+  // limit); "fmae-sdk-lb-" + 8-char run ID = 20 chars.
+  new loadbalancer.LoadBalancer {
+    label = "plugin-sdk-test-elbv2-loadbalancer"
+    name = "formae-sdk-test-lb-\(testRunID)"
+    scheme = "internal"
+    type = "application"
+    subnets {
+      testSubnetA.res.subnetId
+      testSubnetB.res.subnetId
+    }
+    securityGroups {
+      albSG.res.groupId
+    }
+  }
+}

--- a/testdata/elasticloadbalancingv2-truststore.pkl
+++ b/testdata/elasticloadbalancingv2-truststore.pkl
@@ -1,0 +1,95 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/s3/bucket.pkl"
+import "@aws/s3/object.pkl"
+import "@aws/elasticloadbalancingv2/truststore.pkl"
+
+// Read the test run ID from environment variable set by the test harness
+// This ensures consistent naming within a test run but unique names between runs
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local stackName = "plugin-sdk-test-elasticloadbalancingv2-truststore-\(testRunID)"
+
+// Bucket that stages the CA certificate bundle the trust store validates
+// client certificates against.
+local caBundleBucket = new bucket.Bucket {
+  label = "truststore-ca-bundle-bucket"
+  bucketName = "formae-plugin-sdk-test-ts-\(testRunID)"
+}
+
+// Self-signed CA public certificate used as the trust store's CA bundle. This
+// is a CA bundle for validating *client* certificates, NOT a server cert, so it
+// does not require ACM. Generated deterministically with openssl:
+//   openssl req -x509 -newkey rsa:2048 -nodes -sha256 -days 36500 \
+//     -keyout ca.key -out ca.pem \
+//     -subj "/CN=Formae Plugin SDK Test CA/O=Platform Engineering Labs" \
+//     -addext "basicConstraints=critical,CA:TRUE" \
+//     -addext "keyUsage=critical,keyCertSign,cRLSign"
+// notAfter = 2126 (100 years) so the embedded bundle never expires in CI.
+local caBundleObject = new object.Object {
+  label = "truststore-ca-bundle"
+  bucket = caBundleBucket.res.bucketName
+  key = "ca-bundle/ca.pem"
+  contentType = "application/x-pem-file"
+  content = """
+    -----BEGIN CERTIFICATE-----
+    MIIDgzCCAmugAwIBAgIUW8+PgKZ/n2Bq1ux8RmCqS45ICRowDQYJKoZIhvcNAQEL
+    BQAwSDEiMCAGA1UEAwwZRm9ybWFlIFBsdWdpbiBTREsgVGVzdCBDQTEiMCAGA1UE
+    CgwZUGxhdGZvcm0gRW5naW5lZXJpbmcgTGFiczAgFw0yNjA3MTcxNzI4MTlaGA8y
+    MTI2MDYyMzE3MjgxOVowSDEiMCAGA1UEAwwZRm9ybWFlIFBsdWdpbiBTREsgVGVz
+    dCBDQTEiMCAGA1UECgwZUGxhdGZvcm0gRW5naW5lZXJpbmcgTGFiczCCASIwDQYJ
+    KoZIhvcNAQEBBQADggEPADCCAQoCggEBAKHu4Vtm27P/2qF/ZovqXOsKHgQHGfLW
+    kuBf9set040cymRX50tVC/JQV6S6SoYlWKGVA2VFCAHW/OgrGu0tvPPopNgJKzUQ
+    fDuPitzV/EpoPeoWB+K8kucFIuPBFnVuCaFSNAR53Q5JI4TZPkwZe3SGZfry9QEv
+    j7juxEYb8F0Gcji6NUMflmycfYQBaV4ATsBnDHbwBggB+w8YLdaqJTsKEWmugcAA
+    vuDSQ4oSbldQCvoRwCCbVd3YZQRdSSaQZ7r5mKaPk8S7w7uNHtegzM9hTb5E5qKi
+    utSU/mRlVihA827id5rhn5FTySbtQ4SFE/7XCTr8AqIL7tmziUcErJsCAwEAAaNj
+    MGEwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFOj9
+    YZJoPb4TuzqOTnjRIcJ+45wqMB8GA1UdIwQYMBaAFOj9YZJoPb4TuzqOTnjRIcJ+
+    45wqMA0GCSqGSIb3DQEBCwUAA4IBAQCQQg+UY6KGVgPxxuaUoNJ3dprDhWFZFwHM
+    0FpVT1Wrn1AixmZZD4lFVPwbZqdmb5X2K+bkQ3SH9L6dMs21YykAtj4/4AwnhuXD
+    44qqUCk5OP172W0kbsS798e3ApYdNrNfHJYRrCKZ6MUqqqkrrNUNAyDTt+OzFzqO
+    YItjZnY+mdjPVUvcStr2zexXOUipPKNCAfEhjdTwSWa5oD2CCVEYMOrM2cHNqKed
+    UWjUF1IAHrddw8lVQIpbrzMAICHW4qnl3vZ4efEvSV8rZt8vStNNQVwbAmhVdBbi
+    71rZ7RZaw0iD7PfTxQ5EndU6E4MUAAiyDZa7FBsyVit8lIwzjVFN
+    -----END CERTIFICATE-----
+    """
+}
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for ELBv2 TrustStore (mTLS CA bundle from S3)"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  caBundleBucket
+
+  caBundleObject
+
+  // Resource under test: the TrustStore is a singleton and a leaf (nothing
+  // references it), so the harness can OOB-delete it in isolation.
+  new truststore.TrustStore {
+    label = "plugin-sdk-test-truststore"
+    name = "formae-sdk-test-ts-\(testRunID)"
+    caCertificatesBundleS3Bucket = caBundleBucket.res.bucketName
+    caCertificatesBundleS3Key = caBundleObject.res.key
+    tags = new Listing<aws.Tag> {
+      new { key = "Owner"; value = "plugin-sdk" }
+    }
+  }
+}

--- a/testdata/iam-servicelinkedrole.pkl
+++ b/testdata/iam-servicelinkedrole.pkl
@@ -1,0 +1,57 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+// Conformance fixture for AWS::IAM::ServiceLinkedRole. The role is standalone,
+// so it is the only resource in the stack and is trivially the singleton leaf
+// the harness requires.
+//
+// This type has no settable name: AWS derives RoleName (the readOnly primary
+// identifier) from AWSServiceName, so per-run uniqueness comes from customSuffix
+// instead of a name interpolation. testRunID yields
+// AWSServiceRoleForAutoScaling_<testRunID>, which is distinct per run and never
+// collides with the unsuffixed AWSServiceRoleForAutoScaling that EC2 Auto
+// Scaling auto-creates on first use.
+//
+// autoscaling.amazonaws.com is chosen deliberately: only some services accept
+// CustomSuffix (a service that rejects it would be limited to ONE role per
+// account and could not be tested concurrently), and Auto Scaling is the
+// service AWS's own CloudFormation documentation uses for the CustomSuffix
+// example.
+//
+// awsServiceName and customSuffix are both writeOnly — AWS does not return them
+// on read — mirroring cloudfront-function.pkl's autoPublish. Only RoleName and
+// Description come back.
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/iam/servicelinkedrole.pkl"
+
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local stackName = "plugin-sdk-test-iam-servicelinkedrole-\(testRunID)"
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for IAM ServiceLinkedRole"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  new servicelinkedrole.ServiceLinkedRole {
+    label = "plugin-sdk-test-servicelinkedrole"
+    awsServiceName = "autoscaling.amazonaws.com"
+    customSuffix = testRunID
+    description = "Plugin SDK test service-linked role"
+  }
+}

--- a/testdata/kms-alias.pkl
+++ b/testdata/kms-alias.pkl
@@ -1,0 +1,43 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/kms/key.pkl"
+import "@aws/kms/kmsalias.pkl"
+
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local stackName = "plugin-sdk-test-kms-alias-\(testRunID)"
+
+local testKey = new key.Key {
+  label = "test-key"
+  description = "Formae plugin SDK test key for KMS Alias"
+}
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for KMS Alias"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  testKey
+
+  new kmsalias.Alias {
+    label = "plugin-sdk-test-alias"
+    aliasName = "alias/formae-sdk-test-alias-\(testRunID)"
+    targetKeyId = testKey.res.arn
+  }
+}

--- a/testdata/lambda-layerversion.pkl
+++ b/testdata/lambda-layerversion.pkl
@@ -1,0 +1,70 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/s3/bucket.pkl"
+import "@aws/s3/object.pkl"
+import "@aws/lambda/layerversion.pkl"
+
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local stackName = "plugin-sdk-test-lambda-layerversion-\(testRunID)"
+
+// Lambda layer content can only be supplied from S3 (the schema has no inline
+// zipFile equivalent), so the fixture stages a minimal zip in its own bucket.
+local layerBucket = new bucket.Bucket {
+  label = "lambda-layerversion-test-bucket"
+  bucketName = "formae-plugin-sdk-test-layerver-\(testRunID)"
+}
+
+// Base64 of a deflate zip containing python/formae_layer_hello.py.
+local layerZip = new object.Object {
+  label = "lambda-layerversion-test-zip"
+  bucket = layerBucket.res.bucketName
+  key = "layers/formae-layer.zip"
+  contentBase64 = "UEsDBBQAAAAIAAAAIVoBsZUcLwAAADIAAAAcAAAAcHl0aG9uL2Zvcm1hZV9sYXllcl9oZWxsby5weUtJTVPISM3JydfQtOJSAIKi1JLSojwFJbCgQlpRfq5CWn5RbmKqQk5iZWqREhcAUEsBAhQDFAAAAAgAAAAhWgGxlRwvAAAAMgAAABwAAAAAAAAAAAAAAKQBAAAAAHB5dGhvbi9mb3JtYWVfbGF5ZXJfaGVsbG8ucHlQSwUGAAAAAAEAAQBKAAAAaQAAAAAA"
+  contentType = "application/zip"
+}
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for Lambda LayerVersion"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  layerBucket
+
+  layerZip
+
+  // Every property on LayerVersion is createOnly: publishing new content always
+  // produces a new layer version rather than mutating the existing one.
+  new layerversion.LayerVersion {
+    label = "plugin-sdk-test-lambda-layerversion"
+    layerName = "formae-sdk-test-layerver-\(testRunID)"
+    description = "Plugin SDK test layer version"
+    content = new layerversion.Content {
+      s3Bucket = layerZip.res.bucket
+      s3Key = layerZip.res.key
+    }
+    compatibleRuntimes {
+      "python3.12"
+    }
+    compatibleArchitectures {
+      "x86_64"
+    }
+    licenseInfo = "Apache-2.0"
+  }
+}

--- a/testdata/lambda-layerversionpermission.pkl
+++ b/testdata/lambda-layerversionpermission.pkl
@@ -1,0 +1,75 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/s3/bucket.pkl"
+import "@aws/s3/object.pkl"
+import "@aws/lambda/layerversion.pkl"
+import "@aws/lambda/layerversionpermission.pkl"
+
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local stackName = "plugin-sdk-test-lambda-layerversionpermission-\(testRunID)"
+
+// Lambda layer content can only be supplied from S3 (the schema has no inline
+// zipFile equivalent), so the fixture stages a minimal zip in its own bucket.
+local layerBucket = new bucket.Bucket {
+  label = "lambda-layerversionperm-test-bucket"
+  bucketName = "formae-plugin-sdk-test-layerperm-\(testRunID)"
+}
+
+// Base64 of a deflate zip containing python/formae_layer_hello.py.
+local layerZip = new object.Object {
+  label = "lambda-layerversionperm-test-zip"
+  bucket = layerBucket.res.bucketName
+  key = "layers/formae-layer.zip"
+  contentBase64 = "UEsDBBQAAAAIAAAAIVoBsZUcLwAAADIAAAAcAAAAcHl0aG9uL2Zvcm1hZV9sYXllcl9oZWxsby5weUtJTVPISM3JydfQtOJSAIKi1JLSojwFJbCgQlpRfq5CWn5RbmKqQk5iZWqREhcAUEsBAhQDFAAAAAgAAAAhWgGxlRwvAAAAMgAAABwAAAAAAAAAAAAAAKQBAAAAAHB5dGhvbi9mb3JtYWVfbGF5ZXJfaGVsbG8ucHlQSwUGAAAAAAEAAQBKAAAAaQAAAAAA"
+  contentType = "application/zip"
+}
+
+local testLayerVersion = new layerversion.LayerVersion {
+  label = "test-layerversion-for-permission"
+  layerName = "formae-sdk-test-layerperm-\(testRunID)"
+  content = new layerversion.Content {
+    s3Bucket = layerZip.res.bucket
+    s3Key = layerZip.res.key
+  }
+  compatibleRuntimes {
+    "python3.12"
+  }
+}
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for Lambda LayerVersionPermission"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  layerBucket
+
+  layerZip
+
+  testLayerVersion
+
+  // Every property is createOnly: a layer permission statement is immutable, so
+  // any change is add/remove rather than an in-place update.
+  new layerversionpermission.LayerVersionPermission {
+    label = "plugin-sdk-test-lambda-layerversionpermission"
+    layerVersionArn = testLayerVersion.res.layerVersionArn
+    action = "lambda:GetLayerVersion"
+    principal = "*"
+  }
+}

--- a/testdata/lambda-version.pkl
+++ b/testdata/lambda-version.pkl
@@ -1,0 +1,80 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/iam/role.pkl"
+import "@aws/lambda/func.pkl"
+import "@aws/lambda/version.pkl"
+
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local stackName = "plugin-sdk-test-lambda-version-\(testRunID)"
+
+local lambdaRole = new role.Role {
+  label = "lambda-execution-role"
+  roleName = "formae-sdk-test-lambda-ver-role-\(testRunID)"
+  assumeRolePolicyDocument {
+    ["Version"] = "2012-10-17"
+    ["Statement"] {
+      new {
+        ["Effect"] = "Allow"
+        ["Principal"] {
+          ["Service"] = "lambda.amazonaws.com"
+        }
+        ["Action"] = "sts:AssumeRole"
+      }
+    }
+  }
+}
+
+local testFunction = new func.Function {
+  label = "test-function-for-version"
+  functionName = "formae-sdk-test-lambda-ver-\(testRunID)"
+  role = lambdaRole.res.arn
+  runtime = "python3.12"
+  handler = "index.handler"
+  code = new func.Code {
+    zipFile = """
+      import json
+      def handler(event, context):
+          return {
+              'statusCode': 200,
+              'body': json.dumps({'message': 'hello from formae'})
+          }
+      """
+  }
+  memorySize = 128
+  timeout = 10
+}
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for Lambda Version"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  lambdaRole
+
+  testFunction
+
+  // Every property on Version is createOnly: publishing a version snapshots the
+  // function's current code, so any change replaces the version.
+  new version.Version {
+    label = "plugin-sdk-test-lambda-version"
+    functionName = testFunction.res.arn
+    description = "Plugin SDK test version"
+  }
+}

--- a/testdata/networkfirewall-loggingconfiguration.pkl
+++ b/testdata/networkfirewall-loggingconfiguration.pkl
@@ -1,0 +1,151 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/ec2/vpc.pkl"
+import "@aws/ec2/subnet.pkl"
+import "@aws/logs/loggroup.pkl"
+import "@aws/networkfirewall/rulegroup.pkl"
+import "@aws/networkfirewall/firewallpolicy.pkl"
+import "@aws/networkfirewall/firewall.pkl"
+import "@aws/networkfirewall/loggingconfiguration.pkl"
+
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local stackName = "plugin-sdk-test-nfw-logging-\(testRunID)"
+local azA = "us-east-1a"
+local azB = "us-east-1b"
+
+local testVpc = new vpc.VPC {
+  label = "nfwlog-vpc"
+  cidrBlock = "10.0.0.0/16"
+  enableDnsSupport = true
+  enableDnsHostnames = true
+}
+
+// Dedicated firewall subnets, one per AZ.
+local fwSubnetA = new subnet.Subnet {
+  label = "nfwlog-fw-subnet-a"
+  vpcId = testVpc.res.vpcId
+  cidrBlock = "10.0.0.0/28"
+  availabilityZone = azA
+  tags = new Listing<aws.Tag> { new { key = "Name"; value = "nfwlog-fw-subnet-a" } }
+}
+local fwSubnetB = new subnet.Subnet {
+  label = "nfwlog-fw-subnet-b"
+  vpcId = testVpc.res.vpcId
+  cidrBlock = "10.0.0.16/28"
+  availabilityZone = azB
+  tags = new Listing<aws.Tag> { new { key = "Name"; value = "nfwlog-fw-subnet-b" } }
+}
+
+// Stateful domain-allowlist rule group (the FQDN allowlist).
+local allowlist = new rulegroup.RuleGroup {
+  label = "nfwlog-allowlist"
+  ruleGroupName = "nfwlog-allowlist-\(testRunID)"
+  type = "STATEFUL"
+  capacity = 100
+  ruleGroup = new rulegroup.RuleGroupData {
+    rulesSource = new rulegroup.RulesSource {
+      rulesSourceList = new rulegroup.RulesSourceList {
+        targets = new Listing<String> { "github.com"; "api.anthropic.com" }
+        targetTypes = new Listing<String> { "TLS_SNI"; "HTTP_HOST" }
+        generatedRulesType = "ALLOWLIST"
+      }
+    }
+    statefulRuleOptions = new rulegroup.StatefulRuleOptions {
+      ruleOrder = "STRICT_ORDER"
+    }
+  }
+}
+
+// Firewall policy referencing the allowlist rule group.
+local policy = new firewallpolicy.FirewallPolicy {
+  label = "nfwlog-policy"
+  firewallPolicyName = "nfwlog-policy-\(testRunID)"
+  firewallPolicy = new firewallpolicy.FirewallPolicyData {
+    statelessDefaultActions = new Listing<String> { "aws:forward_to_sfe" }
+    statelessFragmentDefaultActions = new Listing<String> { "aws:forward_to_sfe" }
+    statefulDefaultActions = new Listing<String> { "aws:drop_established" }
+    statefulEngineOptions = new firewallpolicy.StatefulEngineOptions {
+      ruleOrder = "STRICT_ORDER"
+    }
+    statefulRuleGroupReferences = new Listing<firewallpolicy.StatefulRuleGroupReference> {
+      new {
+        resourceArn = allowlist.res.arn
+        // STRICT_ORDER requires an explicit evaluation priority per reference.
+        priority = 1
+      }
+    }
+  }
+}
+
+// Firewall spanning both AZs.
+local fw = new firewall.Firewall {
+  label = "nfwlog-firewall"
+  firewallName = "nfwlog-firewall-\(testRunID)"
+  firewallPolicyArn = policy.res.arn
+  vpcId = testVpc.res.vpcId
+  subnetMappings = new Listing<firewall.SubnetMapping> {
+    new { subnetId = fwSubnetA.res.subnetId }
+    new { subnetId = fwSubnetB.res.subnetId }
+  }
+}
+
+// CloudWatch Logs destination for the firewall's flow logs.
+local logGroup = new loggroup.LogGroup {
+  label = "nfwlog-log-group"
+  logGroupName = "/formae/nfw/plugin-sdk-test-\(testRunID)"
+  retentionInDays = 1
+}
+
+// Logging configuration attaching flow logging to the firewall. Listed last in
+// the forma block: the conformance harness verifies the final resource in the
+// fixture and OOB-deletes it in isolation, so it must be a leaf (nothing
+// references it) and a singleton. CloudControl can't LIST this type, so the
+// plugin supplies a custom firewall-scoped List (see the schema); this fixture
+// exercises both the CRUD and discovery lifecycles.
+local logging = new loggingconfiguration.LoggingConfiguration {
+  label = "nfwlog-logging"
+  firewallArn = fw.res.arn
+  loggingConfiguration = new loggingconfiguration.LoggingConfigurationData {
+    logDestinationConfigs = new Listing<loggingconfiguration.LogDestinationConfig> {
+      new {
+        logType = "FLOW"
+        logDestinationType = "CloudWatchLogs"
+        logDestination = new Mapping<String, String|formae.Resolvable> {
+          ["logGroup"] = logGroup.res.logGroupName
+        }
+      }
+    }
+  }
+}
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for AWS Network Firewall LoggingConfiguration"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  testVpc
+  fwSubnetA
+  fwSubnetB
+  allowlist
+  policy
+  fw
+  logGroup
+  logging
+}

--- a/testdata/networkfirewall-rulegroup.pkl
+++ b/testdata/networkfirewall-rulegroup.pkl
@@ -1,0 +1,69 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+// Conformance fixture for AWS::NetworkFirewall::RuleGroup. The rule group is
+// standalone — it needs no VPC, policy or firewall — so it is the only resource
+// in the stack and is trivially the singleton leaf the harness requires: it is
+// last in the forma block, nothing references it, and it OOB-deletes in
+// isolation.
+//
+// The schema's RulesSource only models rulesSourceList, so a STATELESS group is
+// not expressible here; this exercises the STATEFUL domain-list surface —
+// rulesSourceList and statefulRuleOptions — plus the createOnly capacity and the
+// EntitySet tags.
+//
+// ruleVariables is deliberately NOT set: the schema declares RuleVariables.ipSets,
+// which renders on the wire as "IpSets", but AWS requires "IPSets" and rejects the
+// create with `extraneous key [IpSets] is not permitted`. The field needs an
+// outputField = "IPSets" hint (as servicelinkedrole.pkl does for AWSServiceName)
+// before any fixture can cover it.
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/networkfirewall/rulegroup.pkl"
+
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local stackName = "plugin-sdk-test-networkfirewall-rulegroup-\(testRunID)"
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for AWS Network Firewall RuleGroup"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  new rulegroup.RuleGroup {
+    label = "plugin-sdk-test-rulegroup"
+    ruleGroupName = "formae-plugin-sdk-test-rg-\(testRunID)"
+    type = "STATEFUL"
+    capacity = 100
+    description = "Plugin SDK test stateful domain allowlist rule group"
+    ruleGroup = new rulegroup.RuleGroupData {
+      rulesSource = new rulegroup.RulesSource {
+        rulesSourceList = new rulegroup.RulesSourceList {
+          targets = new Listing<String> { "github.com"; "api.anthropic.com" }
+          targetTypes = new Listing<rulegroup.TargetType> { "TLS_SNI"; "HTTP_HOST" }
+          generatedRulesType = "ALLOWLIST"
+        }
+      }
+      statefulRuleOptions = new rulegroup.StatefulRuleOptions {
+        ruleOrder = "STRICT_ORDER"
+      }
+    }
+    tags {
+      new { key = "Environment"; value = "test" }
+    }
+  }
+}

--- a/testdata/sqs-queueinlinepolicy.pkl
+++ b/testdata/sqs-queueinlinepolicy.pkl
@@ -1,0 +1,56 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/sqs/queue.pkl"
+import "@aws/sqs/queueinlinepolicy.pkl"
+
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local stackName = "plugin-sdk-test-sqs-queueinlinepolicy-\(testRunID)"
+
+local testQueue = new queue.Queue {
+  label = "test-queue"
+  queueName = "formae-sdk-test-qip-queue-\(testRunID)"
+}
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for SQS QueueInlinePolicy"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  testQueue
+
+  new queueinlinepolicy.QueueInlinePolicy {
+    label = "plugin-sdk-test-queueinlinepolicy"
+    queue = testQueue.res.queueUrl
+    policyDocument {
+      ["Version"] = "2012-10-17"
+      ["Statement"] {
+        new {
+          ["Sid"] = "AllowSendMessage"
+          ["Effect"] = "Allow"
+          ["Principal"] {
+            ["AWS"] = "*"
+          }
+          ["Action"] = "sqs:SendMessage"
+          ["Resource"] = "*"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Marks genuine secret-value fields opaque (formae.SecretValue) so opaque values hash at rest end-to-end, and pins the official pkg/model v0.1.26. Cuts stable 0.1.15.