### PR TITLE
chore(deps): build conformance tests against the merged SDK fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/platform-engineering-labs/formae/pkg/model v0.1.26
 	github.com/platform-engineering-labs/formae/pkg/plugin v0.4.1
-	github.com/platform-engineering-labs/formae/pkg/plugin-conformance-tests v0.2.7-0.20260807070128-5348094a7516
+	github.com/platform-engineering-labs/formae/pkg/plugin-conformance-tests v0.2.7-0.20260807190231-e53140dcb057
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/platform-engineering-labs/formae/pkg/model v0.1.26
 	github.com/platform-engineering-labs/formae/pkg/plugin v0.4.1
-	github.com/platform-engineering-labs/formae/pkg/plugin-conformance-tests v0.2.6
+	github.com/platform-engineering-labs/formae/pkg/plugin-conformance-tests v0.2.7-0.20260807070128-5348094a7516
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -140,8 +140,8 @@ github.com/platform-engineering-labs/formae/pkg/model v0.1.26 h1:80p843bmz9sLTtU
 github.com/platform-engineering-labs/formae/pkg/model v0.1.26/go.mod h1:1dmsFwoaJZkHevBsAIZr068CWzG7de1VNz7PFWvM3Z8=
 github.com/platform-engineering-labs/formae/pkg/plugin v0.4.1 h1:dg8TBQVJR8DVF28bvmzAG4Ms1Id0yIr6Kd8c3UTO3iw=
 github.com/platform-engineering-labs/formae/pkg/plugin v0.4.1/go.mod h1:ZFXMfeZljHVDWQTSeJ4dj2EG3iTjdrxQjm7DpvOYUXk=
-github.com/platform-engineering-labs/formae/pkg/plugin-conformance-tests v0.2.7-0.20260807070128-5348094a7516 h1:s/ISDEmXCcPLGwWldZS2bb0PO2xEmwk00004Dee8bq8=
-github.com/platform-engineering-labs/formae/pkg/plugin-conformance-tests v0.2.7-0.20260807070128-5348094a7516/go.mod h1:gq591ZeRZ4jAHpdSvCyrOvi8qyALxcXQQhd0B6GRMAo=
+github.com/platform-engineering-labs/formae/pkg/plugin-conformance-tests v0.2.7-0.20260807190231-e53140dcb057 h1:Jlp7rjxoCX5sraK27igNmfpcnJ371rfNu6vVBCnG8ek=
+github.com/platform-engineering-labs/formae/pkg/plugin-conformance-tests v0.2.7-0.20260807190231-e53140dcb057/go.mod h1:gq591ZeRZ4jAHpdSvCyrOvi8qyALxcXQQhd0B6GRMAo=
 github.com/platform-engineering-labs/orbital v0.1.36 h1:nPMLxDbwDrjlhJoMQXAE86HtVhQHC2A6BJlWYmNM75c=
 github.com/platform-engineering-labs/orbital v0.1.36/go.mod h1:wwVPqOmW5RO78dDzL/G5CN1Ioao0P/aUsOZVrPVx64s=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=

--- a/go.sum
+++ b/go.sum
@@ -140,8 +140,8 @@ github.com/platform-engineering-labs/formae/pkg/model v0.1.26 h1:80p843bmz9sLTtU
 github.com/platform-engineering-labs/formae/pkg/model v0.1.26/go.mod h1:1dmsFwoaJZkHevBsAIZr068CWzG7de1VNz7PFWvM3Z8=
 github.com/platform-engineering-labs/formae/pkg/plugin v0.4.1 h1:dg8TBQVJR8DVF28bvmzAG4Ms1Id0yIr6Kd8c3UTO3iw=
 github.com/platform-engineering-labs/formae/pkg/plugin v0.4.1/go.mod h1:ZFXMfeZljHVDWQTSeJ4dj2EG3iTjdrxQjm7DpvOYUXk=
-github.com/platform-engineering-labs/formae/pkg/plugin-conformance-tests v0.2.6 h1:xslGa2DOFslxD0jxwI/XaUxdetpqSn++rfpqbW/uLbE=
-github.com/platform-engineering-labs/formae/pkg/plugin-conformance-tests v0.2.6/go.mod h1:gq591ZeRZ4jAHpdSvCyrOvi8qyALxcXQQhd0B6GRMAo=
+github.com/platform-engineering-labs/formae/pkg/plugin-conformance-tests v0.2.7-0.20260807070128-5348094a7516 h1:s/ISDEmXCcPLGwWldZS2bb0PO2xEmwk00004Dee8bq8=
+github.com/platform-engineering-labs/formae/pkg/plugin-conformance-tests v0.2.7-0.20260807070128-5348094a7516/go.mod h1:gq591ZeRZ4jAHpdSvCyrOvi8qyALxcXQQhd0B6GRMAo=
 github.com/platform-engineering-labs/orbital v0.1.36 h1:nPMLxDbwDrjlhJoMQXAE86HtVhQHC2A6BJlWYmNM75c=
 github.com/platform-engineering-labs/orbital v0.1.36/go.mod h1:wwVPqOmW5RO78dDzL/G5CN1Ioao0P/aUsOZVrPVx64s=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=


### PR DESCRIPTION
## Summary

Pins `pkg/plugin-conformance-tests` to a pseudo-version of current formae main (`v0.2.7-0.20260807190231-e53140dc`) so CI exercises three merged conformance-harness fixes against the pinned dependency.

Until now only the nightly saw them: `nightly.yml` injects `replace` directives pointing the SDK at a fresh clone of formae main, while `ci.yml` builds against the pins. So none of these could affect a CI run on this repo.

### What the pinned version fixes

- **CRUD sync wait was hardcoded to 60s** (formae#601), shorter than this plugin's own `pkg/ccx` retry budget (~3 min over a 1s..30s backoff). A healthy sync takes 0-3s, so the harness was aborting syncs still legitimately retrying through CloudControl throttling. Now `FORMAE_TEST_SYNC_TIMEOUT`, default 5 min.
- **Out-of-band delete wait never re-triggered sync** (formae#601). A single sync landing inside AWS's propagation window read the resource as still present and cached that; nothing went back to the cloud again. This is what failed `ec2-networkaclentry`. Now re-triggers on a backoff via `FORMAE_TEST_OOB_SYNC_RETRIGGER_INTERVAL`.
- **The harness deleted the agent log on teardown** (formae#605). The per-test temp directory holding `formae-test.log` was removed unconditionally, so a failing test left no durable record. It is now retained on failure and the surviving path printed.

Neither workflow needs an env var here; all defaults are correct for this repo.

## Why the log-retention fix matters here

`ecs-service-with-lb` and `ecs-service-with-lb-rule-routing` are the last undiagnosed nightly failures. The fixture **passes in isolation** against formae main and fails only under the nightly's `max-parallel: 10` on the shared account, so it is contention-shaped rather than a code defect. Its originating error has never been recoverable: the first resource fails ~23 minutes before the job ends, and the log was being deleted during teardown.

With this pin the next nightly retains that log. Wiring the workflow to upload it is tracked separately as PLA-444, which carries a security constraint worth repeating: upload `formae-test.log` **only**, never the directory, which also holds the generated config including the agent network cookie, and this repo's artifacts are world-downloadable.

## Scope

Only `pkg/plugin-conformance-tests` moves. `pkg/plugin v0.4.1` and `pkg/model v0.1.26` stay on their released tags.

## Verification

Against the re-pointed dependency: `go build ./...` clean, `go vet` clean under `unit`, `integration` and `conformance` tags, full unit suite passing. Confirmed all three fixes are present in the resolved module rather than assuming the version string implies them.

## Follow-up

This is a pseudo-version by design. An official `pkg/plugin-conformance-tests` tag should replace it before the 0.89.0 release.