### PR TITLE
fix(ci): stop NetworkFirewall cleanup leaks + deflake OIDC assume-role

### DIFF
--- a/.github/actions/aws-credentials/action.yml
+++ b/.github/actions/aws-credentials/action.yml
@@ -1,0 +1,62 @@
+# © 2026 Platform Engineering Labs Inc.
+#
+# SPDX-License-Identifier: FSL-1.1-ALv2
+#
+# Composite action: assume the AWS test role via GitHub OIDC, retrying once
+# with a freshly-minted OIDC token if the first attempt fails.
+#
+# Why: conformance jobs intermittently failed at "Configure AWS Credentials"
+# with `connect ETIMEDOUT <sts-ip>:443` followed by `Token expired`. A single
+# transient runner→STS network blip sends aws-actions/configure-aws-credentials
+# into its long internal AssumeRole retry, which outlives the short-lived GitHub
+# OIDC token; every subsequent retry then fails token-expired and the whole job
+# dies. Re-running the action mints a *new* OIDC token (core.getIDToken() runs
+# per invocation), so a second attempt after a brief cool-off clears the blip.
+#
+# The job must have `permissions: id-token: write` and check out the repo before
+# using this local action.
+name: Configure AWS Credentials (with OIDC retry)
+description: Assume an AWS role via OIDC with a fresh-token retry on transient STS failures.
+inputs:
+  role-to-assume:
+    description: ARN of the role to assume.
+    required: true
+  role-session-name:
+    description: STS session name.
+    required: true
+  aws-region:
+    description: AWS region.
+    required: false
+    default: us-east-1
+  role-duration-seconds:
+    description: Assumed-role session duration in seconds.
+    required: false
+    default: "3600"
+runs:
+  using: composite
+  steps:
+    - name: Configure AWS Credentials (attempt 1)
+      id: attempt1
+      continue-on-error: true
+      uses: aws-actions/configure-aws-credentials@v6
+      with:
+        aws-region: ${{ inputs.aws-region }}
+        role-to-assume: ${{ inputs.role-to-assume }}
+        role-session-name: ${{ inputs.role-session-name }}
+        role-duration-seconds: ${{ inputs.role-duration-seconds }}
+
+    - name: Cool off before OIDC retry
+      if: steps.attempt1.outcome == 'failure'
+      shell: bash
+      run: |
+        echo "::warning::First AssumeRole attempt failed (likely a transient STS timeout); retrying with a fresh OIDC token after 15s."
+        sleep 15
+
+    - name: Configure AWS Credentials (attempt 2)
+      if: steps.attempt1.outcome == 'failure'
+      uses: aws-actions/configure-aws-credentials@v6
+      with:
+        aws-region: ${{ inputs.aws-region }}
+        role-to-assume: ${{ inputs.role-to-assume }}
+        role-session-name: ${{ inputs.role-session-name }}
+        role-duration-seconds: ${{ inputs.role-duration-seconds }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,9 +82,8 @@ jobs:
           go-version: "1.26"
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: ./.github/actions/aws-credentials
         with:
-          aws-region: us-east-1
           role-to-assume: arn:aws:iam::942849037363:role/admin-test-pel
           role-session-name: IntegrationTests
 
@@ -128,9 +127,8 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: ./.github/actions/aws-credentials
         with:
-          aws-region: us-east-1
           role-to-assume: arn:aws:iam::942849037363:role/admin-test-pel
           role-session-name: CIPreCleanup
 
@@ -169,9 +167,8 @@ jobs:
           pkl-version: 0.30.0
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: ./.github/actions/aws-credentials
         with:
-          aws-region: us-east-1
           role-to-assume: arn:aws:iam::942849037363:role/admin-test-pel
           role-session-name: ConformanceTests
           role-duration-seconds: 7200
@@ -207,9 +204,8 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: ./.github/actions/aws-credentials
         with:
-          aws-region: us-east-1
           role-to-assume: arn:aws:iam::942849037363:role/admin-test-pel
           role-session-name: CIPostCleanup
 

--- a/.github/workflows/debug-conformance.yml
+++ b/.github/workflows/debug-conformance.yml
@@ -63,9 +63,8 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: ./.github/actions/aws-credentials
         with:
-          aws-region: us-east-1
           role-to-assume: arn:aws:iam::942849037363:role/admin-test-pel
           role-session-name: DebugPreCleanup
 
@@ -151,9 +150,8 @@ jobs:
       # === End source-build path ===
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: ./.github/actions/aws-credentials
         with:
-          aws-region: us-east-1
           role-to-assume: arn:aws:iam::942849037363:role/admin-test-pel
           role-session-name: DebugConformance
           role-duration-seconds: 7200
@@ -198,9 +196,8 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: ./.github/actions/aws-credentials
         with:
-          aws-region: us-east-1
           role-to-assume: arn:aws:iam::942849037363:role/admin-test-pel
           role-session-name: DebugPostCleanup
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -57,9 +57,8 @@ jobs:
           go-version: "1.26"
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: ./.github/actions/aws-credentials
         with:
-          aws-region: us-east-1
           role-to-assume: arn:aws:iam::942849037363:role/admin-test-pel
           role-session-name: NightlyIntegrationTests
 
@@ -102,9 +101,8 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: ./.github/actions/aws-credentials
         with:
-          aws-region: us-east-1
           role-to-assume: arn:aws:iam::942849037363:role/admin-test-pel
           role-session-name: NightlyPreCleanup
 
@@ -243,9 +241,8 @@ jobs:
           go mod tidy
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: ./.github/actions/aws-credentials
         with:
-          aws-region: us-east-1
           role-to-assume: arn:aws:iam::942849037363:role/admin-test-pel
           role-session-name: NightlyConformanceTests
           role-duration-seconds: 7200
@@ -289,9 +286,8 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: ./.github/actions/aws-credentials
         with:
-          aws-region: us-east-1
           role-to-assume: arn:aws:iam::942849037363:role/admin-test-pel
           role-session-name: NightlyPostCleanup
 

--- a/scripts/ci/clean-environment.sh
+++ b/scripts/ci/clean-environment.sh
@@ -813,19 +813,37 @@ aws efs describe-access-points --region "$REGION" 2>/dev/null | \
 done
 
 # --- Network Firewall (before VPCs/subnets)
-# The networkfirewall conformance fixture creates a Firewall, FirewallPolicy
-# and stateful RuleGroup, all named with `nfw-*` prefixes. They have a strict
-# deletion order — a policy can't be deleted while a firewall references it,
-# and a rule group can't be deleted while a policy references it — and the
-# firewall plants ENIs in the dedicated firewall subnets, so its deletion must
-# complete before the VPC/subnet sweeps below. The fixture's VPC is untagged
-# and its subnets carry only `nfw-*` Name tags (not $FORMAE_PREFIX), so they're
-# reclaimed by the orphan-untagged-VPC sweep — but only once these firewalls
-# are gone and their ENIs released.
+# The networkfirewall conformance fixtures create Firewalls, FirewallPolicies
+# and stateful RuleGroups across four fixture files, each with its own prefix:
+# `nfw-*` (networkfirewall), `nfwp-*` (networkfirewall-firewallpolicy),
+# `nfwlog-*` (networkfirewall-loggingconfiguration) and the rule-group-only
+# fixture's `formae-plugin-sdk-test-rg-*`. They have a strict deletion order —
+# a policy can't be deleted while a firewall references it, and a rule group
+# can't be deleted while a policy references it — and the firewall plants ENIs
+# in the dedicated firewall subnets, so its deletion must complete before the
+# VPC/subnet sweeps below. The fixtures' VPCs are untagged and their subnets
+# carry only `nfw*-*` Name tags (not $FORMAE_PREFIX), so they're reclaimed by
+# the orphan-untagged-VPC sweep — but only once these firewalls are gone and
+# their ENIs released.
+#
+# nfw_is_test: true if a Network Firewall resource name belongs to a test
+# fixture. Matches every fixture prefix (`nfw`, which also covers `nfwp`/
+# `nfwlog`) plus the shared test prefixes. Historically this only matched
+# `nfw-allowlist-*`/`nfw-policy-*`/`nfw-firewall-*`, so the nfwp-/nfwlog-/
+# formae-prefixed resources leaked every run until the account hit the
+# NetworkFirewall service limit (ServiceLimitExceeded on RuleGroup create).
+nfw_is_test() {
+    local name="$1"
+    [[ "$name" == nfw* \
+        || "$name" == *"$FORMAE_PREFIX"* \
+        || "$name" == *"$SDK_PREFIX"* \
+        || "$name" == *"$TEST_PREFIX"* ]]
+}
+
 echo "Cleaning Network Firewall test firewalls..."
 NFW_TEST_FIREWALLS=()
 while IFS= read -r fw_name; do
-    [[ -n "$fw_name" && "$fw_name" == nfw-firewall-* ]] && NFW_TEST_FIREWALLS+=("$fw_name")
+    [[ -n "$fw_name" ]] && nfw_is_test "$fw_name" && NFW_TEST_FIREWALLS+=("$fw_name")
 done < <(aws network-firewall list-firewalls --region "$REGION" --query "Firewalls[].FirewallName" --output text 2>/dev/null | tr '\t' '\n')
 
 for fw_name in "${NFW_TEST_FIREWALLS[@]}"; do
@@ -848,7 +866,7 @@ if [ ${#NFW_TEST_FIREWALLS[@]} -gt 0 ]; then
     while [ $waited -lt 300 ]; do
         remaining=0
         while IFS= read -r fw_name; do
-            [[ -n "$fw_name" && "$fw_name" == nfw-firewall-* ]] && remaining=$((remaining + 1))
+            [[ -n "$fw_name" ]] && nfw_is_test "$fw_name" && remaining=$((remaining + 1))
         done < <(aws network-firewall list-firewalls --region "$REGION" --query "Firewalls[].FirewallName" --output text 2>/dev/null | tr '\t' '\n')
         [ "$remaining" = "0" ] && break
         sleep 10
@@ -861,7 +879,7 @@ fi
 echo "Cleaning Network Firewall test firewall policies..."
 aws network-firewall list-firewall-policies --region "$REGION" \
     --query "FirewallPolicies[].Name" --output text 2>/dev/null | tr '\t' '\n' | while read -r pol_name; do
-    if [[ -n "$pol_name" && "$pol_name" == nfw-policy-* ]]; then
+    if [[ -n "$pol_name" ]] && nfw_is_test "$pol_name"; then
         echo "  Deleting Network Firewall firewall policy: $pol_name"
         aws network-firewall delete-firewall-policy --firewall-policy-name "$pol_name" --region "$REGION" 2>/dev/null || true
     fi
@@ -871,22 +889,26 @@ done
 echo "Cleaning Network Firewall test rule groups..."
 aws network-firewall list-rule-groups --region "$REGION" --type STATEFUL \
     --query "RuleGroups[].Name" --output text 2>/dev/null | tr '\t' '\n' | while read -r rg_name; do
-    if [[ -n "$rg_name" && "$rg_name" == nfw-allowlist-* ]]; then
+    if [[ -n "$rg_name" ]] && nfw_is_test "$rg_name"; then
         echo "  Deleting Network Firewall rule group: $rg_name"
         aws network-firewall delete-rule-group --rule-group-name "$rg_name" --type STATEFUL --region "$REGION" 2>/dev/null || true
     fi
 done
 
-# Delete the firewall's CloudWatch log group (`/formae/test/nfw-*`). The generic
-# log-group sweep further below only matches $TEST_PREFIX (plugin-sdk-test), so
-# this prefix would otherwise be missed.
+# Delete the firewall's CloudWatch log group. The logging fixture names it
+# `/formae/nfw/plugin-sdk-test-*`; the generic log-group sweep further below
+# matches $TEST_PREFIX (plugin-sdk-test) as a prefix and so misses anything
+# under the `/formae/nfw/` namespace. Sweep both `/formae/nfw/` and the legacy
+# `/formae/test/nfw-` prefix here.
 echo "Cleaning Network Firewall test log groups..."
-aws logs describe-log-groups --region "$REGION" --log-group-name-prefix "/formae/test/nfw-" \
-    --query "logGroups[].logGroupName" --output text 2>/dev/null | tr '\t' '\n' | while read -r lg; do
-    if [[ -n "$lg" ]]; then
-        echo "  Deleting Network Firewall log group: $lg"
-        aws logs delete-log-group --log-group-name "$lg" --region "$REGION" 2>/dev/null || true
-    fi
+for lg_prefix in "/formae/nfw/" "/formae/test/nfw-"; do
+    aws logs describe-log-groups --region "$REGION" --log-group-name-prefix "$lg_prefix" \
+        --query "logGroups[].logGroupName" --output text 2>/dev/null | tr '\t' '\n' | while read -r lg; do
+        if [[ -n "$lg" ]]; then
+            echo "  Deleting Network Firewall log group: $lg"
+            aws logs delete-log-group --log-group-name "$lg" --region "$REGION" 2>/dev/null || true
+        fi
+    done
 done
 
 # ============================================================================


### PR DESCRIPTION
CI/nightly hygiene fixes, **independent of the formae release** (no SDK dependency) — split out of #151 so they can merge now and unblock tonight's nightly. The opaque-secret SDK bump stays in #151 (gated on formae PR #574).

## 1. NetworkFirewall cleanup leak → `ServiceLimitExceeded`
`clean-environment.sh` only deleted `nfw-firewall-*` / `nfw-policy-*` / `nfw-allowlist-*`, but the four networkfirewall fixtures use four prefixes — `nfw-*`, `nfwp-*`, `nfwlog-*`, and `formae-plugin-sdk-test-rg-*`. Everything else leaked every run; the account had **50 orphan rule groups** (+6 policies / 5 firewalls), tripping `ServiceLimitExceeded` on RuleGroup create. Broadened the matcher (`nfw_is_test`) to every fixture prefix and fixed the log-group sweep (`/formae/nfw/…`, not `/formae/test/nfw-`). Live orphans already purged with this script (50→0).

Side benefit: the leaked firewalls pinned their VPCs/subnets alive, inflating the account resource count that the 2 req/s-throttled discovery scan walks — which is what pushed `ec2-subnet` discovery past its 5-min timeout. Controlling the leak addresses that too (no code/timeout change).

## 2. OIDC assume-role deflake
Jobs intermittently died at *Configure AWS Credentials* with `connect ETIMEDOUT <sts-ip>` → `Token expired`: a transient runner→STS blip sends the action into its long internal retry, which outlives the short-lived OIDC token. New local composite action `.github/actions/aws-credentials` retries the whole step once after a brief cool-off, minting a **fresh OIDC token** on the second attempt. Wired into all 11 credential steps across `ci.yml`, `nightly.yml`, `debug-conformance.yml`.