### PR TITLE
test(secretsmanager): drop removed RedactSensitive field from Read test

### DIFF
--- a/pkg/cfres/secretsmanager/secret_test.go
+++ b/pkg/cfres/secretsmanager/secret_test.go
@@ -49,10 +49,9 @@ func (m *mockSMClient) GetSecretValue(ctx context.Context, input *secretsmanager
 }
 
 func TestSecret_Read_AlwaysEnrichesSecretValue(t *testing.T) {
-	// Read unconditionally enriches: the secret value is always fetched and
-	// merged into the result properties regardless of the RedactSensitive flag.
-	// Setting RedactSensitive=true proves the plugin no longer short-circuits on
-	// that flag (the whole point of this branch's removal).
+	// Read unconditionally enriches: the secret value is always fetched from
+	// SecretsManager and merged into the result properties. The agent decides
+	// how to store it (opaque hashing), so the plugin never withholds it.
 	ctx := context.Background()
 	ccxMock := &mockCCXReader{}
 	smMock := &mockSMClient{}
@@ -70,12 +69,9 @@ func TestSecret_Read_AlwaysEnrichesSecretValue(t *testing.T) {
 	}, nil)
 
 	s := &Secret{cfg: &config.Config{}}
-	// RedactSensitive=true is the flag the old code used to skip enrichment.
-	// With the flag removed, enrichment must still fire.
 	result, err := s.readWithClients(ctx, ccxMock, smMock, &resource.ReadRequest{
-		NativeID:        "my-secret-id",
-		ResourceType:    "AWS::SecretsManager::Secret",
-		RedactSensitive: true,
+		NativeID:     "my-secret-id",
+		ResourceType: "AWS::SecretsManager::Secret",
 	})
 
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

The enrichment branch keyed on `ReadRequest.RedactSensitive` was removed from the plugin in 37218e4, but the unit test still set the field. Since the field no longer exists on the SDK's `ReadRequest`, the test only compiled against the pinned `pkg/plugin v0.4.1` (the last tag carrying it) and broke as soon as the plugin was built against formae main.

That is exactly what the nightly does: `nightly.yml` injects `replace` directives pointing the SDK at a fresh clone of formae main. The 2026-08-06 nightly failed **142 of 148 jobs** on `request.RedactSensitive undefined` in `secret.go` — three consecutive nightlies ran on the same commit `fd20c19` and went green → 1 failure → mass failure with no plugin change, because the SDK moved underneath them. The production side is already fixed; this is the leftover in the test.

Drop the field and restate the comments in terms of the behaviour under test: Read always fetches and merges the secret value, and the agent decides how to store it.

Verified against both SDK versions — build, `go vet` under the `unit`/`integration`/`conformance` tags, and the full unit suite are clean against the pinned `v0.4.1` and against formae main.

### Follow-up

`go.mod` still pins `pkg/plugin-conformance-tests v0.2.6`, which carries the hardcoded 60s sync wait that platform-engineering-labs/formae#601 makes configurable. Once that lands and a new module tag is cut, bumping it here lets CI benefit too; the nightly picks it up immediately via the replace directives.