### PR TITLE
feat(secretsmanager): adopt ScalarSecretResolvable for secretValue/.json() references

### DIFF
--- a/examples/PklProject
+++ b/examples/PklProject
@@ -6,6 +6,6 @@ dependencies {
 
   // Formae schema - fetched from public registry
   ["formae"] {
-    uri = "package://hub.platform.engineering/plugins/pkl/schema/pkl/formae/formae@0.88.0"
+    uri = "package://hub.platform.engineering/plugins/pkl/schema/pkl/formae/formae@0.89.0"
   }
 }

--- a/examples/secret-resolvable/main.pkl
+++ b/examples/secret-resolvable/main.pkl
@@ -115,7 +115,7 @@ forma {
         engine = "postgres"
         engineVersion = "13"
         masterUsername = "testuser"
-        masterUserPassword = dbSecret.res.secretString
+        masterUserPassword = dbSecret.res.secretValue
         dbSubnetGroupName = dbSubnetGroup.res.dbSubnetGroupName
         vpcSecurityGroups { dbSecurityGroup.res.groupId }
         storageEncrypted = true

--- a/formae-plugin.pkl
+++ b/formae-plugin.pkl
@@ -11,7 +11,7 @@ summary = "AWS resource plugin (CloudControl-based)"
 description = "AWS CloudControl resource plugin for Formae"
 category = "cloud"
 license = "FSL-1.1-ALv2"
-minFormaeVersion = "0.88.0"
+minFormaeVersion = "0.89.0"
 
 output {
   renderer = new JsonRenderer {}

--- a/schema/pkl/PklProject
+++ b/schema/pkl/PklProject
@@ -2,7 +2,7 @@ amends "pkl:Project"
 
 dependencies {
   ["formae"] {
-    uri = "package://hub.platform.engineering/plugins/pkl/schema/pkl/formae/formae@0.88.0"
+    uri = "package://hub.platform.engineering/plugins/pkl/schema/pkl/formae/formae@0.89.0"
   }
 }
 

--- a/schema/pkl/secretsmanager/secret.pkl
+++ b/schema/pkl/secretsmanager/secret.pkl
@@ -33,8 +33,9 @@ open class ReplicaRegion extends formae.SubResource {
 }
 
 
-open class SecretResolvable extends formae.Resolvable {
+open class SecretResolvable extends formae.ScalarSecretResolvable {
     type = module.type
+    hidden valueProperty = "SecretString"
 
     // CloudControl exposes the secret's ARN as the primary identifier `Id`
     // (and `Ref`); there is no separate `Arn` property on this resource type.
@@ -66,7 +67,9 @@ open class SecretResolvable extends formae.Resolvable {
     type = module.type
     identifier = "Id"
 }
-open class Secret extends formae.Resource {
+open class Secret extends formae.Secret {
+    hidden valueProperty = "SecretString"
+
     @aws.FieldHint
     description: String?
 


### PR DESCRIPTION
## Summary

- `SecretResolvable` now extends `formae.ScalarSecretResolvable` (introduced in formae@0.89.0) instead of `formae.Resolvable` directly, which adds `secret.res.secretValue` (a `SecretValueResolvable` pointing at `SecretString`) and `secret.res.secretValue.json("path")` for structured/JSON-typed secret lookups.
- `Secret` now extends `formae.Secret` (which itself extends `formae.Resource` and adds the abstract `valueProperty`) rather than `formae.Resource` directly; `valueProperty = "SecretString"` is set on both `Secret` and `SecretResolvable`.
- All existing accessors — `secretString`, `arn`, `id`, `name`, `ref` — are preserved verbatim on `SecretResolvable` for backwards compatibility. Existing formae files using `.res.secretString` continue to work without any changes.
- The example (`examples/secret-resolvable/main.pkl`) is updated to demonstrate the new `.res.secretValue` accessor.
- `minFormaeVersion` and the Pkl schema dependency are bumped to `0.89.0`; this adoption genuinely requires the 0.89.0 engine and schema — the `ScalarSecretResolvable` and `SecretValueResolvable` types do not exist in earlier versions.

## Requires formae 0.89.0

This change requires a formae agent and schema at 0.89.0 or later. The new resolvable types (`ScalarSecretResolvable`, `SecretValueResolvable`) are defined in `formae@0.89.0`; older agents will not understand `secretValue` references even if the Pkl evaluates.

## Test plan

- [x] `pkl project resolve schema/pkl` succeeds against `formae@0.89.0`
- [x] Type-check fixture confirms `secret.res.secretValue` resolves to `SecretValueResolvable`, `secret.res.secretValue.json("username")` resolves to `SecretValueResolvable`, and `secret.res.secretString` still resolves (backwards compat)
- [x] `pkl project resolve examples` succeeds
- [x] `make test` passes (all unit tests green)
- [x] `go vet ./...` clean
- [x] `make install` installs to `~/.pel/formae/plugins/aws/v0.1.16`

🤖 Generated with [Claude Code](https://claude.com/claude-code)