### PR TITLE
chore: remove internal references from comments and fixtures

### DIFF
--- a/pkg/cfres/ecs/service.go
+++ b/pkg/cfres/ecs/service.go
@@ -49,9 +49,6 @@ const (
 // Non-default shapes (CODE_DEPLOY / EXTERNAL controllers, DAEMON scheduling,
 // classic-ELB attachments) fall through to generic CCAPI Status via the shape
 // gate in Create/Update.
-//
-// Design: ~/dev/personal/engineering-notes/formae-plugin-aws/design/2026-05-18-ecs-service-stability-tracking.md
-// Bug:    ~/dev/personal/engineering-notes/formae-plugin-aws/2026-05-17-ecs-service-create-should-report-inprogress-until-deployment-stable.md
 type Service struct {
 	cfg                *config.Config
 	ccxClientFactory   func(*config.Config) (ccxClient, error)

--- a/schema/pkl/networkfirewall/firewallpolicy.pkl
+++ b/schema/pkl/networkfirewall/firewallpolicy.pkl
@@ -43,7 +43,7 @@ open class FirewallPolicyData extends formae.SubResource {
     // CloudControl does not reliably apply a remove+add pair against these
     // lists, leaving both the old and new action present (which AWS then
     // rejects, e.g. "aws:drop_strict / aws:drop_established cannot exist
-    // together"). See PLA-37.
+    // together").
     // The stateless default-action lists stay String (not a literal union):
     // beyond the reserved actions (aws:pass, aws:drop, aws:forward_to_sfe) AWS
     // also accepts the names of custom actions defined in the policy, so a

--- a/scripts/ci/clean-environment.sh
+++ b/scripts/ci/clean-environment.sh
@@ -180,8 +180,8 @@ echo "Cleaning S3 test buckets..."
 aws s3api list-buckets --query "Buckets[?contains(Name, '$FORMAE_PREFIX') || contains(Name, '$SDK_PREFIX') || contains(Name, '$TEST_PREFIX')].Name" --output text 2>/dev/null | tr '\t' '\n' | while read -r bucket; do
     if [[ -n "$bucket" ]]; then
         # The CloudTrail log bucket (formae-plugin-sdk-test-ct-logs-*) is a
-        # PERSISTENT prerequisite (Option B / PLA-302) provisioned + emptied in
-        # section 8b-ct below; never delete it here.
+        # PERSISTENT prerequisite provisioned + emptied in section 8b-ct below;
+        # never delete it here.
         if [[ "$bucket" == formae-plugin-sdk-test-ct-logs-* ]]; then
             echo "  Skipping persistent CloudTrail log bucket: $bucket"
             continue
@@ -196,12 +196,11 @@ done
 
 # 8b-ct. Provision + empty the PERSISTENT CloudTrail log-delivery bucket.
 # This bucket is a persistent conformance prerequisite for the cloudtrail-trail
-# fixture (Option B / PLA-302): CloudTrail deposits placeholder/log objects into
-# it, and CloudControl refuses to delete a non-empty bucket, so the fixture
-# references this externally-owned bucket by name instead of managing it. We
-# therefore CREATE it if absent and EMPTY it here, but never DELETE it (unlike
-# section 8b). The self-contained forceDestroy-managed version is tracked in
-# PLA-345. Every step is guarded so it never aborts the cleanup script.
+# fixture: CloudTrail deposits placeholder/log objects into it, and CloudControl
+# refuses to delete a non-empty bucket, so the fixture references this
+# externally-owned bucket by name instead of managing it. We therefore CREATE it
+# if absent and EMPTY it here, but never DELETE it (unlike section 8b). Every
+# step is guarded so it never aborts the cleanup script.
 echo "Provisioning + emptying persistent CloudTrail log bucket..."
 if acct=$(aws sts get-caller-identity --query Account --output text 2>/dev/null) && [[ -n "$acct" && "$acct" != "None" ]]; then
     ct_bucket="formae-plugin-sdk-test-ct-logs-${acct}"

--- a/testdata/cloudtrail-trail-update.pkl
+++ b/testdata/cloudtrail-trail-update.pkl
@@ -16,12 +16,10 @@ local accountID = read("env:FORMAE_TEST_ACCOUNT_ID")
 local stackName = "plugin-sdk-test-cloudtrail-trail-\(testRunID)"
 
 // The CloudTrail log-delivery bucket is a PERSISTENT, formae-UNMANAGED
-// prerequisite provisioned by scripts/ci/clean-environment.sh (Option B /
-// PLA-302): CloudTrail deposits placeholder objects into it, and CloudControl
-// refuses to delete a non-empty bucket, so managing the bucket here made the
-// whole-stack Destroy fail. Referencing it by name keeps it out of formae's
-// lifecycle. The self-contained forceDestroy-managed version is tracked in
-// PLA-345.
+// prerequisite provisioned by scripts/ci/clean-environment.sh: CloudTrail
+// deposits placeholder objects into it, and CloudControl refuses to delete a
+// non-empty bucket, so managing the bucket here made the whole-stack Destroy
+// fail. Referencing it by name keeps it out of formae's lifecycle.
 local logBucketName = "formae-plugin-sdk-test-ct-logs-\(accountID)"
 
 forma {

--- a/testdata/cloudtrail-trail.pkl
+++ b/testdata/cloudtrail-trail.pkl
@@ -16,12 +16,10 @@ local accountID = read("env:FORMAE_TEST_ACCOUNT_ID")
 local stackName = "plugin-sdk-test-cloudtrail-trail-\(testRunID)"
 
 // The CloudTrail log-delivery bucket is a PERSISTENT, formae-UNMANAGED
-// prerequisite provisioned by scripts/ci/clean-environment.sh (Option B /
-// PLA-302): CloudTrail deposits placeholder objects into it, and CloudControl
-// refuses to delete a non-empty bucket, so managing the bucket here made the
-// whole-stack Destroy fail. Referencing it by name keeps it out of formae's
-// lifecycle. The self-contained forceDestroy-managed version is tracked in
-// PLA-345.
+// prerequisite provisioned by scripts/ci/clean-environment.sh: CloudTrail
+// deposits placeholder objects into it, and CloudControl refuses to delete a
+// non-empty bucket, so managing the bucket here made the whole-stack Destroy
+// fail. Referencing it by name keeps it out of formae's lifecycle.
 local logBucketName = "formae-plugin-sdk-test-ct-logs-\(accountID)"
 
 forma {

--- a/testdata/networkfirewall-update.pkl
+++ b/testdata/networkfirewall-update.pkl
@@ -10,7 +10,7 @@
 // mutually exclusive, so the update must REPLACE the list — a per-element
 // remove+add leaves both present and AWS rejects it
 // ("aws:drop_strict / aws:drop_established cannot exist together"). Exercises
-// the updateMethod=Atomic schema hint on the *DefaultActions lists. See PLA-37.
+// the updateMethod=Atomic schema hint on the *DefaultActions lists.
 
 amends "@formae/forma.pkl"
 import "@formae/formae.pkl"

--- a/testdata/route53-recordsetgroup.pkl
+++ b/testdata/route53-recordsetgroup.pkl
@@ -58,7 +58,7 @@ forma {
       }
       // Second record type in the batch. Deliberately AAAA (not TXT): a TXT
       // value must be quote-wrapped, and formae's extract-to-pkl serialization
-      // mangles embedded quotes in listing elements (PLA-108), which fails the
+      // mangles embedded quotes in listing elements, which fails the
       // extract round-trip for reasons unrelated to this provisioner. The
       // provisioner treats all simple record types uniformly, so AAAA gives
       // clean multi-type coverage.


### PR DESCRIPTION
## Summary

Remove internal references from the tree, per the project's open-source hygiene guideline (no internal issue-tracker identifiers or private document paths in source).

- `pkg/cfres/ecs/service.go`: drop two `Design:`/`Bug:` comment lines pointing at a private local document path.
- `scripts/ci/clean-environment.sh`, `testdata/cloudtrail-trail.pkl`, `testdata/cloudtrail-trail-update.pkl`, `testdata/networkfirewall-update.pkl`, `schema/pkl/networkfirewall/firewallpolicy.pkl`, `testdata/route53-recordsetgroup.pkl`: strip inline tracker IDs and an orphaned design-doc option label from comments.

Each comment keeps its behavioral rationale; only the pointer is removed. No functional change - `go build`, `make verify-schema`, and `pkl eval` on the touched fixtures all pass.