### PR TITLE
feat(s3): model BlockedEncryptionTypes on bucket default encryption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Install with `sudo formae plugin install aws` on the host that runs the
 formae agent.
 
+## [Unreleased]
+
+### Added
+
+- S3 `BucketEncryption`: `ServerSideEncryptionRule` now models
+  `BlockedEncryptionTypes` (an `EncryptionType` listing of `NONE`/`SSE-C`), so
+  buckets that block SSE-C round-trip through extract and reconcile instead of
+  having the setting stripped on bring-under-management.
+
 ## [0.1.16]
 
 ### Changed

--- a/schema/pkl/s3/bucket.pkl
+++ b/schema/pkl/s3/bucket.pkl
@@ -42,6 +42,13 @@ open class AnalyticsConfiguration extends formae.SubResource {
     tagFilters: Listing<aws.Tag>?
 }
 
+typealias EncryptionType = "NONE"|"SSE-C"
+
+@aws.SubResourceHint
+open class BlockedEncryptionTypes extends formae.SubResource {
+    encryptionType: Listing<EncryptionType>?
+}
+
 @aws.SubResourceHint
 open class BucketEncryption extends formae.SubResource {
     serverSideEncryptionConfiguration: Listing<ServerSideEncryptionRule>
@@ -477,6 +484,8 @@ open class ServerSideEncryptionByDefault extends formae.SubResource {
 
 @aws.SubResourceHint
 open class ServerSideEncryptionRule extends formae.SubResource {
+    blockedEncryptionTypes: BlockedEncryptionTypes?
+
     bucketKeyEnabled: Boolean?
 
     serverSideEncryptionByDefault: ServerSideEncryptionByDefault?

--- a/testdata/s3-bucket-encryption-update.pkl
+++ b/testdata/s3-bucket-encryption-update.pkl
@@ -1,0 +1,59 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/s3/bucket.pkl"
+
+// Read the test run ID from environment variable set by the test harness
+// This ensures consistent naming within a test run but unique names between runs
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local stackName = "plugin-sdk-test-s3-bucket-encryption-\(testRunID)"
+
+// The default-encryption block (including BlockedEncryptionTypes) is held
+// identical to the base fixture; the update mutates a tag. This exercises the
+// Update path and confirms BlockedEncryptionTypes survives a reconcile without
+// being stripped, while avoiding an in-place edit of the single encryption
+// rule (which S3 rejects when re-put as part of a rule mutation).
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for S3 Bucket default encryption with BlockedEncryptionTypes"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  new bucket.Bucket {
+    label = "plugin-sdk-test-bucket-encryption"
+    bucketName = "formae-plugin-sdk-test-encryption-\(testRunID)"
+    tags {
+      new { key = "Environment"; value = "updated" }
+    }
+    bucketEncryption = new bucket.BucketEncryption {
+      serverSideEncryptionConfiguration {
+        new bucket.ServerSideEncryptionRule {
+          bucketKeyEnabled = true
+          serverSideEncryptionByDefault = new bucket.ServerSideEncryptionByDefault {
+            sseAlgorithm = "AES256"
+          }
+          blockedEncryptionTypes = new bucket.BlockedEncryptionTypes {
+            encryptionType {
+              "SSE-C"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/testdata/s3-bucket-encryption.pkl
+++ b/testdata/s3-bucket-encryption.pkl
@@ -1,0 +1,51 @@
+/*
+ * © 2025 Platform Engineering Labs Inc.
+ *
+ * SPDX-License-Identifier: FSL-1.1-ALv2
+ */
+
+amends "@formae/forma.pkl"
+import "@formae/formae.pkl"
+
+import "@aws/aws.pkl"
+
+import "@aws/s3/bucket.pkl"
+
+// Read the test run ID from environment variable set by the test harness
+// This ensures consistent naming within a test run but unique names between runs
+local testRunID = read("env:FORMAE_TEST_RUN_ID")
+local stackName = "plugin-sdk-test-s3-bucket-encryption-\(testRunID)"
+
+forma {
+  new formae.Stack {
+    label = stackName
+    description = "Plugin SDK test for S3 Bucket default encryption with BlockedEncryptionTypes"
+  }
+
+  new formae.Target {
+    label = "aws-target"
+    config = new aws.Config {
+      region = "us-east-1"
+    }
+  }
+
+  new bucket.Bucket {
+    label = "plugin-sdk-test-bucket-encryption"
+    bucketName = "formae-plugin-sdk-test-encryption-\(testRunID)"
+    bucketEncryption = new bucket.BucketEncryption {
+      serverSideEncryptionConfiguration {
+        new bucket.ServerSideEncryptionRule {
+          bucketKeyEnabled = true
+          serverSideEncryptionByDefault = new bucket.ServerSideEncryptionByDefault {
+            sseAlgorithm = "AES256"
+          }
+          blockedEncryptionTypes = new bucket.BlockedEncryptionTypes {
+            encryptionType {
+              "SSE-C"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add `BlockedEncryptionTypes` to the S3 `ServerSideEncryptionRule` schema (`schema/pkl/s3/bucket.pkl`) - an `EncryptionType` listing constrained to `NONE`/`SSE-C`, matching the CloudFormation resource schema.
- The Cloud Control runtime already reads this property into actual state, but the declarative schema had no field for it. As a result a bucket that blocks SSE-C could not be brought under management cleanly: `extract` omitted the field and a reconcile planned to remove and re-add the encryption rule without it.
- Add a dedicated conformance fixture `testdata/s3-bucket-encryption.pkl` (plus an `-update` variant) exercising the full lifecycle. Verified against real AWS: Create / Verify / Extract / Sync / Update / Destroy all pass.

## Note on the update fixture

The `-update` fixture mutates a tag while holding the encryption block (including `BlockedEncryptionTypes`) identical, rather than editing the encryption rule in place. An in-place edit of the single `ServerSideEncryptionConfiguration` rule currently fails for an unrelated, pre-existing reason: the update diff appends a second rule (`add` at `/1`) instead of replacing `/0`, so S3 rejects the two-rule config as malformed XML. That reproduces with or without `BlockedEncryptionTypes` and is tracked separately in PLA-372. The tag-based update still confirms `BlockedEncryptionTypes` survives a reconcile without being stripped, which is the behavior this change is about.