### PR TITLE
test(apigateway): declare the second Lambda in the method-lambda base fixture

### DIFF
--- a/testdata/apigateway-method-lambda.pkl
+++ b/testdata/apigateway-method-lambda.pkl
@@ -57,6 +57,31 @@ local testFunction = new func.Function {
   timeout = 10
 }
 
+// Second Lambda. Nothing points at it here; the update fixture re-points the
+// Method to it, so it has to exist up front for that step to exercise a pure
+// Integration update. It is also declared here so the destroy step, which runs
+// against this file, owns it. Otherwise it outlives the forma and blocks
+// deletion of the execution role it depends on.
+local testFunctionB = new func.Function {
+  label = "test-function-b-for-method"
+  functionName = "formae-sdk-test-meth-lambda-b-\(testRunID)"
+  role = lambdaRole.res.arn
+  runtime = "python3.12"
+  handler = "index.handler"
+  code = new func.Code {
+    zipFile = """
+      import json
+      def handler(event, context):
+          return {
+              'statusCode': 200,
+              'body': json.dumps({'message': 'hello from formae B'})
+          }
+      """
+  }
+  memorySize = 128
+  timeout = 10
+}
+
 // RestApi dependency.
 local testApi = new restapi.RestApi {
   label = "test-restapi-for-method"
@@ -91,6 +116,8 @@ forma {
   lambdaRole
 
   testFunction
+
+  testFunctionB
 
   // Parent RestApi
   testApi


### PR DESCRIPTION
## Summary

`conformance-tests (apigateway-method-lambda)` has failed its Destroy phase twice (CI run 31137319868, and tonight's nightly 31145933067) with:

```
Error: error destroying forma: ResourceHasDependents
ERR Failed to create destroy from forma error="deleting \"lambda-execution-role\" would
cascade-delete dependent resource \"test-function-b-for-method\";
re-run with --on-dependents=cascade to proceed"
```

The conformance runner destroys against the **base** fixture (`runner.go` step 16 passes `tc.PKLFile`), but `test-function-b-for-method` was declared only in the `-update` fixture. So the update created it, the destroy did not own it, and it retained a dependency on `lambda-execution-role` — which the agent's cascade guard then refused to delete.

The update fixture already described this Lambda as *"Second Lambda - same as create (pre-exists)"*, so declaring it in the base is what was intended all along; it simply was never added.

After the change the base and update resource sets are identical, and evaluating both fixtures shows the only remaining difference is the Method's integration target:

```
<  "$label": "test-function-for-method",
>  "$label": "test-function-b-for-method",
```

So the update still exercises exactly the Integration update the pair was written for, with no same-changeset create.

### Related

A sweep of all `*-update.pkl` / base pairs found one other fixture that adds a resource the base does not declare: `events-rule-update.pkl` adds `plugin-sdk-test-rule-queue-2`. That one has no dependency edge into the base's resources, so it leaks the queue rather than failing the destroy. Left alone here rather than changing a currently-passing test, but worth fixing separately — leaked resources in the shared account inflate discovery list volume, which feeds the CloudControl throttling behind other conformance flakes.