### PR TITLE
chore(deps): re-lock formae@0.88.0 schema and bump to 0.1.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Install with `sudo formae plugin install aws` on the host that runs the
 formae agent.
 
+## [0.1.16]
+
+### Changed
+
+- Bump examples to the latest formae 0.88.0 schema.
+
 ## [0.1.15]
 
 ### Changed

--- a/formae-plugin.pkl
+++ b/formae-plugin.pkl
@@ -5,7 +5,7 @@
  */
 
 name = "aws"
-version = "0.1.15"
+version = "0.1.16"
 namespace = "AWS"
 summary = "AWS resource plugin (CloudControl-based)"
 description = "AWS CloudControl resource plugin for Formae"


### PR DESCRIPTION
## What

Re-lock the `formae@0.88.0` PKL schema dependency to the **republished** Hub content checksum, and bump the plugin version `0.1.15 → 0.1.16`.

The formae `0.88.0` schema package on the Hub was overwritten with new content. The plugin's resolved dependency was pinned to the old content checksum. Re-resolving each `PklProject` now locks the formae dependency to the new checksum:

```
"sha256": "6b16d456300be7113a17eb99e9d340c61b926d0cd0a3af90704d74e9fac4ab8f"
```

(previously the stale `d73a22d0…`)

## Why

Needed to unblock the formae `0.88.0` release's bundle-examples step, which resolves this plugin's schema against the republished `0.88.0` and fails on the stale pin.

## Changes

- `formae-plugin.pkl`: version `0.1.15 → 0.1.16` (source of truth; the Makefile derives `schema/pkl/VERSION` from it at build time).
- `CHANGELOG.md`: new `## [0.1.16]` entry.

The `PklProject.deps.json` lockfiles are `.gitignore`d and regenerated at build/publish time; they were re-resolved locally to verify the resolve produces the new checksum across `schema/pkl`, `examples`, and `testdata`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)