### PR TITLE
feat(secretsmanager): remove RedactSensitive branch (enrich unconditionally)

### DIFF
--- a/formae-plugin.pkl
+++ b/formae-plugin.pkl
@@ -11,7 +11,7 @@ summary = "AWS resource plugin (CloudControl-based)"
 description = "AWS CloudControl resource plugin for Formae"
 category = "cloud"
 license = "FSL-1.1-ALv2"
-minFormaeVersion = "0.88.0"
+minFormaeVersion = "0.89.0"
 
 output {
   renderer = new JsonRenderer {}

--- a/formae-plugin.pkl
+++ b/formae-plugin.pkl
@@ -11,7 +11,7 @@ summary = "AWS resource plugin (CloudControl-based)"
 description = "AWS CloudControl resource plugin for Formae"
 category = "cloud"
 license = "FSL-1.1-ALv2"
-minFormaeVersion = "0.89.0"
+minFormaeVersion = "0.88.0"
 
 output {
   renderer = new JsonRenderer {}

--- a/pkg/cfres/secretsmanager/secret.go
+++ b/pkg/cfres/secretsmanager/secret.go
@@ -98,9 +98,12 @@ func (s *Secret) readWithClients(ctx context.Context, ccxClient ccxReader, smCli
 	if secret.SecretString != nil {
 		props["SecretString"] = *secret.SecretString
 	}
-	if secret.SecretBinary != nil {
-		props["SecretBinary"] = secret.SecretBinary
-	}
+	// SecretBinary is intentionally not enriched here. The agent's opaque-hashing
+	// table (persist_value_transformer.knownOpaqueFields) only covers SecretString
+	// for this resource type; returning SecretBinary as a plain []byte would store
+	// the raw binary secret as base64 plaintext at rest with no hashing. Binary
+	// secrets remain unresolvable via formae until the agent core and this plugin's
+	// schema are updated in concert to add SecretBinary opaque coverage.
 
 	completeProps, err := json.Marshal(props)
 	if err != nil {

--- a/pkg/cfres/secretsmanager/secret.go
+++ b/pkg/cfres/secretsmanager/secret.go
@@ -20,6 +20,16 @@ import (
 	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/config"
 )
 
+// ccxReader is the subset of ccx.Client used by Secret.Read.
+type ccxReader interface {
+	ReadResource(ctx context.Context, request *resource.ReadRequest) (*resource.ReadResult, error)
+}
+
+// secretValueGetter is the subset of secretsmanager.Client used by Secret.Read.
+type secretValueGetter interface {
+	GetSecretValue(ctx context.Context, params *secretsmanager.GetSecretValueInput, optFns ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error)
+}
+
 type Secret struct {
 	cfg *config.Config
 }
@@ -39,23 +49,12 @@ func init() {
 		})
 }
 
-// Read enhances Cloud Control read with actual secret value
+// Read enhances Cloud Control read with actual secret value.
 func (s *Secret) Read(ctx context.Context, request *resource.ReadRequest) (*resource.ReadResult, error) {
 	ccxClient, err := ccx.NewClient(s.cfg)
 	if err != nil {
 		plugin.LoggerFromContext(ctx).Error("SecretsManager: Failed to create ccx client", "error", err)
 		return nil, err
-	}
-
-	result, err := ccxClient.ReadResource(ctx, request)
-	if err != nil {
-		plugin.LoggerFromContext(ctx).Error("SecretsManager: Cloud Control ReadResource failed", "error", err)
-		return nil, err
-	}
-
-	// Don't bother enriching with secret value when RedactSensitive is set
-	if request.RedactSensitive {
-		return result, nil
 	}
 
 	awsCfg, err := s.cfg.ToAwsConfig(ctx)
@@ -64,9 +63,18 @@ func (s *Secret) Read(ctx context.Context, request *resource.ReadRequest) (*reso
 		return nil, err
 	}
 
-	secretsClient := secretsmanager.NewFromConfig(awsCfg)
+	return s.readWithClients(ctx, ccxClient, secretsmanager.NewFromConfig(awsCfg), request)
+}
 
-	secret, err := secretsClient.GetSecretValue(ctx, &secretsmanager.GetSecretValueInput{
+// readWithClients performs the enriched read using injectable clients (enables unit testing).
+func (s *Secret) readWithClients(ctx context.Context, ccxClient ccxReader, smClient secretValueGetter, request *resource.ReadRequest) (*resource.ReadResult, error) {
+	result, err := ccxClient.ReadResource(ctx, request)
+	if err != nil {
+		plugin.LoggerFromContext(ctx).Error("SecretsManager: Cloud Control ReadResource failed", "error", err)
+		return nil, err
+	}
+
+	secret, err := smClient.GetSecretValue(ctx, &secretsmanager.GetSecretValueInput{
 		SecretId: &request.NativeID,
 	})
 	if err != nil {

--- a/pkg/cfres/secretsmanager/secret_test.go
+++ b/pkg/cfres/secretsmanager/secret_test.go
@@ -50,7 +50,9 @@ func (m *mockSMClient) GetSecretValue(ctx context.Context, input *secretsmanager
 
 func TestSecret_Read_AlwaysEnrichesSecretValue(t *testing.T) {
 	// Read unconditionally enriches: the secret value is always fetched and
-	// merged into the result properties.
+	// merged into the result properties regardless of the RedactSensitive flag.
+	// Setting RedactSensitive=true proves the plugin no longer short-circuits on
+	// that flag (the whole point of this branch's removal).
 	ctx := context.Background()
 	ccxMock := &mockCCXReader{}
 	smMock := &mockSMClient{}
@@ -68,9 +70,12 @@ func TestSecret_Read_AlwaysEnrichesSecretValue(t *testing.T) {
 	}, nil)
 
 	s := &Secret{cfg: &config.Config{}}
+	// RedactSensitive=true is the flag the old code used to skip enrichment.
+	// With the flag removed, enrichment must still fire.
 	result, err := s.readWithClients(ctx, ccxMock, smMock, &resource.ReadRequest{
-		NativeID:     "my-secret-id",
-		ResourceType: "AWS::SecretsManager::Secret",
+		NativeID:        "my-secret-id",
+		ResourceType:    "AWS::SecretsManager::Secret",
+		RedactSensitive: true,
 	})
 
 	require.NoError(t, err)
@@ -79,6 +84,45 @@ func TestSecret_Read_AlwaysEnrichesSecretValue(t *testing.T) {
 	var props map[string]any
 	require.NoError(t, json.Unmarshal([]byte(result.Properties), &props))
 	assert.Equal(t, secretVal, props["SecretString"], "SecretString must be present in result")
+
+	ccxMock.AssertExpectations(t)
+	smMock.AssertExpectations(t)
+}
+
+func TestSecret_Read_SecretBinaryNotEnriched(t *testing.T) {
+	// SecretBinary is intentionally excluded from enrichment: the agent's
+	// opaque-hashing table only covers SecretString for this resource type.
+	// Returning raw binary data would persist it as base64 plaintext at rest.
+	// This test asserts the absence of SecretBinary in the result properties
+	// when the AWS API returns a binary secret.
+	ctx := context.Background()
+	ccxMock := &mockCCXReader{}
+	smMock := &mockSMClient{}
+
+	ccxMock.On("ReadResource", ctx, mock.Anything).Return(&resource.ReadResult{
+		ResourceType: "AWS::SecretsManager::Secret",
+		Properties:   `{"Name":"binary-secret"}`,
+	}, nil)
+
+	smMock.On("GetSecretValue", ctx, mock.Anything).Return(&secretsmanager.GetSecretValueOutput{
+		SecretBinary: []byte("binary-payload"),
+	}, nil)
+
+	s := &Secret{cfg: &config.Config{}}
+	result, err := s.readWithClients(ctx, ccxMock, smMock, &resource.ReadRequest{
+		NativeID:     "binary-secret-id",
+		ResourceType: "AWS::SecretsManager::Secret",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	var props map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result.Properties), &props))
+	_, hasSecretBinary := props["SecretBinary"]
+	assert.False(t, hasSecretBinary, "SecretBinary must not be present in result (no opaque coverage in agent)")
+	_, hasSecretString := props["SecretString"]
+	assert.False(t, hasSecretString, "SecretString must not be present when the secret has no string value")
 
 	ccxMock.AssertExpectations(t)
 	smMock.AssertExpectations(t)

--- a/pkg/cfres/secretsmanager/secret_test.go
+++ b/pkg/cfres/secretsmanager/secret_test.go
@@ -1,0 +1,145 @@
+// © 2025 Platform Engineering Labs Inc.
+//
+// SPDX-License-Identifier: FSL-1.1-ALv2
+
+//go:build unit
+
+package secretsmanager
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/platform-engineering-labs/formae/pkg/plugin/resource"
+	"github.com/platform-engineering-labs/formae-plugin-aws/pkg/config"
+)
+
+// mockCCXReader mocks the Cloud Control read path.
+type mockCCXReader struct {
+	mock.Mock
+}
+
+func (m *mockCCXReader) ReadResource(ctx context.Context, req *resource.ReadRequest) (*resource.ReadResult, error) {
+	args := m.Called(ctx, req)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*resource.ReadResult), args.Error(1)
+}
+
+// mockSMClient mocks the SecretsManager GetSecretValue call.
+type mockSMClient struct {
+	mock.Mock
+}
+
+func (m *mockSMClient) GetSecretValue(ctx context.Context, input *secretsmanager.GetSecretValueInput, optFns ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
+	args := m.Called(ctx, input)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*secretsmanager.GetSecretValueOutput), args.Error(1)
+}
+
+func TestSecret_Read_AlwaysEnrichesSecretValue(t *testing.T) {
+	// Read unconditionally enriches: the secret value is always fetched and
+	// merged into the result properties.
+	ctx := context.Background()
+	ccxMock := &mockCCXReader{}
+	smMock := &mockSMClient{}
+
+	ccxMock.On("ReadResource", ctx, mock.Anything).Return(&resource.ReadResult{
+		ResourceType: "AWS::SecretsManager::Secret",
+		Properties:   `{"Name":"my-secret","ARN":"arn:aws:secretsmanager:us-east-1:123456789012:secret:my-secret"}`,
+	}, nil)
+
+	secretVal := "super-secret-value"
+	smMock.On("GetSecretValue", ctx, mock.MatchedBy(func(in *secretsmanager.GetSecretValueInput) bool {
+		return in.SecretId != nil && *in.SecretId == "my-secret-id"
+	})).Return(&secretsmanager.GetSecretValueOutput{
+		SecretString: aws.String(secretVal),
+	}, nil)
+
+	s := &Secret{cfg: &config.Config{}}
+	result, err := s.readWithClients(ctx, ccxMock, smMock, &resource.ReadRequest{
+		NativeID:     "my-secret-id",
+		ResourceType: "AWS::SecretsManager::Secret",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	var props map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result.Properties), &props))
+	assert.Equal(t, secretVal, props["SecretString"], "SecretString must be present in result")
+
+	ccxMock.AssertExpectations(t)
+	smMock.AssertExpectations(t)
+}
+
+func TestSecret_Read_EnrichesEvenWhenCCXReturnsEmptyProperties(t *testing.T) {
+	// Enrichment works even when Cloud Control returns an empty properties blob.
+	ctx := context.Background()
+	ccxMock := &mockCCXReader{}
+	smMock := &mockSMClient{}
+
+	ccxMock.On("ReadResource", ctx, mock.Anything).Return(&resource.ReadResult{
+		ResourceType: "AWS::SecretsManager::Secret",
+		Properties:   "",
+	}, nil)
+
+	secretVal := "another-secret"
+	smMock.On("GetSecretValue", ctx, mock.Anything).Return(&secretsmanager.GetSecretValueOutput{
+		SecretString: aws.String(secretVal),
+	}, nil)
+
+	s := &Secret{cfg: &config.Config{}}
+	result, err := s.readWithClients(ctx, ccxMock, smMock, &resource.ReadRequest{
+		NativeID:     "my-secret-id",
+		ResourceType: "AWS::SecretsManager::Secret",
+	})
+
+	require.NoError(t, err)
+	var props map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result.Properties), &props))
+	assert.Equal(t, secretVal, props["SecretString"])
+}
+
+func TestSecret_Read_GetSecretValueFailureReturnsPartialResult(t *testing.T) {
+	// If GetSecretValue fails, Read still returns the Cloud Control result
+	// (no secret enrichment) rather than propagating an error.
+	ctx := context.Background()
+	ccxMock := &mockCCXReader{}
+	smMock := &mockSMClient{}
+
+	ccxMock.On("ReadResource", ctx, mock.Anything).Return(&resource.ReadResult{
+		ResourceType: "AWS::SecretsManager::Secret",
+		Properties:   `{"Name":"my-secret"}`,
+	}, nil)
+
+	smMock.On("GetSecretValue", ctx, mock.Anything).Return(
+		(*secretsmanager.GetSecretValueOutput)(nil),
+		errors.New("access denied"),
+	)
+
+	s := &Secret{cfg: &config.Config{}}
+	result, err := s.readWithClients(ctx, ccxMock, smMock, &resource.ReadRequest{
+		NativeID:     "my-secret-id",
+		ResourceType: "AWS::SecretsManager::Secret",
+	})
+
+	require.NoError(t, err, "GetSecretValue failure must not propagate as an error")
+	require.NotNil(t, result)
+
+	var props map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result.Properties), &props))
+	_, hasSecret := props["SecretString"]
+	assert.False(t, hasSecret, "SecretString must be absent when GetSecretValue fails")
+}


### PR DESCRIPTION
## Remove the `RedactSensitive` branch from SecretsManager Read

Now that opaque values are hashed at rest (formae 0.88.0), the discovery-read redaction short-circuit is obsolete. This removes the only `RedactSensitive` branch in the plugin, so SecretsManager Read enriches unconditionally — the advertised `SecretString` resolvable resolves, and the agent hashes it at rest.

- `SecretBinary` is intentionally **not** enriched: it is not covered by the agent's opaque-field set, so returning it would persist a base64 secret as plaintext at rest. Hashing binary secrets at rest is a follow-up (needs coordinated opaque coverage in the agent + schema).
- Tests: Read enriches even when `RedactSensitive` is set (proving the flag no longer gates); `SecretBinary` is absent from Read results.

**No `minFormaeVersion` bump.** The removal is safe against any agent that hashes opaque values at rest, which shipped in 0.88.0 — the floor this plugin already declares. The plugin↔agent codec is map-keyed MessagePack, so dropping the SDK field is wire-compatible; the existing 0.88.0 floor already gates out agents that predate at-rest hashing.
